### PR TITLE
Add support of GCS without secret, using GKE ServiceAccount

### DIFF
--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -65,7 +65,7 @@ spec:
                   name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
                   key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
             {{- end }}
-            {{ if eq .Values.filestore.backend "gcs" }}
+            {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
             {{ end }}
@@ -78,7 +78,7 @@ spec:
               readOnly: true
             - mountPath: {{ .Values.filestore.filesystem.path }}
               name: sentry-data
-            {{- if eq .Values.filestore.backend "gcs" }}
+            {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
             - name: sentry-google-cloud-key
               mountPath: /var/run/secrets/google
             {{ end }}
@@ -96,7 +96,7 @@ spec:
           {{- else }}
             emptyDir: {}
           {{ end }}
-          {{- if eq .Values.filestore.backend "gcs" }}
+          {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
           - name: sentry-google-cloud-key
             secret:
               secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -68,7 +68,7 @@ spec:
               name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
-        {{ if eq .Values.filestore.backend "gcs" }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
@@ -81,7 +81,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if eq .Values.filestore.backend "gcs" }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -98,7 +98,7 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if eq .Values.filestore.backend "gcs" }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -74,7 +74,7 @@ spec:
               name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
-        {{ if eq .Values.filestore.backend "gcs" }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
@@ -87,7 +87,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if eq .Values.filestore.backend "gcs" }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -104,7 +104,7 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if eq .Values.filestore.backend "gcs" }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -64,7 +64,7 @@ spec:
               name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
-        {{ if eq .Values.filestore.backend "gcs" }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
@@ -77,7 +77,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if eq .Values.filestore.backend "gcs" }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -94,7 +94,7 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if eq .Values.filestore.backend "gcs" }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -68,7 +68,7 @@ spec:
               name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
-        {{ if eq .Values.filestore.backend "gcs" }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
@@ -81,7 +81,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if eq .Values.filestore.backend "gcs" }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -118,7 +118,7 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if eq .Values.filestore.backend "gcs" }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -73,7 +73,7 @@ spec:
               name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
-        {{ if eq .Values.filestore.backend "gcs" }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
@@ -86,7 +86,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if eq .Values.filestore.backend "gcs" }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -103,7 +103,7 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if eq .Values.filestore.backend "gcs" }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/templates/deployment-symbolicator.yaml
+++ b/sentry/templates/deployment-symbolicator.yaml
@@ -56,7 +56,7 @@ spec:
         ports:
         - containerPort: {{ template "symbolicator.port" }}
         env:
-        {{ if eq .Values.filestore.backend "gcs" }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
@@ -69,7 +69,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: symbolicator-data
-        {{- if eq .Values.filestore.backend "gcs" }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -101,7 +101,7 @@ spec:
           name: {{ template "sentry.fullname" . }}-symbolicator
       - name: symbolicator-data
         emptyDir: {}
-      {{- if eq .Values.filestore.backend "gcs" }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -353,12 +353,12 @@ filestore:
       ## different nodes.
       persistentWorkers: false
 
-  ## Point this at a pre-configured secret containing a service account. The resulting
-  ## secret will be mounted at /var/run/secrets/google
-  gcs:
+  gcs: {}
+    ## Point this at a pre-configured secret containing a service account. The resulting
+    ## secret will be mounted at /var/run/secrets/google
+    # secretName:
     # credentialsFile: credentials.json
-    #  secretName:
-    #  bucketName:
+    # bucketName:
 
   ## Currently unconfigured and changing this has no impact on the template configuration.
   s3: {}


### PR DESCRIPTION
We auth to GCS usgin GKE ServiceAccount with `iam.gke.io/gcp-service-account` annotation. In this case secret and environment variable for it are not needed.

https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity