### PR TITLE
Fix missing quotes in the sentry conf

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 7.4.0
+version: 7.4.1
 appVersion: 20.10.1
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -13,11 +13,11 @@ metadata:
 data:
   config.yml: |-
     {{- if .Values.system.adminEmail }}
-    system.admin-email: {{ .Values.system.adminEmail }}
+    system.admin-email: {{ .Values.system.adminEmail | quote }}
     {{- end }}
     system.secret-key: {{ .Values.system.secretKey | default (randAlphaNum 50) | quote }}
     {{- if .Values.system.url }}
-    system.url-prefix: {{ .Values.system.url }}
+    system.url-prefix: {{ .Values.system.url | quote }}
     {{- end }}
     postprocess.use-cache-key: 1.0
 
@@ -31,34 +31,34 @@ data:
     {{- end }}
 
     {{- if .Values.github.appId }}
-    github-app.id: {{ .Values.github.appId }}
+    github-app.id: {{ .Values.github.appId | quote }}
     {{ end }}
     {{- if .Values.github.appName }}
-    github-app.name: "{{ .Values.github.appName }}"
+    github-app.name: {{ .Values.github.appName | quote }}
     {{ end }}
     {{- if .Values.github.privateKey }}
     github-app.private-key: |-
       {{ .Values.github.privateKey | nindent 8 }}"
     {{ end }}
     {{- if .Values.github.webhookSecret }}
-    github-app.webhook-secret: "{{ .Values.github.webhookSecret }}"
+    github-app.webhook-secret: {{ .Values.github.webhookSecret | quote }}
     {{ end }}
     {{- if .Values.github.clientId }}
-    github-app.client-id: "{{ .Values.github.clientId }}"
+    github-app.client-id: {{ .Values.github.clientId | quote }}
     {{ end }}
     {{- if .Values.github.clientSecret }}
-    github-app.client-secret: "{{ .Values.github.clientSecret }}"
+    github-app.client-secret: {{ .Values.github.clientSecret | quote }}
     {{ end }}
 
     {{- if .Values.slack.clientId }}
-    slack.client-id: "{{ .Values.slack.clientId }}"
-    slack.client-secret: "{{ .Values.slack.clientSecret }}"
+    slack.client-id: {{ .Values.slack.clientId | quote }}
+    slack.client-secret: {{ .Values.slack.clientSecret | quote }}
     {{- if .Values.slack.legacyApp }}
     slack.legacy-app: True
-    slack.verification-token: "{{ .Values.slack.verificationToken }}"
+    slack.verification-token: {{ .Values.slack.verificationToken | quote }}
     {{- else }}
     slack.legacy-app: False
-    slack.signing-secret: "{{ .Values.slack.signingSecret }}"
+    slack.signing-secret: {{ .Values.slack.signingSecret | quote }}
     {{ end }}
     {{ end }}
 
@@ -69,10 +69,10 @@ data:
       default:
         hosts:
           0:
-            host: "{{ $redisHost }}"
+            host: {{ $redisHost | quote }}
             port: {{ $redisPort }}
             {{- if $redisPass }}
-            password: "{{ $redisPass }}"
+            password: {{ $redisPass | quote }}
             {{- end }}
 
     ################
@@ -80,37 +80,37 @@ data:
     ################
     # Uploaded media uses these `filestore` settings. The available
     # backends are either `filesystem` or `s3`.
-    filestore.backend: '{{ .Values.filestore.backend }}'
+    filestore.backend: {{ .Values.filestore.backend | quote }}
     {{- if eq .Values.filestore.backend "filesystem" }}
     filestore.options:
-      location: '{{ .Values.filestore.filesystem.path }}'
+      location: {{ .Values.filestore.filesystem.path | quote }}
     {{ end }}
     {{- if eq .Values.filestore.backend "gcs" }}
     filestore.options:
-      bucket_name: '{{ .Values.filestore.gcs.bucketName }}'
+      bucket_name: {{ .Values.filestore.gcs.bucketName | quote }}
     {{ end }}
     {{- if eq .Values.filestore.backend "s3" }}
     filestore.options:
       {{- if .Values.filestore.s3.accessKey }}
-      access_key: '{{ .Values.filestore.s3.accessKey }}'
+      access_key: {{ .Values.filestore.s3.accessKey | quote }}
       {{- end }}
       {{- if .Values.filestore.s3.secretKey }}
-      secret_key: '{{ .Values.filestore.s3.secretKey }}'
+      secret_key: {{ .Values.filestore.s3.secretKey | quote }}
       {{- end }}
       {{- if .Values.filestore.s3.bucketName }}
