### PR TITLE
Fixing indentation on spec.env for Deployments

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -110,7 +110,7 @@ data:
       {{- end }}
     {{ end }}
 
-    {{ .Values.config.configYml }}
+{{ .Values.config.configYml | indent 4 }}
   sentry.conf.py: |-
     from sentry.conf.server import *  # NOQA
 
@@ -326,4 +326,4 @@ data:
     # BITBUCKET_CONSUMER_KEY = 'YOUR_BITBUCKET_CONSUMER_KEY'
     # BITBUCKET_CONSUMER_SECRET = 'YOUR_BITBUCKET_CONSUMER_SECRET'
 
-    {{ .Values.config.sentryConfPy }}
+{{ .Values.config.sentryConfPy | indent 4 }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -57,13 +57,13 @@ spec:
           - "run"
           - "cron"
         env:
-          - name: SNUBA
-            value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
-          - name: C_FORCE_ROOT
-            value: "true"
+        - name: SNUBA
+          value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        - name: C_FORCE_ROOT
+          value: "true"
         {{ if eq .Values.filestore.backend "gcs" }}
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
 {{- if .Values.sentry.cron.env }}
 {{ toYaml .Values.sentry.cron.env | indent 8 }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -50,11 +50,11 @@ spec:
         imagePullPolicy: {{ .Values.images.sentry.pullPolicy }}
         command: ["sentry", "run", "post-process-forwarder", "--commit-batch-size", "1"]
         env:
-          - name: SNUBA
-            value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        - name: SNUBA
+          value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
         {{ if eq .Values.filestore.backend "gcs" }}
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
 {{- if .Values.sentry.postProcessForward.env }}
 {{ toYaml .Values.sentry.postProcessForward.env | indent 8 }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -55,11 +55,11 @@ spec:
         ports:
         - containerPort: {{ template "sentry.port" }}
         env:
-          - name: SNUBA
-            value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        - name: SNUBA
+          value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
         {{ if eq .Values.filestore.backend "gcs" }}
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
 {{- if .Values.sentry.web.env }}
 {{ toYaml .Values.sentry.web.env | indent 8 }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -62,13 +62,13 @@ spec:
           - "{{ .Values.sentry.worker.concurrency }}"
           {{- end }}
         env:
-          - name: SNUBA
-            value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
-          - name: C_FORCE_ROOT
-            value: "true"
+        - name: SNUBA
+          value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        - name: C_FORCE_ROOT
+          value: "true"
         {{ if eq .Values.filestore.backend "gcs" }}
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
 {{- if .Values.sentry.worker.env }}
 {{ toYaml .Values.sentry.worker.env | indent 8 }}


### PR DESCRIPTION
Indentation was incorrect which meant adding envs would break the chart templating.

I've sneaked in a fix on the configmap that I actually broke (sorry)