### PR TITLE
[sentry] Update stable repo to new url

### DIFF
--- a/sentry/Chart.lock
+++ b/sentry/Chart.lock
@@ -9,13 +9,13 @@ dependencies:
   repository: https://sentry-kubernetes.github.io/charts
   version: 1.5.0
 - name: rabbitmq-ha
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 1.39.0
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 8.2.1
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
   version: 6.0.5
-digest: sha256:95a04a0fd6722f2f1b2d1750355060369a7d8e1cee6fd0e26974a4c402aff998
-generated: "2020-08-10T10:58:35.648936347+02:00"
+digest: sha256:e6df9c6f840b58037ae7533260b240076ef1272b4a8fbbf131dd1bd1cafa2cf8
+generated: "2020-11-13T13:02:52.231306881+03:00"

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 7.2.0
+version: 7.2.1
 appVersion: 20.10.1
 dependencies:
   - name: redis
@@ -18,12 +18,12 @@ dependencies:
     version: 1.5.0
     condition: clickhouse.enabled
   - name: rabbitmq-ha
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     version: 1.39.0
     alias: rabbitmq
     condition: rabbitmq.enabled
   - name: postgresql
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     version: 8.2.1
     condition: postgresql.enabled
   - name: nginx


### PR DESCRIPTION
The old stable repo has been turned off. Currently, 7.2.0 cannot be installed.