### PR TITLE
Adopt incubator/sentry-kubernetes chart

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,10 @@ jobs:
         uses: yeouchien/helm3-action@f3a7c239c5c60777210c8e631839edf5dd3fa29c
         with:
           command: lint ./sentry
+      - name: Lint Helm
+        uses: yeouchien/helm3-action@f3a7c239c5c60777210c8e631839edf5dd3fa29c
+        with:
+          command: lint ./sentry-kubernetes
       # - name: Create kind cluster
       #   uses: helm/kind-action@v1.0.0-alpha.3
       #   with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -41,6 +41,11 @@ jobs:
         with:
           command: package main/clickhouse --destination gh-pages/charts
 
+      - name: Build zips
+        uses: yeouchien/helm3-action@f3a7c239c5c60777210c8e631839edf5dd3fa29c
+        with:
+          command: package main/sentry-kubernetes --destination gh-pages/charts
+
       - name: Create index file
         uses: yeouchien/helm3-action@f3a7c239c5c60777210c8e631839edf5dd3fa29c
         with:

--- a/sentry-kubernetes/.helmignore
+++ b/sentry-kubernetes/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/sentry-kubernetes/Chart.yaml
+++ b/sentry-kubernetes/Chart.yaml
@@ -1,15 +1,14 @@
-apiVersion: v1
-appVersion: latest
+apiVersion: v2
+name: sentry-kubernetes
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
+type: application
+version: 0.3.0
+appVersion: latest
 home: https://github.com/getsentry/sentry-kubernetes
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 keywords:
 - sentry
 - report kubernetes events
-maintainers:
-- email: ctadeu@gmail.com
-  name: cpanato
-name: sentry-kubernetes
 sources:
 - https://github.com/getsentry/sentry-kubernetes
-version: 0.2.3
+- https://github.com/sentry-kubernetes/charts

--- a/sentry-kubernetes/Chart.yaml
+++ b/sentry-kubernetes/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+appVersion: latest
+description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
+home: https://github.com/getsentry/sentry-kubernetes
+icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
+keywords:
+- sentry
+- report kubernetes events
+maintainers:
+- email: ctadeu@gmail.com
+  name: cpanato
+name: sentry-kubernetes
+sources:
+- https://github.com/getsentry/sentry-kubernetes
+version: 0.2.3

--- a/sentry-kubernetes/OWNERS
+++ b/sentry-kubernetes/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- cpanato
+- gianrubio
+reviewers:
+- cpanato
+- gianrubio

--- a/sentry-kubernetes/OWNERS
+++ b/sentry-kubernetes/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- cpanato
-- gianrubio
-reviewers:
-- cpanato
-- gianrubio

