### PR TITLE
Actually configure Slack based on current documentation

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 5.3.0
+version: 5.4.0
 appVersion: 20.8.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -49,11 +49,12 @@ data:
     {{- if .Values.slack.clientId }}
     slack.client-id: "{{ .Values.slack.clientId }}"
     slack.client-secret: "{{ .Values.slack.clientSecret }}"
-    slack.verification-token: "{{ .Values.slack.verificationToken }}"
     {{- if .Values.slack.legacyApp }}
     slack.legacy-app: True
+    slack.verification-token: "{{ .Values.slack.verificationToken }}"
     {{- else }}
     slack.legacy-app: False
+    slack.signing-secret: "{{ .Values.slack.signingSecret }}"
     {{ end }}
     {{ end }}
 

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -253,10 +253,11 @@ slack: {}
 #   clientId:
 #   clientSecret:
 #   verificationToken:
+#   signingSecret:
 #   # channels.* of Slack API is deprecated.
-#   # All new slack apps created after June 10th, 2020 will give error,
-#   # you need to specify `False` if you want to use the Slack App created after that.
-#   # ref : https://github.com/getsentry/sentry/pull/19446
+#   If legacyApp is set to `true`, then define the verificationToken property
+#   If legacyApp is set to `false`, then define the signingSecret property
+#   Reference -> https://develop.sentry.dev/integrations/slack/
 #   legacyApp:
 
 nginx:


### PR DESCRIPTION
https://develop.sentry.dev/integrations/slack/

According to current documentation, based on the `legacyApp` property, specific things need to be defined in order for the Slack integration to work