### PR TITLE
Allow to specify strategy type recreate for sentry web deployment

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 6.1.1
+version: 6.2.1
 appVersion: 20.9.0
 dependencies:
   - name: redis

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 6.1.0
+version: 6.1.1
 appVersion: 20.9.0
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -8,10 +8,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-{{- if .Values.sentry.web.enableRecreate }}
   strategy:
-    type: Recreate
-{{- end }}
+    type: {{ .Values.sentry.web.strategyType }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+{{- if .Values.sentry.web.enableRecreate }}
+  strategy:
+    type: Recreate
+{{- end }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -48,9 +48,8 @@ relay:
 sentry:
   singleOrganization: true
   web:
-    # if using filestore backend filesystem with RWO access,
-    # enable recreate strategy type, instead of default rolling update
-    enableRecreate: false
+    # if using filestore backend filesystem with RWO access, set strategyType to Recreate
+    strategyType: RollingUpdate
     replicas: 1
     env: []
     probeInitialDelaySeconds: 10

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -48,6 +48,9 @@ relay:
 sentry:
   singleOrganization: true
   web:
+    # if using filestore backend filesystem with RWO access,
+    # enable recreate strategy type, instead of default rolling update
+    enableRecreate: false
     replicas: 1
     env: []
     probeInitialDelaySeconds: 10


### PR DESCRIPTION
This fixes an issue for people who are using filesystem filestore with RWO type access. 
Otherwise during rolling update, existing sentry-web deployment holds access to PVC and doesn't allow new deployment to start up.
Fixes: https://github.com/sentry-kubernetes/charts/issues/77
