### PR TITLE
Update service-relay.yaml

### DIFF
--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -11,10 +11,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Don't specify key 'annotations' again, as that causes duplicate annotation keys.

Consider the following `values.yaml` content:
```
service:
  annotations:
    foobar: "foobar" 
```

With the current code, this would generate the following yaml when running helm template (note: I'm replacing some content with "..." for readability):
```
# Source: sentry/templates/service-relay.yaml
kind: Service
...
metadata:
  name: sentry-relay
...
  annotations:
     foobar: "foobar"
  annotations:
    foobar: foobar```