### PR TITLE
Run Snuba in Distributed Dataset Mode

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: 10.0.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -1,5 +1,5 @@
-{{- $redisPort := .Values.redis.redisPort -}}
-{{- $redisHost := .Values.redis.hostOverride | default (include "sentry.redis.host" .) -}}
+{{- $redisHost := include "sentry.redis.host" . -}}
+{{- $redisPort := include "sentry.redis.port" . -}}
 {{- $redisPass := .Values.redis.password -}}
 apiVersion: v1
 kind: ConfigMap

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -16,7 +16,7 @@ data:
     DEBUG = env("DEBUG", "0").lower() in ("1", "true")
 
     {{- if .Values.kafka.enabled }}
-    DEFAULT_BROKERS = "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}"
+    DEFAULT_BROKERS = [{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) | quote }}]
     {{- end }}
 
     REDIS_HOST = {{ include "sentry.redis.host" . | quote }}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -32,7 +32,9 @@ data:
     DOGSTATSD_PORT = None
 
     # Clickhouse Options
-    CLICKHOUSE_HOST = {{ include "sentry.clickhouse.host" . | quote }}
+    CLICKHOUSE_HOST = env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }})
     CLICKHOUSE_PORT = {{ include "sentry.clickhouse.port" . }}
+
+    DATASET_MODE = env("DATASET_MODE", "distributed")
 
 {{ .Values.config.snubaSettingsPy | indent 4 }}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -1,5 +1,4 @@
 {{- $redisHost := .Values.redis.hostOverride | default (include "sentry.redis.host" .) -}}
-{{- $redisPort := .Values.redis.redisPort | default (include "sentry.redis.port" .) -}}
 {{- $redisPass := .Values.redis.password -}}
 apiVersion: v1
 kind: ConfigMap
@@ -23,7 +22,7 @@ data:
     {{- end }}
 
     REDIS_HOST = {{ $redisHost | quote }}
-    REDIS_PORT = {{ $redisPort | default 6379 }}
+    REDIS_PORT = {{ include "sentry.redis.port" . }}
     REDIS_PASSWORD = {{ $redisPass | quote }}
     REDIS_DB = int(env("REDIS_DB", 1))
     USE_REDIS_CLUSTER = False

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -1,4 +1,5 @@
 {{- $redisHost := .Values.redis.hostOverride | default (include "sentry.redis.host" .) -}}
+{{- $redisPort := .Values.redis.redisPort | default (include "sentry.redis.port" .) -}}
 {{- $redisPass := .Values.redis.password -}}
 apiVersion: v1
 kind: ConfigMap
@@ -10,13 +11,29 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  SNUBA_SETTINGS: docker
-  CLICKHOUSE_HOST: "{{ template "sentry.clickhouse.host" . }}"
-  CLICKHOUSE_PORT: "{{ template "sentry.clickhouse.port" . }}"
-  REDIS_HOST: "{{ $redisHost }}"
-  {{- if $redisPass }}
-  REDIS_PASSWORD: "{{ $redisPass }}"
-  {{- end }}
-  {{- if .Values.kafka.enabled }}
-  DEFAULT_BROKERS: "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}"
-  {{- end }}
+  settings.py: |
+    import os
+
+    env = os.environ.get
+
+    DEBUG = env("DEBUG", "0").lower() in ("1", "true")
+
+    {{- if .Values.kafka.enabled }}
+    DEFAULT_BROKERS = "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}"
+    {{- end }}
+
+    REDIS_HOST = {{ $redisHost | quote }}
+    REDIS_PORT = {{ $redisPort | default 6379 }}
+    REDIS_PASSWORD = {{ $redisPass | quote }}
+    REDIS_DB = int(env("REDIS_DB", 1))
+    USE_REDIS_CLUSTER = False
+
+    # Dogstatsd Options
+    DOGSTATSD_HOST = None
+    DOGSTATSD_PORT = None
+
+    # Clickhouse Options
+    CLICKHOUSE_HOST = {{ include "sentry.clickhouse.host" . | quote }}
+    CLICKHOUSE_PORT = {{ include "sentry.clickhouse.port" . }}
+
+{{ .Values.config.snubaSettingsPy | indent 4 }}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -19,7 +19,7 @@ data:
     DEFAULT_BROKERS = "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}"
     {{- end }}
 
-    REDIS_HOST = {{ include "sentry.redis.host" | quote }}
+    REDIS_HOST = {{ include "sentry.redis.host" . | quote }}
     REDIS_PORT = {{ include "sentry.redis.port" . }}
     {{- if .Values.redis.password }}
     REDIS_PASSWORD = {{ .Values.redis.password | quote }}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -1,5 +1,3 @@
