### PR TITLE
feat(sentry): use AppVersion as the default image tag

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 5.0.0
+version: 5.0.1
 appVersion: 20.7.2
 dependencies:
   - name: redis

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -12,6 +12,22 @@
 {{- define "sentry.port" -}}9000{{- end -}}
 {{- define "snuba.port" -}}1218{{- end -}}
 
+{{- define "relay.image" -}}
+{{- default "getsentry/relay" .Values.images.relay.repository -}}
+:
+{{- default .Chart.AppVersion .Values.images.relay.tag -}}
+{{- end -}}
+{{- define "sentry.image" -}}
+{{- default "getsentry/sentry" .Values.images.sentry.repository -}}
+:
+{{- default .Chart.AppVersion .Values.images.sentry.tag -}}
+{{- end -}}
+{{- define "snuba.image" -}}
+{{- default "getsentry/snuba" .Values.images.snuba.repository -}}
+:
+{{- default .Chart.AppVersion .Values.images.snuba.tag -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -50,7 +50,8 @@ spec:
       {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-relay-init
-          image: {{ .Values.images.relay.repository }}:{{ .Values.images.relay.tag }}
+          image: "{{ template "sentry.image" . }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
           args:
             - "credentials"
             - "generate"
@@ -66,8 +67,8 @@ spec:
               readOnly: true
       containers:
       - name: {{ .Chart.Name }}-relay
-        image: "{{ .Values.images.relay.repository }}:{{ .Values.images.relay.tag }}"
-        imagePullPolicy: {{ .Values.images.relay.pullPolicy }}
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         ports:
         - containerPort: {{ template "relay.port" }}
         env:

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-relay-init
-          image: "{{ template "sentry.image" . }}"
+          image: "{{ template "relay.image" . }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
           args:
             - "credentials"
@@ -67,7 +67,7 @@ spec:
               readOnly: true
       containers:
       - name: {{ .Chart.Name }}-relay
-        image: "{{ template "sentry.image" . }}"
+        image: "{{ template "relay.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         ports:
         - containerPort: {{ template "relay.port" }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -50,8 +50,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-cron
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
-        imagePullPolicy: {{ .Values.images.sentry.pullPolicy }}
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["sentry"]
         args:
           - "run"

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-ingest-consumer
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
+        image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ .Values.images.sentry.pullPolicy }}
         command: ["sentry"]
         args:

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -46,8 +46,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-post-process-forward
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
-        imagePullPolicy: {{ .Values.images.sentry.pullPolicy }}
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["sentry", "run", "post-process-forwarder", "--commit-batch-size", "{{ default "1" .Values.sentry.postProcessForward.commitBatchSize }}"]
         env:
         - name: SNUBA

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -51,8 +51,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-web
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
-        imagePullPolicy: {{ .Values.images.sentry.pullPolicy }}
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["sentry", "run", "web"]
         ports:
         - containerPort: {{ template "sentry.port" }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -51,8 +51,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-worker
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
-        imagePullPolicy: {{ .Values.images.sentry.pullPolicy }}
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["sentry"]
         args:
           - "run"

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -50,8 +50,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-snuba
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
-        imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
+        image: "{{ template "snuba.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -48,8 +48,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-snuba
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
-        imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
+        image: "{{ template "snuba.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
         command: ["snuba", "consumer", "--storage", "events", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -48,8 +48,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-snuba
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
-        imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
+        image: "{{ template "snuba.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
         command: ["snuba", "consumer", "--storage", "outcomes_raw", "--auto-offset-reset=latest", "--max-batch-size",  "3"]
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -48,8 +48,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-snuba
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
-        imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
+        image: "{{ template "snuba.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
         command: ["snuba", "replacer", "--storage", "events", "--auto-offset-reset=latest", "--max-batch-size",  "3"]
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-snuba
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
+        image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
         command: ["snuba", "consumer", "--storage", "sessions_raw", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
         ports:

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-snuba
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
+        image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ .Values.images.snuba.pullPolicy }}
         command: ["snuba", "consumer", "--storage", "transactions", "--consumer-group", "transactions_group", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
         ports:

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -37,7 +37,8 @@ spec:
       {{- end }}
       containers:
       - name: db-init-job
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["sentry","upgrade","--noinput"]
         env:
         {{- if .Values.postgresql.enabled }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
       - name: snuba-init
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
+        image: "{{ template "snuba.image" . }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
         command:
           - /bin/bash

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
       - name: snuba-migrate
-        image: "{{ .Values.images.snuba.repository }}:{{ .Values.images.snuba.tag }}"
+        image: "{{ template "snuba.image" . }}"
         # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
         command:
           - /bin/bash

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -35,7 +35,8 @@ spec:
       {{- end }}
       containers:
       - name: user-create-job
-        image: "{{ .Values.images.sentry.repository }}:{{ .Values.images.sentry.tag }}"
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["/bin/bash", "-c"]
         # Create user but do not exit 1 when user already exists (exit code 3 from createuser command)
         # https://docs.sentry.io/server/cli/createuser/

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -7,19 +7,19 @@ user:
 
 images:
   sentry:
-    repository: getsentry/sentry
-    tag: 20.7.2
-    pullPolicy: IfNotPresent
+    # repository: getsentry/sentry
+    # tag: Chart.AppVersion
+    # pullPolicy: IfNotPresent
     # imagePullSecrets: []
   snuba:
-    repository: getsentry/snuba
-    tag: 20.7.2
-    pullPolicy: IfNotPresent
+    # repository: getsentry/snuba
+    # tag: Chart.AppVersion
+    # pullPolicy: IfNotPresent
     # imagePullSecrets: []
   relay:
-    repository: getsentry/relay
-    tag: 20.7.2
-    pullPolicy: IfNotPresent
+    # repository: getsentry/relay
+    # tag: Chart.AppVersion
+    # pullPolicy: IfNotPresent
     # imagePullSecrets: []
 
 relay:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -10,17 +10,17 @@ images:
     # repository: getsentry/sentry
     # tag: Chart.AppVersion
     # pullPolicy: IfNotPresent
-    # imagePullSecrets: []
+    imagePullSecrets: []
   snuba:
     # repository: getsentry/snuba
     # tag: Chart.AppVersion
     # pullPolicy: IfNotPresent
-    # imagePullSecrets: []
+    imagePullSecrets: []
   relay:
     # repository: getsentry/relay
     # tag: Chart.AppVersion
     # pullPolicy: IfNotPresent
-    # imagePullSecrets: []
+    imagePullSecrets: []
 
 relay:
   replicas: 1


### PR DESCRIPTION
Make it easier to avoid out of sync versions in the future (with 20.7.2 using `AppVersion` should just be fine, #137)