### PR TITLE
Fix snuba when clickhouse has no replica

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -45,8 +45,10 @@ spec:
               for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query="{{ $createQuery }}";
+                {{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query="{{ $createQuery }}";
+                {{- end }}
               done
             done
             {{- else }}

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -45,7 +45,7 @@ spec:
               for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query="{{ $createQuery }}";
-                {{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
+                {{- if .Values.clickhouse.clickhouse.configmap.remote_servers.replica.backup.enabled }}
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless --port={{ $clickhousePort }} --query="{{ $createQuery }}";
                 {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -49,7 +49,7 @@ spec:
             for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
               snuba bootstrap --force;
-              {{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
+              {{- if .Values.clickhouse.clickhouse.configmap.remote_servers.replica.backup.enabled }}
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
               snuba bootstrap --force;
               {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -49,8 +49,10 @@ spec:
             for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
               snuba bootstrap --force;
+              {{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
               snuba bootstrap --force;
+              {{- end }}
             done
             {{- else }}
             export CLICKHOUSE_HOST={{ $clickhouseHost }};

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -49,8 +49,10 @@ spec:
             for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
               snuba migrations migrate --force;
+              {{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
               snuba migrations migrate --force;
+              {{- end }}
             done
             {{- else }}
             export CLICKHOUSE_HOST={{ $clickhouseHost }};

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -49,7 +49,7 @@ spec:
             for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless;
               snuba migrations migrate --force;
-              {{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
+              {{- if .Values.clickhouse.clickhouse.configmap.remote_servers.replica.backup.enabled }}
               export CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless;
               snuba migrations migrate --force;
               {{- end }}


### PR DESCRIPTION
When `clickhouse.configmap.remote_servers.replica.backup.enabled` is set to `false` snuba fails to run jobs as it still tries to connect to `sentry-clickhouse-replica-headless`.

As I understand, for non production or super critical environements `clickhouse.configmap.remote_servers.replica.backup.enabled` could be disabled without big risk, especially if clickhouse itself has a few k8s replicas.