### PR TITLE
Add (partial) support for Symbolicator deployment

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 6.1.0
+version: 6.2.0
 appVersion: 20.9.0
 dependencies:
   - name: redis

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -11,6 +11,7 @@
 {{- define "relay.port" -}}3000{{- end -}}
 {{- define "sentry.port" -}}9000{{- end -}}
 {{- define "snuba.port" -}}1218{{- end -}}
+{{- define "symbolicator.port" -}}3021{{- end -}}
 
 {{- define "relay.image" -}}
 {{- default "getsentry/relay" .Values.images.relay.repository -}}
@@ -26,6 +27,12 @@
 {{- default "getsentry/snuba" .Values.images.snuba.repository -}}
 :
 {{- default .Chart.AppVersion .Values.images.snuba.tag -}}
+{{- end -}}
+
+{{- define "symbolicator.image" -}}
+{{- default "getsentry/symbolicator" .Values.images.symbolicator.repository -}}
+:
+{{- .Values.images.symbolicator.tag -}}
 {{- end -}}
 
 {{/*

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -21,10 +21,13 @@ data:
     {{- end }}
     postprocess.use-cache-key: 1.0
 
+    # This URL will be used to tell Symbolicator where to obtain the Sentry source.
+    # See https://getsentry.github.io/symbolicator/api/
+    system.internal-url-prefix: 'http://{{ template "sentry.fullname" . }}-web:{{ .Values.service.externalPort }}'
     symbolicator.enabled: {{ .Values.symbolicator.enabled }}
     {{- if .Values.symbolicator.enabled }}
     symbolicator.options:
-      url: "http://{{ template "sentry.fullname" . }}-symbolicator:3021"
+      url: "http://{{ template "sentry.fullname" . }}-symbolicator:{{ template "symbolicator.port" }}"
     {{- end }}
 
     {{- if .Values.github.appId }}

--- a/sentry/templates/configmap-symbolicator.yaml
+++ b/sentry/templates/configmap-symbolicator.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.symbolicator.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sentry.fullname" . }}-symbolicator
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.yml: |-
+    # See: https://getsentry.github.io/symbolicator/#configuration
+    cache_dir: "/data"
+    bind: "0.0.0.0:{{ template "symbolicator.port" }}"
+    logging:
+      level: "{{ .Values.symbolicator.api.logging.level }}"
+    metrics:
+      statsd: null
+    sentry_dsn: null # TODO: Automatically fill this with the internal project DSN
+{{- end }}

--- a/sentry/templates/deployment-symbolicator.yaml
+++ b/sentry/templates/deployment-symbolicator.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.symbolicator.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-symbolicator-api
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "sentry.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: symbolicator-api
+{{- if not .Values.symbolicator.api.autoscaling.enabled }}
+  replicas: {{ .Values.symbolicator.api.replicas }}
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-symbolicator.yaml") . | sha256sum }}
+        {{- if .Values.symbolicator.api.annotations }}
+{{ toYaml .Values.symbolicator.api.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: symbolicator-api
+        {{- if .Values.symbolicator.api.podLabels }}
+{{ toYaml .Values.symbolicator.api.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.symbolicator.api.affinity }}
+      affinity:
+{{ toYaml .Values.symbolicator.api.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.symbolicator.api.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.symbolicator.api.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.symbolicator.api.tolerations }}
+      tolerations:
+{{ toYaml .Values.symbolicator.api.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.symbolicator.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.symbolicator.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-symbolicator
+        image: "{{ template "symbolicator.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.symbolicator.pullPolicy }}
+        args: ["run", "-c", "/etc/symbolicator/config.yml"]
+        ports:
+        - containerPort: {{ template "symbolicator.port" }}
+        env:
+        {{ if eq .Values.filestore.backend "gcs" }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        {{ end }}
+{{- if .Values.symbolicator.api.env }}
+{{ toYaml .Values.symbolicator.api.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/symbolicator
+          name: config
+          readOnly: true
+        - mountPath: /data
+          name: symbolicator-data
+        {{- if eq .Values.filestore.backend "gcs" }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthcheck
+            port: {{ template "symbolicator.port" }}
+            scheme: HTTP
+          initialDelaySeconds: {{ .Values.symbolicator.api.probeInitialDelaySeconds }}
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthcheck
+            port: {{ template "symbolicator.port" }}
+            scheme: HTTP
+          initialDelaySeconds: {{ .Values.symbolicator.api.probeInitialDelaySeconds }}
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+{{ toYaml .Values.symbolicator.api.resources | indent 12 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-symbolicator
+      - name: symbolicator-data
+        emptyDir: {}
+      {{- if eq .Values.filestore.backend "gcs" }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+      {{- if .Values.symbolicator.api.priorityClassName }}
+      priorityClassName: "{{ .Values.symbolicator.api.priorityClassName }}"
+      {{- end }}
+{{- end }}

--- a/sentry/templates/service-symbolicator.yaml
+++ b/sentry/templates/service-symbolicator.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.symbolicator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sentry.fullname" . }}-symbolicator
+  annotations:
+   {{- range $key, $value := .Values.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ template "symbolicator.port" }}
+    targetPort: {{ template "symbolicator.port" }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "sentry.fullname" . }}
+    role: symbolicator-api
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -27,6 +27,11 @@ images:
     # tag: Chart.AppVersion
     # pullPolicy: IfNotPresent
     imagePullSecrets: []
+  symbolicator:
+    # repository: getsentry/symbolicator
+    tag: 0.2.0
+    # pullPolicy: IfNotPresent
+    imagePullSecrets: []
 
 relay:
   replicas: 1
@@ -228,6 +233,30 @@ mail:
 
 symbolicator:
   enabled: false
+  api:
+    replicas: 1
+    env: []
+    probeInitialDelaySeconds: 10
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
+    # podLabels: []
+    # priorityClassName: "xxx"
+    logging:
+      level: warn
+
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 50
+  # TODO The cleanup cronjob is not yet implemented
+  cleanup:
+    enabled: false
+    # podLabels: []
+    # affinity: {}
+    # env: []
 
 auth:
   register: true
@@ -377,6 +406,8 @@ externalClickhouse:
   ##
   # clusterName: test_shard_localhost
 
+# Settings for Kafka.
+# See https://github.com/bitnami/charts/tree/master/bitnami/kafka
 kafka:
   enabled: true
   replicaCount: 3
@@ -385,6 +416,10 @@ kafka:
   offsetsTopicReplicationFactor: 3
   transactionStateLogReplicationFactor: 3
   transactionStateLogMinIsr: 3
+  # 50 MB
+  maxMessageBytes: "50000000"
+  # 50 MB
+  socketRequestMaxBytes: "50000000"
 
   service:
     port: 9092


### PR DESCRIPTION
- Add partial support for Symbolicator. This should work. But the cleanup cronjob of Symbolicator is not yet implemented.
- The `/data` of Symbolicator is using *emptyDir* volume for now. (should we use PVC?) Notice the [doc](https://getsentry.github.io/symbolicator/advanced/caching/) says the volume must be POSIX-compliant.
- Increase the max size of Kafka events as minidump will exceed the default limit. I set it to the same value as [here](https://github.com/getsentry/onpremise/blob/e9cff2e28867eda078b3d3b103aae68252e19d91/docker-compose.yml#L94).
- To try it out, use
```
helm upgrade --install \
  --debug \
  --create-namespace \
  --namespace sentry \
  --wait \
  --timeout 20m \
  --set "postgresql.postgresqlPassword=changeme" \
  --set "symbolicator.enabled=true" \
  -f ./values.yaml \
  sentry ./
```
- Create a Electron project on Sentry web UI.
- And to simulate crash, clone the repo https://github.com/hanshsieh/misc/tree/crashing-electron , switch to the branch `crashing-electron`, update `main.js`, follow the `README.md`
- For the first crash report, you may need to wait a few minutes because Symbolicator will download the debug files in the background.