### PR TITLE
sentry: relay mode config

### DIFF
--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   config.yml: |-
     relay:
-      mode: managed
+      mode: {{ .Values.relay.mode }}
       upstream: "http://{{ template "sentry.fullname" . }}-web:{{ template "sentry.port" }}/"
       host: 0.0.0.0
       port: {{ template "relay.port" }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -23,6 +23,7 @@ images:
     # imagePullSecrets: []
 
 relay:
+  mode: proxy
   replicas: 1
   env: []
   probeInitialDelaySeconds: 10
@@ -166,7 +167,6 @@ snuba:
   migrateJob:
     env: []
 
-
 hooks:
   enabled: true
   dbInit:
@@ -226,7 +226,8 @@ github: {} # https://github.com/settings/apps (Create a Github App)
 #   privateKey: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpA" !!!! Don't forget a trailing \n
 #   webhookSecret:  "xxxxx`"
 
-githubSso: {} # https://github.com/settings/developers (Create a OAuth App)
+githubSso:
+  {} # https://github.com/settings/developers (Create a OAuth App)
   # clientId: "xx"
   # clientSecret: "xx"
 
@@ -343,7 +344,7 @@ clickhouse:
       dataPersistentVolume:
         enabled: true
         accessModes:
-        - "ReadWriteOnce"
+          - "ReadWriteOnce"
         storage: "30Gi"
 
 ## This value is only used when clickhouse.enabled is set to false
@@ -441,16 +442,16 @@ rabbitmq:
 
   definitions:
     policies: |-
-     {
-       "name": "ha-all",
-       "pattern": "^((?!celeryev.*).)*$",
-       "vhost": "/",
-       "definition": {
-         "ha-mode": "all",
-         "ha-sync-mode": "automatic",
-         "ha-sync-batch-size": 1
-       }
-     }
+      {
+        "name": "ha-all",
+        "pattern": "^((?!celeryev.*).)*$",
+        "vhost": "/",
+        "definition": {
+          "ha-mode": "all",
+          "ha-sync-mode": "automatic",
+          "ha-sync-batch-size": 1
+        }
+      }
 
 ## Prometheus Exporter / Metrics
 ##

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -23,7 +23,7 @@ images:
     # imagePullSecrets: []
 
 relay:
-  mode: proxy
+  mode: managed
   replicas: 1
   env: []
   probeInitialDelaySeconds: 10
@@ -167,7 +167,6 @@ snuba:
   migrateJob:
     env: []
 
-
 hooks:
   enabled: true
   dbInit:
@@ -227,7 +226,8 @@ github: {} # https://github.com/settings/apps (Create a Github App)
 #   privateKey: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpA" !!!! Don't forget a trailing \n
 #   webhookSecret:  "xxxxx`"
 
-githubSso: {} # https://github.com/settings/developers (Create a OAuth App)
+githubSso:
+  {} # https://github.com/settings/developers (Create a OAuth App)
   # clientId: "xx"
   # clientSecret: "xx"
 
@@ -344,7 +344,7 @@ clickhouse:
       dataPersistentVolume:
         enabled: true
         accessModes:
-        - "ReadWriteOnce"
+          - "ReadWriteOnce"
         storage: "30Gi"
 
 ## This value is only used when clickhouse.enabled is set to false
@@ -442,16 +442,16 @@ rabbitmq:
 
   definitions:
     policies: |-
-     {
-       "name": "ha-all",
-       "pattern": "^((?!celeryev.*).)*$",
-       "vhost": "/",
-       "definition": {
-         "ha-mode": "all",
-         "ha-sync-mode": "automatic",
-         "ha-sync-batch-size": 1
-       }
-     }
+      {
+        "name": "ha-all",
+        "pattern": "^((?!celeryev.*).)*$",
+        "vhost": "/",
+        "definition": {
+          "ha-mode": "all",
+          "ha-sync-mode": "automatic",
+          "ha-sync-batch-size": 1
+        }
+      }
 
 ## Prometheus Exporter / Metrics
 ##

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -167,6 +167,7 @@ snuba:
   migrateJob:
     env: []
 
+
 hooks:
   enabled: true
   dbInit:
@@ -226,8 +227,7 @@ github: {} # https://github.com/settings/apps (Create a Github App)
 #   privateKey: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpA" !!!! Don't forget a trailing \n
 #   webhookSecret:  "xxxxx`"
 
-githubSso:
-  {} # https://github.com/settings/developers (Create a OAuth App)
+githubSso: {} # https://github.com/settings/developers (Create a OAuth App)
   # clientId: "xx"
   # clientSecret: "xx"
 
@@ -344,7 +344,7 @@ clickhouse:
       dataPersistentVolume:
         enabled: true
         accessModes:
-          - "ReadWriteOnce"
+        - "ReadWriteOnce"
         storage: "30Gi"
 
 ## This value is only used when clickhouse.enabled is set to false
@@ -442,16 +442,16 @@ rabbitmq:
 
   definitions:
     policies: |-
-      {
-        "name": "ha-all",
-        "pattern": "^((?!celeryev.*).)*$",
-        "vhost": "/",
-        "definition": {
-          "ha-mode": "all",
-          "ha-sync-mode": "automatic",
-          "ha-sync-batch-size": 1
-        }
-      }
+     {
+       "name": "ha-all",
+       "pattern": "^((?!celeryev.*).)*$",
+       "vhost": "/",
+       "definition": {
+         "ha-mode": "all",
+         "ha-sync-mode": "automatic",
+         "ha-sync-batch-size": 1
+       }
+     }
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
Relay pod is crashing in current version of chart (5.0.0), changing relay mode to "proxy" helps. Default "managed" mode doesn't seem to be supported https://getsentry.github.io/relay/