### PR TITLE
feat(sentry): bump clickhouse image to 19.17

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 4.8.0
+version: 4.8.1
 appVersion: 20.7.0
 dependencies:
   - name: redis

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -277,7 +277,7 @@ config:
 clickhouse:
   enabled: true
   clickhouse:
-    imageVersion: "19.16"
+    imageVersion: "19.17"
     configmap:
       remote_servers:
         internal_replication: true


### PR DESCRIPTION
https://github.com/getsentry/onpremise/pull/464

Edit, I've upgrade from 19.16 to 19.17 on a running Sentry without any issues.