### PR TITLE
Fixed clickhouse database init "Bad get: has UInt64" because of '-' character in cluster name

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -4,7 +4,7 @@
 {{- $clickhouseClusterName := include "sentry.clickhouse.cluster.name" . -}}
 {{- $tables := "errors groupassignee groupedmessage outcomes_hourly outcomes_mv_hourly outcomes_raw sentry sessions_hourly sessions_hourly_mv sessions_raw transactions" -}}
 {{- $dropQuery := "DROP TABLE IF EXISTS ${tbl}_dist" -}}
-{{- $createQuery := $clickhouseClusterName | printf "CREATE TABLE ${tbl}_dist AS ${tbl}_local ENGINE = Distributed(%s, default, ${tbl}_local, rand())" -}}
+{{- $createQuery := $clickhouseClusterName | printf "CREATE TABLE ${tbl}_dist AS ${tbl}_local ENGINE = Distributed('%s', default, ${tbl}_local, rand())" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
When naming the release "my-sentry", clickhouse-init crashed with the following error log:
`Code: 170. DB::Exception: Received from my-sentry-1-clickhouse-0.my-sentry-1-clickhouse-headless:9000. DB::Exception: Bad get: has UInt64, requested String.`

It turns out it was due to the sql parser interpreting "-" as an arithmetic expression [ClickHouse/issues/6484](https://github.com/ClickHouse/ClickHouse/issues/6484).

The fix was to surround the cluster name with single quotes