### PR TITLE
fix: erroneous formating in relay configmap

### DIFF
--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -13,9 +13,9 @@ metadata:
 data:
   config.yml: |-
     relay:
-      {{- if .Values.relay.mode -}}
+      {{- if .Values.relay.mode }}
       mode: {{ .Values.relay.mode }}
-      {{- end -}}
+      {{- end }}
       upstream: "http://{{ template "sentry.fullname" . }}-web:{{ .Values.service.externalPort }}/"
       host: 0.0.0.0
       port: {{ template "relay.port" }}


### PR DESCRIPTION
Due to trailing minuses in the conditionals, the yaml is geneated in an erroneous way such that there are no newlines before and after the relay.mode yaml key.
This leads to invalid yaml syntax causing the relay pod to crash.

fixes: #202
Signed-off-by: Daniel Schneider <daniel.schneider@eramux.com>