-      bucket_name: '{{ .Values.filestore.s3.bucketName }}'
+      bucket_name: {{ .Values.filestore.s3.bucketName | quote }}
       {{- end }}
       {{- if .Values.filestore.s3.endpointUrl }}
-      endpoint_url: '{{ .Values.filestore.s3.endpointUrl }}'
+      endpoint_url: {{ .Values.filestore.s3.endpointUrl | quote }}
       {{- end }}
       {{- if .Values.filestore.s3.signature_version }}
-      signature_version: '{{ .Values.filestore.s3.signature_version }}'
+      signature_version: {{ .Values.filestore.s3.signature_version | quote }}
       {{- end }}
       {{- if .Values.filestore.s3.region_name }}
-      region_name: '{{ .Values.filestore.s3.region_name }}'
+      region_name: {{ .Values.filestore.s3.region_name | quote }}
       {{- end }}
       {{- if .Values.filestore.s3.default_acl }}
-      default_acl: '{{ .Values.filestore.s3.default_acl }}'
+      default_acl: {{ .Values.filestore.s3.default_acl | quote }}
       {{- end }}
     {{ end }}
 
@@ -124,10 +124,10 @@ data:
     DATABASES = {
         "default": {
             "ENGINE": "sentry.db.postgres",
-            "NAME": "{{ include "sentry.postgresql.database" . }}",
-            "USER": "{{ include "sentry.postgresql.username" . }}",
-            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "{{ include "sentry.postgresql.password" . }}"),
-            "HOST": "{{ include "sentry.postgresql.host" . }}",
+            "NAME": {{ include "sentry.postgresql.database" . | quote }},
+            "USER": {{ include "sentry.postgresql.username" . | quote }},
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", {{ include "sentry.postgresql.password" . | quote }}),
+            "HOST": {{ include "sentry.postgresql.host" . | quote }},
             "PORT": {{ template "sentry.postgresql.port" . }},
             {{- if .Values.externalPostgresql.sslMode }}
             'OPTIONS': {
@@ -186,7 +186,7 @@ data:
     SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 
     DEFAULT_KAFKA_OPTIONS = {
-        "bootstrap.servers": "{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}",
+        "bootstrap.servers": {{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) | quote }},
         "message.max.bytes": 50000000,
         "socket.timeout.ms": 1000,
     }
@@ -369,13 +369,13 @@ data:
     #######################
     # Email Configuration #
     #######################
-    SENTRY_OPTIONS['mail.backend'] = os.getenv("SENTRY_EMAIL_BACKEND", "{{ .Values.mail.backend }}")
-    SENTRY_OPTIONS['mail.use-tls'] = bool(strtobool(os.getenv("SENTRY_EMAIL_USE_TLS", "{{ .Values.mail.useTls }}")))
-    SENTRY_OPTIONS['mail.username'] = os.getenv("SENTRY_EMAIL_USERNAME", "{{ .Values.mail.username }}")
-    SENTRY_OPTIONS['mail.password'] = os.getenv("SENTRY_EMAIL_PASSWORD", "{{ .Values.mail.password }}")
-    SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port }}))
-    SENTRY_OPTIONS['mail.host'] = os.getenv("SENTRY_EMAIL_HOST", "{{ .Values.mail.host }}")
-    SENTRY_OPTIONS['mail.from'] = os.getenv("SENTRY_EMAIL_FROM", "{{ .Values.mail.from }}")
+    SENTRY_OPTIONS['mail.backend'] = os.getenv("SENTRY_EMAIL_BACKEND", {{ .Values.mail.backend | quote }})
+    SENTRY_OPTIONS['mail.use-tls'] = bool(strtobool(os.getenv("SENTRY_EMAIL_USE_TLS", {{ .Values.mail.useTls | quote }})))
+    SENTRY_OPTIONS['mail.username'] = os.getenv("SENTRY_EMAIL_USERNAME", {{ .Values.mail.username | quote }})
+    SENTRY_OPTIONS['mail.password'] = os.getenv("SENTRY_EMAIL_PASSWORD", {{ .Values.mail.password | quote }})
+    SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port | quote }}))
+    SENTRY_OPTIONS['mail.host'] = os.getenv("SENTRY_EMAIL_HOST", {{ .Values.mail.host | quote }})
+    SENTRY_OPTIONS['mail.from'] = os.getenv("SENTRY_EMAIL_FROM", {{ .Values.mail.from | quote }})
 
     #########################
     # Bitbucket Integration #


### PR DESCRIPTION
In the configmap for the Sentry config, there're some places that miss to use the `quote` function and would cause some problems in certain cases.
One example is when the admin email look like `#hello@example.com` (this is an valid email)