-{{- $redisHost := .Values.redis.hostOverride | default (include "sentry.redis.host" .) -}}
-{{- $redisPass := .Values.redis.password -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,9 +19,11 @@ data:
     DEFAULT_BROKERS = "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}"
     {{- end }}
 
-    REDIS_HOST = {{ $redisHost | quote }}
+    REDIS_HOST = {{ include "sentry.redis.host" | quote }}
     REDIS_PORT = {{ include "sentry.redis.port" . }}
-    REDIS_PASSWORD = {{ $redisPass | quote }}
+    {{- if .Values.redis.password }}
+    REDIS_PASSWORD = {{ .Values.redis.password | quote }}
+    {{- end }}
     REDIS_DB = int(env("REDIS_DB", 1))
     USE_REDIS_CLUSTER = False
 

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -54,10 +54,16 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.snuba.api.env }}
         env:
+          - name: SNUBA_SETTINGS
+            value: /etc/snuba/settings.py
+{{- if .Values.snuba.api.env }}
 {{ toYaml .Values.snuba.api.env | indent 8 }}
 {{- end }}
+        volumeMounts:
+        - mountPath: /etc/snuba
+          name: config
+          readOnly: true
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -80,3 +86,7 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.snuba.api.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "sentry.fullname" . }}-snuba

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
         {{- if .Values.snuba.api.annotations }}
 {{ toYaml .Values.snuba.api.annotations | indent 8 }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -51,9 +51,6 @@ spec:
         imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
         ports:
         - containerPort: {{ template "snuba.port" }}
-        envFrom:
-        - configMapRef:
-            name: {{ template "sentry.fullname" . }}-snuba
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
         {{- if .Values.snuba.consumer.annotations }}
 {{ toYaml .Values.snuba.consumer.annotations | indent 8 }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -55,9 +55,19 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.snuba.consumer.env }}
         env:
+          - name: SNUBA_SETTINGS
+            value: /etc/snuba/settings.py
+{{- if .Values.snuba.consumer.env }}
 {{ toYaml .Values.snuba.consumer.env | indent 8 }}
 {{- end }}
+        volumeMounts:
+        - mountPath: /etc/snuba
+          name: config
+          readOnly: true
         resources:
 {{ toYaml .Values.snuba.consumer.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "sentry.fullname" . }}-snuba

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -52,9 +52,6 @@ spec:
         command: ["snuba", "consumer", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
         ports:
         - containerPort: {{ template "snuba.port" }}
-        envFrom:
-        - configMapRef:
-            name: {{ template "sentry.fullname" . }}-snuba
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -52,9 +52,6 @@ spec:
         command: ["snuba", "replacer", "--auto-offset-reset=latest", "--max-batch-size",  "3"]
         ports:
         - containerPort: {{ template "snuba.port" }}
-        envFrom:
-        - configMapRef:
-            name: {{ template "sentry.fullname" . }}-snuba
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -55,9 +55,19 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.snuba.replacer.env }}
         env:
+          - name: SNUBA_SETTINGS
+            value: /etc/snuba/settings.py
+{{- if .Values.snuba.replacer.env }}
 {{ toYaml .Values.snuba.replacer.env | indent 8 }}
 {{- end }}
+        volumeMounts:
+        - mountPath: /etc/snuba
+          name: config
+          readOnly: true
         resources:
 {{ toYaml .Values.snuba.replacer.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "sentry.fullname" . }}-snuba

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
         {{- if .Values.snuba.replacer.annotations }}
 {{ toYaml .Values.snuba.replacer.annotations | indent 8 }}

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -33,12 +33,12 @@ spec:
       containers:
       - name: clickhouse-init
         image: "{{ .Values.clickhouse.clickhouse.image }}:{{ .Values.clickhouse.clickhouse.imageVersion }}"
