### PR TITLE
Add legacyApp field for slack

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -49,7 +49,7 @@ data:
     slack.client-secret: "{{ .Values.slack.clientSecret }}"
     slack.verification-token: "{{ .Values.slack.verificationToken }}"
     {{- if .Values.slack.legacyApp }}
-    slack.legacy-app: "{{ .Values.slack.legacyApp }}"
+    slack.legacy-app: {{ .Values.slack.legacyApp }}
     {{ end }}
     {{ end }}
 

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -48,6 +48,9 @@ data:
     slack.client-id: "{{ .Values.slack.clientId }}"
     slack.client-secret: "{{ .Values.slack.clientSecret }}"
     slack.verification-token: "{{ .Values.slack.verificationToken }}"
+    {{- if .Values.slack.legacyApp }}
+    slack.legacy-app: "{{ .Values.slack.legacyApp }}"
+    {{ end }}
     {{ end }}
 
     ################

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -49,7 +49,9 @@ data:
     slack.client-secret: "{{ .Values.slack.clientSecret }}"
     slack.verification-token: "{{ .Values.slack.verificationToken }}"
     {{- if .Values.slack.legacyApp }}
-    slack.legacy-app: {{ .Values.slack.legacyApp }}
+    slack.legacy-app: True
+    {{- else }}
+    slack.legacy-app: False
     {{ end }}
     {{ end }}
 

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -192,6 +192,7 @@ slack: {}
 #   clientId:
 #   clientSecret:
 #   verificationToken:
+#   legacyApp:
 
 ingress:
   enabled: false

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -192,6 +192,10 @@ slack: {}
 #   clientId:
 #   clientSecret:
 #   verificationToken:
+#   # channels.* of Slack API is deprecated.
+#   # All new slack apps created after June 10th, 2020 will give error,
+#   # you need to specify `False` if you want to use the Slack App created after that.
+#   # ref : https://github.com/getsentry/sentry/pull/19446
 #   legacyApp:
 
 ingress:


### PR DESCRIPTION
For the integration with the Slack App to work, need to configure `slack.legacy-app` .

ref : https://github.com/getsentry/sentry/pull/19446