### PR TITLE
fix: django.security.csrf issue

### DIFF
--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -16,6 +16,9 @@ data:
     server {
       listen {{ template "nginx.port" }};
 
+      proxy_redirect off;
+      proxy_set_header Host $host;
+
       location /api/store/ {
         proxy_pass http://relay;
       }


### PR DESCRIPTION
https://github.com/sentry-kubernetes/charts/issues/153
I got the same problem.

Nginx should set a host header for csrf.

https://github.com/getsentry/onpremise/pull/463
This PR seems to solve this problem. (It works in my k8s)