--- a/sentry-kubernetes/README.md
+++ b/sentry-kubernetes/README.md
@@ -1,0 +1,27 @@
+# sentry-kubernetes
+
+[sentry-kubernetes](https://github.com/getsentry/sentry-kubernetes) is a utility that pushes Kubernetes events to [Sentry](https://sentry.io).
+
+# Installation:
+
+```console
+$ helm install incubator/sentry-kubernetes --name my-release --set sentry.dsn=<your-dsn>
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the sentry-kubernetes chart and their default values.
+
+| Parameter               | Description                                                                                                                 | Default                       |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `sentry.dsn`            | Sentry dsn                                                                                                                  | Empty                         |
+| `existingSecret`        | Existing secret to read DSN from                                                                                            | Empty                         |
+| `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
+| `sentry.release`        | Sentry release                                                                                                              | Empty                         |
+| `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |
+| `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
+| `image.tag`             | Container image tag                                                                                                         | `latest`                      |
+| `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
+| `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                            |
+| `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
+| `priorityClassName`     | pod priorityClassName                                                                                                       | Empty                         |

--- a/sentry-kubernetes/README.md
+++ b/sentry-kubernetes/README.md
@@ -5,7 +5,7 @@
 # Installation:
 
 ```console
-$ helm install incubator/sentry-kubernetes --name my-release --set sentry.dsn=<your-dsn>
+$ helm install sentry/sentry-kubernetes --name my-release --set sentry.dsn=<your-dsn>
 ```
 
 ## Configuration

--- a/sentry-kubernetes/templates/NOTES.txt
+++ b/sentry-kubernetes/templates/NOTES.txt
@@ -1,0 +1,3 @@
+sentry-kubernetes has been installed!
+
+If your dsn was correct you should start seeing events in Sentry!

--- a/sentry-kubernetes/templates/_helpers.tpl
+++ b/sentry-kubernetes/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sentry-kubernetes.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sentry-kubernetes.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sentry-kubernetes.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "sentry-kubernetes.labels" }}
+app: {{ template "sentry-kubernetes.name" . }}
+heritage: {{.Release.Service }}
+release: {{.Release.Name }}
+chart: {{ template "sentry-kubernetes.chart" . }}
+{{- if .Values.podLabels}}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sentry-kubernetes.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sentry-kubernetes.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the DSN
+*/}}
+{{- define "sentry-kubernetes.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- printf "%s" .Values.existingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "sentry-kubernetes.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "sentry-kubernetes.createSecret" -}}
+{{- if .Values.existingSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/sentry-kubernetes/templates/clusterrole.yaml
+++ b/sentry-kubernetes/templates/clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/sentry-kubernetes/templates/clusterrolebinding.yaml
+++ b/sentry-kubernetes/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "sentry-kubernetes.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sentry-kubernetes.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/sentry-kubernetes/templates/deployment.yaml
+++ b/sentry-kubernetes/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "sentry-kubernetes.name" . }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "sentry-kubernetes.name" . }}
+        release: {{.Release.Name }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: DSN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "sentry-kubernetes.secretName" . }}
+                key: sentry.dsn
+          {{ if .Values.sentry.environment }}
+          - name: ENVIRONMENT
+            value: {{ .Values.sentry.environment }}
+          {{ end }}
+          {{ if .Values.sentry.release }}
+          - name: RELEASE
+            value: {{ .Values.sentry.release }}
+          {{ end }}
+          {{ if .Values.sentry.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.sentry.logLevel }}
+          {{ end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "sentry-kubernetes.serviceAccountName" . }}

--- a/sentry-kubernetes/templates/secret.yaml
+++ b/sentry-kubernetes/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if (include "sentry-kubernetes.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+type: Opaque
+data:
+  sentry.dsn: {{ .Values.sentry.dsn | b64enc | quote }}
+{{- end -}}

--- a/sentry-kubernetes/templates/serviceaccount.yaml
+++ b/sentry-kubernetes/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.serviceAccountName" . }}
+{{- end }}

--- a/sentry-kubernetes/values.yaml
+++ b/sentry-kubernetes/values.yaml
@@ -1,0 +1,32 @@
+# Default values for sentry-kubernetes.
+
+sentry:
+  dsn: <change-me>
+  logLevel: ~
+# Sentry DSN config using an existing secret:
+# existingSecret:
+image:
+  repository: getsentry/sentry-kubernetes
+  tag: latest
+  pullPolicy: Always
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+# Set priorityCLassName in deployment
+# priorityClassName: ""


### PR DESCRIPTION
I did a `helm pull --untar incubator/sentry-kubernetes` and committed the results as 0d4441bdae8e08182d2c7a4036b09710651f3fdb (with a commit message that attributes the edits to all the original authors in helm/charts).

I also configured GitHub Actions, updated the metadata to v2 and bumped the chart version to 0.3 in a71c7a5f96fccaa33ad5199ccdcb80af192f3cfd.

I need to get my sentry v10 deployment up and running to validate that this still works and I'll wait with (optionally) integrating it with the sentry chart until then. Right now my primary use-case isn't with sentry-kubernetes on the same cluster that sentry is on.

I'll deprecate the chart in incubator and close/update any issues relating to it once this is merged.

Fixes: #93