### PR TITLE
Some fixes. Do not create data PVC when not necessary. Fix double declaration in values.yaml

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 7.3.0
+version: 7.3.1
 appVersion: 20.10.1
 dependencies:
   - name: redis

--- a/sentry/templates/pvc.yaml
+++ b/sentry/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.filestore.backend "filesystem" -}}
 {{- if and .Values.filestore.filesystem.persistence.enabled (not .Values.filestore.filesystem.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -21,4 +22,5 @@ spec:
   storageClassName: "{{ .Values.filestore.filesystem.persistence.storageClass }}"
 {{- end }}
 {{- end }}
+{{- end -}}
 {{- end -}}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -148,9 +148,6 @@ snuba:
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
 
-  replacer:
-    replicas: 1
-
   consumer:
     replicas: 1
     env: []
@@ -161,6 +158,15 @@ snuba:
     # podLabels: []
 
   outcomesConsumer:
+    replicas: 1
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
+    # podLabels: []
+
+  replacer:
     replicas: 1
     env: []
     resources: {}
@@ -180,14 +186,6 @@ snuba:
 
   transactionsConsumer:
     replicas: 1
-    env: []
-    resources: {}
-    affinity: {}
-    nodeSelector: {}
-    # tolerations: []
-    # podLabels: []
-
-  replacer:
     env: []
     resources: {}
     affinity: {}


### PR DESCRIPTION
Just deployed as a replacement candidate for our old Sentry 9 chart and here is what I found:
* Fix filesystem PVC creation with filestore backend not equal to "filesystem"
* Fix double replacer: declaration in values.yaml