### PR TITLE
fix: nginx configmap name in values.yaml

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -258,7 +258,7 @@ slack: {}
 nginx:
   enabled: true
   containerPort: 8080
-  existingServerBlockConfigmap: sentry-nginx
+  existingServerBlockConfigmap: '{{ template "sentry.fullname" . }}'
   resources: {}
   replicaCount: 1
   service:


### PR DESCRIPTION
The nginx configmap name was hardwired to `sentry-nginx`, and it only works if the helm release name is `sentry`.
This commit fixes that by using a templated variable instead