### PR TITLE
Special characters in email and password

### DIFF
--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -44,8 +44,8 @@ spec:
             sentry createuser \
               --no-input \
               --superuser \
-              --email {{ .Values.user.email }} \
-              --password {{ .Values.user.password }} || true; \
+              --email "{{ .Values.user.email }}" \
+              --password "{{ .Values.user.password }}" || true; \
             if [ $? -eq 0 ] || [ $? -eq 3 ]; then \
               exit 0; \
             else \


### PR DESCRIPTION
Currently, this job silently fails if special characters due to missing quoting. Straightforward fix.