### PR TITLE
Fix templating error when disabling hooks

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: 10.0.0
 dependencies:
   - name: redis

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -67,8 +67,8 @@ spec:
           readOnly: true
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
-{{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -67,8 +67,8 @@ spec:
           readOnly: true
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
-{{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- end }}


### PR DESCRIPTION
Currently when disabling the hooks via 

```yaml
hooks:
  enabled: false
```

helm upgrade fails due to snuba-db-init and snuba-migrate still containing some yaml data. 

```yaml
---
# Source: sentry/templates/hooks/snuba-db-init.job.yaml
volumes:
        - name: config
          configMap:
            name: sentry-snuba
---
# Source: sentry/templates/hooks/snuba-migrate.job.yaml
volumes:
        - name: config
          configMap:
            name: sentry-snuba
```

This PR fixes that by actually removing the complete resource when setting enabled=false.
