### PR TITLE
Fixing problems with fetching postgresqlPassword

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -19,7 +19,7 @@ Finally, it's just a case of upgrading and ensuring the correct params are used:
 
 If Redis auth enabled:
 
-> helm upgrade -n <Sentry namespace> <Sentry Release> . --set redis.usePassword=true --set redis.password=<Redis Password> --set postgresql.postgresqlPassword=<Postgresql Password>
+> helm upgrade -n <Sentry namespace> <Sentry Release> . --set redis.usePassword=true --set redis.password=<Redis Password>
 
 If Redis auth is disabled:
-> helm upgrade -n <Sentry namespace> <Sentry Release> . --set postgresql.postgresqlPassword=<Postgresql Password>
+> helm upgrade -n <Sentry namespace> <Sentry Release> .

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -119,7 +119,7 @@ data:
             "ENGINE": "sentry.db.postgres",
             "NAME": "{{ .Values.postgresql.postgresqlDatabase }}",
             "USER": "{{ .Values.postgresql.postgresqlUsername }}",
-            "PASSWORD": "{{ .Values.postgresql.postgresqlPassword }}",
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "{{ .Values.postgresql.postgresqlPassword }}"),
             "HOST": "{{ default ( include "sentry.postgresql.host" .) .Values.postgresql.hostOverride }}",
             "PORT": {{ template "sentry.postgresql.port" . }},
             {{- if .Values.postgresql.postgresSslMode }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -61,6 +61,13 @@ spec:
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
         - name: C_FORCE_ROOT
           value: "true"
+        {{- if .Values.postgresql.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "sentry.postgresql.fullname" . }}
+              key: postgresql-password
+        {{- end }}
         {{ if eq .Values.filestore.backend "gcs" }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -52,6 +52,13 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.postgresql.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "sentry.postgresql.fullname" . }}
+              key: postgresql-password
+        {{- end }}
         {{ if eq .Values.filestore.backend "gcs" }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -57,6 +57,13 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.postgresql.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "sentry.postgresql.fullname" . }}
+              key: postgresql-password
+        {{- end }}
         {{ if eq .Values.filestore.backend "gcs" }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -66,6 +66,13 @@ spec:
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
         - name: C_FORCE_ROOT
           value: "true"
+        {{- if .Values.postgresql.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "sentry.postgresql.fullname" . }}
+              key: postgresql-password
+        {{- end }}
         {{ if eq .Values.filestore.backend "gcs" }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}


### PR DESCRIPTION
Better to rely on the dependency charts implementation of a secret for populating the db creds. 

fixes: #14 

