### PR TITLE
Make organizations:org-subdomains feature optional

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 6.0.0
+version: 6.1.0
 appVersion: 20.9.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -295,6 +295,9 @@ data:
                 "organizations:create",
                 {{ end -}}
 
+                {{- if .Values.sentry.features.orgSubdomains }}
+                "organizations:org-subdomains",
+                {{ end -}}
                 "organizations:advanced-search",
                 "organizations:android-mappings",
                 "organizations:api-keys",
@@ -324,7 +327,6 @@ data:
                 "organizations:monitors",
                 "organizations:onboarding",
                 "organizations:org-saved-searches",
-                "organizations:org-subdomains",
                 "organizations:performance-view",
                 "organizations:relay",
                 "organizations:rule-page",

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -63,6 +63,9 @@ sentry:
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
 
+  features:
+    orgSubdomains: true
+
   worker:
     replicas: 3
     # concurrency: 4


### PR DESCRIPTION
See https://github.com/sentry-kubernetes/charts/issues/208 (DSN endpoint changed)

This PR allows `organizations:org-subdomains` sentry feature to be enabled or not.
Having different subdomains for DSN could break things, therefore it would be nice to have the possibility to disble it.

Note that we could make the whole sentry features list customizable in values.yaml (generated from a default feratures + "exclude_feature" and "include_feature" lists for instance). But for now maybe it's good enough as there is the need for 2 features only (`organizations:create` and `organizations:org-subdomains`)