### PR TITLE
sentry: fix appVersion

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 4.7.1
-appVersion: 20.7.2
+version: 4.7.2
+appVersion: 20.7.0
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
version has been reverted in https://github.com/sentry-kubernetes/charts/pull/128 but not the `appVersion`