### PR TITLE
Fixing missing quotes in Redis host

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -120,7 +120,7 @@ data:
             "NAME": "{{ .Values.postgresql.postgresqlDatabase }}",
             "USER": "{{ .Values.postgresql.postgresqlUsername }}",
             "PASSWORD": "{{ .Values.postgresql.postgresqlPassword }}",
-            "HOST": {{ default ( include "sentry.postgresql.host" .) .Values.postgresql.hostOverride }},
+            "HOST": "{{ default ( include "sentry.postgresql.host" .) .Values.postgresql.hostOverride }}",
             "PORT": {{ template "sentry.postgresql.port" . }},
             {{- if .Values.postgresql.postgresSslMode }}
             'OPTIONS': {


### PR DESCRIPTION
@Mokto 

https://github.com/sentry-kubernetes/charts/commit/87bfc2c7d2e2713ac0e5e39d6a7fca89ef32ba9a#diff-36321f4a83ae6a5eab58853be570ff54R123

Gotta be careful with changes. This broke all the Sentry components.