### PR TITLE
Update Sentry & Snuba and add `migrations` dataset

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 2.2.0
+version: 3.0.0
 appVersion: 10.0.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -38,7 +38,7 @@ data:
             "host": env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }}),
             "port": int(env("CLICKHOUSE_PORT", {{ include "sentry.clickhouse.port" . }})),
             "http_port": int(env("CLICKHOUSE_HTTP_PORT", 8123)),
-            "storage_sets": {"events", "outcomes", "querylog", "sessions", "transactions"},
+            "storage_sets": {"events", "migrations", "outcomes", "querylog", "sessions", "transactions"},
             # FIXME: Snuba will be able to migrate multi node clusters in the future
             "single_node": env("CLICKHOUSE_SINGLE_NODE", "false").lower() == "true"
         },

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.hooks.enabled -}}
 {{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
 {{- $clickhousePort := include "sentry.clickhouse.port" . -}}
-{{- $tables := "errors groupassignee groupedmessage migrations outcomes_hourly outcomes_mv_hourly outcomes_raw sentry sessions_hourly sessions_hourly_mv sessions_raw transactions" -}}
+{{- $tables := "errors groupassignee groupedmessage outcomes_hourly outcomes_mv_hourly outcomes_raw sentry sessions_hourly sessions_hourly_mv sessions_raw transactions" -}}
 {{- $dropQuery := "DROP TABLE IF EXISTS ${tbl}_dist" -}}
 {{- $createQuery := .Release.Name | printf "CREATE TABLE ${tbl}_dist AS ${tbl}_local ENGINE = Distributed(%s-clickhouse, default, ${tbl}_local, rand())" -}}
 apiVersion: batch/v1

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.hooks.enabled -}}
 {{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
 {{- $clickhousePort := include "sentry.clickhouse.port" . -}}
-{{- $tables := "errors groupassignee groupedmessage outcomes_hourly outcomes_mv_hourly outcomes_raw sentry sessions_hourly sessions_hourly_mv sessions_raw transactions" -}}
+{{- $tables := "errors groupassignee groupedmessage migrations outcomes_hourly outcomes_mv_hourly outcomes_raw sentry sessions_hourly sessions_hourly_mv sessions_raw transactions" -}}
 {{- $dropQuery := "DROP TABLE IF EXISTS ${tbl}_dist" -}}
 {{- $createQuery := .Release.Name | printf "CREATE TABLE ${tbl}_dist AS ${tbl}_local ENGINE = Distributed(%s-clickhouse, default, ${tbl}_local, rand())" -}}
 apiVersion: batch/v1

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -8,12 +8,12 @@ user:
 images:
   sentry:
     repository: getsentry/sentry
-    tag: 3674be2
+    tag: cc9f7d1
     pullPolicy: IfNotPresent
     # imagePullSecrets: []
   snuba:
     repository: getsentry/snuba
-    tag: 3fd2e7d6e8825c0b09f47b4d427d532b6c24ca08
+    tag: 882be95ba0d462a29759a49b2e9aad0c1ce111a9
     pullPolicy: IfNotPresent
     # imagePullSecrets: []
 


### PR DESCRIPTION
This PR adds the `migrations` dataset to maintain support for the latest tags and updates the Sentry & Snuba images accordingly. Unfortunately this introduces a backwards incompatability due to getsentry/snuba#1016 not being included in the current default tags, so I've had to bump the major chart version (again!).