### PR TITLE
Exposed clickhouse init container

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -10,4 +10,4 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 1.2.2
+version: 1.3.0

--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -47,8 +47,8 @@ spec:
     {{- end }}
       initContainers:
       - name: init
-        image: busybox:1.31.0
-        imagePullPolicy: IfNotPresent
+        image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
+        imagePullPolicy: {{ .Values.clickhouse.init.imagePullPolicy }}
         args:
         - /bin/sh
         - -c

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -46,8 +46,8 @@ spec:
     {{- end }}
       initContainers:
       - name: init
-        image: busybox:1.31.0
-        imagePullPolicy: IfNotPresent
+        image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
+        imagePullPolicy: {{ .Values.clickhouse.init.imagePullPolicy }}
         args:
         - /bin/sh
         - -c

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -59,6 +59,11 @@ clickhouse:
   image: "yandex/clickhouse-server"
   imageVersion: "19.14"
   imagePullPolicy: "IfNotPresent"
+
+  init:
+    image: "busybox"
+    imageVersion: "1.31.0"
+    imagePullPolicy: "IfNotPresent"
   #imagePullSecrets: 
   ## Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. 
   ## More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes


### PR DESCRIPTION
Moved busybox definitions from inside the template to values.yaml to enable image override and the use of private docker registries. 