### PR TITLE
Add sentry cleanup cronjob

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 5.1.3
+version: 5.2.0
 appVersion: 20.8.0
 dependencies:
   - name: redis

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.sentry.cleanup.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-cleanup
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  schedule: "{{ .Values.sentry.cleanup.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            checksum/configYml: {{ .Values.config.configYml | sha256sum }}
+            checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+            checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
+            {{- if .Values.sentry.cleanup.annotations }}
+{{ toYaml .Values.sentry.cleanup.annotations | indent 12 }}
+            {{- end }}
+          labels:
+            app: {{ template "sentry.fullname" . }}
+            release: "{{ .Release.Name }}"
+            {{- if .Values.sentry.cleanup.podLabels }}
+{{ toYaml .Values.sentry.cleanup.podLabels | indent 12 }}
+            {{- end }}
+        spec:
+          affinity:
+            {{- if .Values.sentry.cleanup.affinity }}
+{{ toYaml .Values.sentry.cleanup.affinity | indent 12 }}
+            {{- end }}
+            {{- if .Values.sentry.cleanup.nodeSelector }}
+          nodeSelector:
+{{ toYaml .Values.sentry.cleanup.nodeSelector | indent 12 }}
+            {{- end }}
+            {{- if .Values.sentry.cleanup.tolerations }}
+          tolerations:
+{{ toYaml .Values.sentry.cleanup.tolerations | indent 12 }}
+            {{- end }}
+            {{- if .Values.images.sentry.imagePullSecrets }}
+          imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 12 }}
+            {{- end }}
+          containers:
+          - name: {{ .Chart.Name }}-sentry-cleanup
+            image: "{{ template "sentry.image" . }}"
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+            command: ["sentry"]
+            args:
+              - "cleanup"
+              - "--days"
+              - "{{ .Values.sentry.cleanup.days }}"
+            env:
+            - name: SNUBA
+              value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+            - name: C_FORCE_ROOT
+              value: "true"
+            {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
+                  key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
+            {{- end }}
+            {{ if eq .Values.filestore.backend "gcs" }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+            {{ end }}
+{{- if .Values.sentry.cleanup.env }}
+{{ toYaml .Values.sentry.cleanup.env | indent 12 }}
+{{- end }}
+            volumeMounts:
+            - mountPath: /etc/sentry
+              name: config
+              readOnly: true
+            - mountPath: {{ .Values.filestore.filesystem.path }}
+              name: sentry-data
+            {{- if eq .Values.filestore.backend "gcs" }}
+            - name: sentry-google-cloud-key
+              mountPath: /var/run/secrets/google
+            {{ end }}
+            resources:
+{{ toYaml .Values.sentry.cleanup.resources | indent 14 }}
+          restartPolicy: Never
+          volumes:
+          - name: config
+            configMap:
+              name: {{ template "sentry.fullname" . }}-sentry
+          - name: sentry-data
+          {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+            persistentVolumeClaim:
+              claimName: {{ template "sentry.fullname" . }}-data
+          {{- else }}
+            emptyDir: {}
+          {{ end }}
+          {{- if eq .Values.filestore.backend "gcs" }}
+          - name: sentry-google-cloud-key
+            secret:
+              secretName: {{ .Values.filestore.gcs.secretName }}
+          {{ end }}
+          {{- if .Values.sentry.cleanup.priorityClassName }}
+          priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"
+          {{- end }}
+{{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -108,6 +108,10 @@ sentry:
     # tolerations: []
     # podLabels: []
     # commitBatchSize: 1
+  cleanup:
+    enabled: false
+    schedule: "0 0 * * *"
+    days: 90
 
 snuba:
   api:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -109,7 +109,7 @@ sentry:
     # podLabels: []
     # commitBatchSize: 1
   cleanup:
-    enabled: false
+    enabled: true
     schedule: "0 0 * * *"
     days: 90
 


### PR DESCRIPTION
https://github.com/sentry-kubernetes/charts/issues/84: Add cleanup jobs with a CronJob

Defaults taken from https://github.com/getsentry/onpremise/blob/21d1b6d42eee14d0de93ba77fe981f9f2a82447e/docker-compose.yml#L184-L191 and https://github.com/getsentry/onpremise/blob/21d1b6d42eee14d0de93ba77fe981f9f2a82447e/.env#L2.

PodSpec inspired by the cron deployment: https://github.com/sentry-kubernetes/charts/blob/develop/sentry/templates/deployment-sentry-cron.yaml