### PR TITLE
Added regex support by default for ingress

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -271,10 +271,8 @@ nginx:
 
 ingress:
   enabled: false
-  # annotations:
-  #   If you are using nginx ingress controller, please use at least those 2 annotations
-  #   kubernetes.io/ingress.class: nginx
-  #   nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"
   #
   # hostname:
   #


### PR DESCRIPTION
Added regex support by default for ingress because ingress template include this one:
https://github.com/sentry-kubernetes/charts/blob/develop/sentry/templates/ingress.yaml#L30