### PR TITLE
fix: pass postgress password to db-init

### DIFF
--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -39,6 +39,14 @@ spec:
       - name: db-init-job
         image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
         command: ["sentry","upgrade","--noinput"]
+        {{- if .Values.postgresql.enabled }}
+        env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "sentry.postgresql.fullname" . }}
+              key: postgresql-password
+        {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config


### PR DESCRIPTION
Fixes: #51 

Found the culprit, in #49 the `POSTGRES_PASSWORD` wasn't added to the sentry-db-init template

Now running the migrations just fine:

```
14:24:25 [WARNING] sentry.utils.geo: settings.GEOIP_PATH_MMDB not configured.
14:24:29 [INFO] sentry.plugins.github: apps-not-configured
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, jira_ac, nodestore, sentry, sessions, sites, social_auth
Running migrations:
  Applying sentry.0001_initial... OK
  Applying contenttypes.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0001_initial... OK
```