### PR TITLE
Snuba hook components started before db-init

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 7.2.0
+version: 7.3.0
 appVersion: 20.10.1
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "20"
+    "helm.sh/hook-weight": "1"
   {{- end }}
 spec:
   selector:

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "19"
+    "helm.sh/hook-weight": "0"
   {{- end }}
 spec:
   selector:

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "21"
+    "helm.sh/hook-weight": "2"
   {{- end }}
 spec:
   selector:


### PR DESCRIPTION
This is needed when migrating data from sentry v9 to v10. Otherwise
system installs/starts but no events are migrated. See #229 for more info.