-        command: [
-          "/bin/bash",
-          "-ec",
-          "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
-            clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query='{{ $createQuery }}';
-            clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query='{{ $createQuery }}';
-          done"
-        ]
+        command:
+          - /bin/bash
+          - -ec
+          - >-
+            for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
+              clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query='{{ $createQuery }}';
+              clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query='{{ $createQuery }}';
+            done
 {{- end }}

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.hooks.enabled -}}
 {{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
+{{- $clickhousePort := include "sentry.clickhouse.port" . -}}
 {{- $createQuery := .Release.Name | printf "CREATE TABLE IF NOT EXISTS sentry_dist AS sentry_local ENGINE = Distributed(%s-clickhouse, default, sentry_local, rand())" -}}
 apiVersion: batch/v1
 kind: Job
@@ -37,9 +38,9 @@ spec:
           "-ec",
           "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
             export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
-            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --query='{{ $createQuery }}';
+            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --port={{ $clickhousePort }} --query='{{ $createQuery }}';
             export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
-            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --query='{{ $createQuery }}';
+            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --port={{ $clickhousePort }} --query='{{ $createQuery }}';
           done"
         ]
 {{- end }}

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.hooks.enabled -}}
+{{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
+{{- $createQuery := .Release.Name | printf "CREATE TABLE IF NOT EXISTS sentry_dist AS sentry_local ENGINE = Distributed(%s-clickhouse, default, sentry_local, rand())" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sentry.fullname" . }}-clickhouse-init
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    metadata:
+      name: {{ template "sentry.fullname" . }}-clickhouse-init
+      labels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+    spec:
+      restartPolicy: Never
+      {{- if .Values.clickhouse.clickhouse.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.clickhouse.clickhouse.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: clickhouse-init
+        image: "{{ .Values.clickhouse.clickhouse.image }}:{{ .Values.clickhouse.clickhouse.imageVersion }}"
+        command: [
+          "/bin/bash",
+          "-ec",
+          "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
+            export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
+            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --query='{{ $createQuery }}';
+            export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
+            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --query='{{ $createQuery }}';
+          done"
+        ]
+{{- end }}

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -15,7 +15,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
-    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-weight": "6"
 spec:
   template:
     metadata:

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -37,10 +37,8 @@ spec:
           "/bin/bash",
           "-ec",
           "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
-            export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
-            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --port={{ $clickhousePort }} --query='{{ $createQuery }}';
-            export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
-            clickhouse-client --database=default --host=$CLICKHOUSE_HOST --port={{ $clickhousePort }} --query='{{ $createQuery }}';
+            clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query='{{ $createQuery }}';
+            clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query='{{ $createQuery }}';
           done"
         ]
 {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.hooks.enabled -}}
+{{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,11 +41,23 @@ spec:
       - name: snuba-init
         image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
-        # We need to run this job a lot of times until it works... until https://github.com/getsentry/snuba/issues/671 is fixed
-        command: ["/bin/bash", "-c", "for i in {1..5};do (LOG_LEVEL=debug snuba bootstrap --force || true);done"]
+        command: [
+          "/bin/bash",
+          "-ec",
+          "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
+            export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
+            snuba bootstrap --force;
+            export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
+            snuba bootstrap --force;
+          done"
+        ]
         env:
+          - name: LOG_LEVEL
+            value: debug
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py
+          - name: DATASET_MODE
+            value: local
 {{- if .Values.snuba.dbInitJob.env }}
 {{ toYaml .Values.snuba.dbInitJob.env | indent 10 }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -46,7 +46,7 @@ spec:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py
 {{- if .Values.snuba.dbInitJob.env }}
-{{ toYaml .Values.snuba.dbInitJob.env | indent 8 }}
+{{ toYaml .Values.snuba.dbInitJob.env | indent 10 }}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/snuba

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -44,10 +44,20 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.snuba.env }}
         env:
+          - name: SNUBA_SETTINGS
+            value: /etc/snuba/settings.py
+{{- if .Values.snuba.env }}
 {{ toYaml .Values.snuba.env | indent 8 }}
 {{- end }}
+        volumeMounts:
+        - mountPath: /etc/snuba
+          name: config
+          readOnly: true
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
 {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "sentry.fullname" . }}-snuba

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -45,8 +45,8 @@ spec:
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py
-{{- if .Values.snuba.env }}
-{{ toYaml .Values.snuba.env | indent 8 }}
+{{- if .Values.snuba.dbInitJob.env }}
+{{ toYaml .Values.snuba.dbInitJob.env | indent 8 }}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/snuba

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       name: {{ template "sentry.fullname" . }}-snuba-db-init
       annotations:
+        checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
         {{- if .Values.snuba.annotations }}
 {{ toYaml .Values.snuba.annotations | indent 8 }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -41,16 +41,16 @@ spec:
       - name: snuba-init
         image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
-        command: [
-          "/bin/bash",
-          "-ec",
-          "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
-            export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
-            snuba bootstrap --force;
-            export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
-            snuba bootstrap --force;
-          done"
-        ]
+        command:
+          - /bin/bash
+          - -ec
+          - >-
+            for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
+              export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
+              snuba bootstrap --force;
+              export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
+              snuba bootstrap --force;
+            done
         env:
           - name: LOG_LEVEL
             value: debug

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -41,9 +41,6 @@ spec:
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
         # We need to run this job a lot of times until it works... until https://github.com/getsentry/snuba/issues/671 is fixed
         command: ["/bin/bash", "-c", "for i in {1..5};do (LOG_LEVEL=debug snuba bootstrap --force || true);done"]
-        envFrom:
-        - configMapRef:
-            name: {{ template "sentry.fullname" . }}-snuba
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -43,10 +43,20 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.snuba.env }}
         env:
+          - name: SNUBA_SETTINGS
+            value: /etc/snuba/settings.py
+{{- if .Values.snuba.env }}
 {{ toYaml .Values.snuba.env | indent 8 }}
 {{- end }}
+        volumeMounts:
+        - mountPath: /etc/snuba
+          name: config
+          readOnly: true
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
 {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "sentry.fullname" . }}-snuba

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.hooks.enabled -}}
+{{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,10 +41,23 @@ spec:
       - name: snuba-migrate
         image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
-        command: ["/bin/bash", "-c", "for i in {1..10};do (LOG_LEVEL=debug snuba migrate || true);done"]
+        command: [
+          "/bin/bash",
+          "-ec",
+          "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
+            export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
+            snuba migrate;
+            export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
+            snuba migrate;
+          done"
+        ]
         env:
+          - name: LOG_LEVEL
+            value: debug
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py
+          - name: DATASET_MODE
+            value: local
 {{- if .Values.snuba.migrateJob.env }}
 {{ toYaml .Values.snuba.migrateJob.env | indent 10 }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -45,7 +45,7 @@ spec:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py
 {{- if .Values.snuba.migrateJob.env }}
-{{ toYaml .Values.snuba.migrateJob.env | indent 8 }}
+{{ toYaml .Values.snuba.migrateJob.env | indent 10 }}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/snuba

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -40,9 +40,6 @@ spec:
         image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
         command: ["/bin/bash", "-c", "for i in {1..10};do (LOG_LEVEL=debug snuba migrate || true);done"]
-        envFrom:
-        - configMapRef:
-            name: {{ template "sentry.fullname" . }}-snuba
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       name: {{ template "sentry.fullname" . }}-snuba-migrate
       annotations:
+        checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
         {{- if .Values.snuba.annotations }}
 {{ toYaml .Values.snuba.annotations | indent 8 }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -41,16 +41,16 @@ spec:
       - name: snuba-migrate
         image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
-        command: [
-          "/bin/bash",
-          "-ec",
-          "for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
-            export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
-            snuba migrate;
-            export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
-            snuba migrate;
-          done"
-        ]
+        command:
+          - /bin/bash
+          - -ec
+          - >-
+            for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
+              export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
+              snuba migrate;
+              export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
+              snuba migrate;
+            done
         env:
           - name: LOG_LEVEL
             value: debug

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -44,8 +44,8 @@ spec:
         env:
           - name: SNUBA_SETTINGS
             value: /etc/snuba/settings.py
-{{- if .Values.snuba.env }}
-{{ toYaml .Values.snuba.env | indent 8 }}
+{{- if .Values.snuba.migrateJob.env }}
+{{ toYaml .Values.snuba.migrateJob.env | indent 8 }}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/snuba

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -92,6 +92,12 @@ snuba:
     # tolerations: []
     # podLabels: []
 
+  dbInitJob:
+    env: {}
+
+  migrateJob:
+    env: {}
+
 
 hooks:
   enabled: true

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -241,6 +241,9 @@ clickhouse:
   enabled: true
   clickhouse:
     imageVersion: "19.16"
+    configmap:
+      remote_servers:
+        internal_replication: true
 
 kafka:
   enabled: true

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -228,6 +228,8 @@ config:
     # No YAML Extension Config Given
   sentryConfPy: |
     # No Python Extension Config Given
+  snubaSettingsPy: |
+    # No Python Extension Config Given
 
 
 clickhouse:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -116,7 +116,6 @@ hooks:
       requests:
         cpu: 700m
         memory: 1Gi
-
 system:
   url: ""
   adminEmail: ""


### PR DESCRIPTION
This pull request configures Snuba to run in distributed dataset mode by:

- Running `snuba-migrate` and `snuba-db-init` jobs against each Clickhouse node
- Configuring Snuba via a `settings.py` file, defaulting `DATASET_MODE` to `distributed`
- Adding a job to create the `sentry_dist` table on each Clickhouse node

Something of note: I've removed the multiple attempts for both the `snuba-migrate` and `snuba-db-init` jobs as it seems the referenced issue has been closed, and it seems to work locally however I though I should mention it just in case.

Fixes #68 