### PR TITLE
fix: do not complete the user-create on error

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: 10.0.0
 dependencies:
   - name: redis

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -36,10 +36,21 @@ spec:
       containers:
       - name: user-create-job
         image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
-        command: ["/bin/bash"]
+        command: ["/bin/bash", "-c"]
+        # Create user but do not exit 1 when user already exists (exit code 3 from createuser command)
+        # https://docs.sentry.io/server/cli/createuser/
         args:
-          - "-c"
-          - "export output=$(sentry createuser --no-input --email {{ .Values.user.email }} --superuser --password {{ .Values.user.password }}) || true"
+          - >
+            sentry createuser \
+              --no-input \
+              --superuser \
+              --email {{ .Values.user.email }} \
+              --password {{ .Values.user.password }} || true; \
+            if [ $? -eq 0 ] || [ $? -eq 3 ]; then \
+              exit 0; \
+            else \
+              exit 1; \
+            fi
         {{- if .Values.postgresql.enabled }}
         env:
         - name: POSTGRES_PASSWORD


### PR DESCRIPTION
This prevents the user-create job to just complete and get removed as complete Job even when the user wasn't created due an error.
I ran into #55 and couldn't login but the Helm chart install completed nicely. The user-create job must have thrown an error but it exited 0 due the `|| true`. This I couldn't check since the Job had completed successfully and was already removed by Helm.

This uses the new exit code `3` in the user create script introduced in getsentry/sentry#16440 to just exit 0 when the user already exists.
All the other (general) errors like, I couldn't connect to the DB are still thrown and will show up as an errored Job in Kubernetes.