### PR TITLE
Remove duplicate service annotations

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 8.0.0
+version: 8.0.1
 appVersion: 20.10.1
 dependencies:
   - name: redis

--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -11,10 +11,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/sentry/templates/service-sentry.yaml
+++ b/sentry/templates/service-sentry.yaml
@@ -11,10 +11,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/sentry/templates/service-snuba.yaml
+++ b/sentry/templates/service-snuba.yaml
@@ -11,10 +11,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/sentry/templates/service-symbolicator.yaml
+++ b/sentry/templates/service-symbolicator.yaml
@@ -12,10 +12,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Don't specify key 'annotations' again, as that causes duplicate annotation keys.

Consider the following `values.yaml` content:
```
service:
  annotations:
    foobar: "foobar" 
```

With the current code, this would generate the following duplicate annotations for service-relay.yaml, service-sentry.yaml, service-snuba.yaml and service-symbolicator.yaml(note: I'm replacing some content with "..." for readability):
```
kind: Service
...
metadata:
  name: sentry-relay
...
  annotations:
    foobar: "foobar"
  annotations:
    foobar: foobar```