### PR TITLE
fix: kafka env if disabled

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -191,7 +191,7 @@ Set Kafka Confluent host
 {{- if .Values.kafka.enabled -}}
     {{- template "sentry.kafka.fullname" . -}}
 {{- else -}}
-    "kafka-confluent"
+    kafka-confluent
 {{- end -}}
 {{- end -}}
 
@@ -199,10 +199,10 @@ Set Kafka Confluent host
 Set Kafka Confluent port
 */}}
 {{- define "sentry.kafka.port" -}}
-{{- if .Values.kafka.enabled -}}
-    {{- default "9092" .Values.kafka.service.port }}
+{{- if and (.Values.kafka.enabled) (.Values.kafka.service.port) -}}
+    {{- .Values.kafka.service.port }}
 {{- else -}}
-    "9092"
+    9092
 {{- end -}}
 {{- end -}}
 

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -17,4 +17,6 @@ data:
   {{- if $redisPass }}
   REDIS_PASSWORD: "{{ $redisPass }}"
   {{- end }}
+  {{- if .Values.kafka.enabled }}
   DEFAULT_BROKERS: "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}"
+  {{- end }}


### PR DESCRIPTION
I had to kill and restart my Kafka instance (after a high load during the weekend, the snuba consumer didn't want to start anymore).

I realized it was not possible to set kafka to disabled.