### PR TITLE
add dbcheck job that ensures that clickhouse and kafka are up

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 8.1.0
+version: 8.2.1
 appVersion: 20.12.1
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "15"
+    "helm.sh/hook-weight": "25"
   {{- end }}
 spec:
   selector:

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -7,6 +7,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.asHook }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   selector:

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   selector:

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.asHook }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "12"
   {{- end }}
 spec:
   selector:

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.hooks.enabled -}}
+{{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
+{{- $clickhousePort := include "sentry.clickhouse.port" . -}}
+{{- $kafkaHost := include "sentry.kafka.host" . -}}
+{{- $kafkaPort := include "sentry.kafka.port" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sentry.fullname" . }}-db-check
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
+    "helm.sh/hook-weight": "-1"
+spec:
+  template:
+    metadata:
+      name: {{ template "sentry.fullname" . }}-db-check
+      annotations:
+        {{- if .Values.sentry.worker.annotations }}
+{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+        {{- if .Values.sentry.worker.podLabels }}
+{{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: Never
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: db-check
+        image: subfuzion/netcat:latest
+        command:
+          - /bin/sh
+          - -c
+          - |
+            {{- if .Values.clickhouse.enabled }}
+            echo "Checking if clickhouse is up"
+            CLICKHOUSE_STATUS=0
+            while [ $CLICKHOUSE_STATUS -eq 0 ]; do
+              CLICKHOUSE_STATUS=1
+              i=0; while [ $i -lt {{ .Values.clickhouse.clickhouse.replicas }} ]; do
+                CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless
+                if ! nc -z "$CLICKHOUSE_HOST" {{ $clickhousePort }}; then
+                  CLICKHOUSE_STATUS=0
+                  echo "$CLICKHOUSE_HOST is not available yet"
+                fi
+                {{- if .Values.clickhouse.clickhouse.configmap.remote_servers.replica.backup.enabled }}
+                CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless
+                if ! nc -z "$CLICKHOUSE_HOST" {{ $clickhousePort }}; then
+                  CLICKHOUSE_STATUS=0
+                  echo "$CLICKHOUSE_HOST is not available yet"
+                fi
+                {{- end }}
+                i=$((i+1))
+              done
+              if [ "$CLICKHOUSE_STATUS" -eq 0 ]; then
+                echo "Clickhouse not ready. Sleeping for 10s before trying again"
+                sleep 10;
+              fi
+            done
+            echo "Clickhouse is up"
+            {{- end }}
+
+            {{- if .Values.kafka.enabled }}
+            echo "Checking if kafka is up"
+            KAFKA_STATUS=0
+            while [ $KAFKA_STATUS -eq 0 ]; do
+              KAFKA_STATUS=1
+              i=0; while [ $i -lt {{ .Values.kafka.replicaCount }} ]; do
+                KAFKA_HOST={{ $kafkaHost }}-$i.{{ $kafkaHost }}-headless
+                if ! nc -z "$KAFKA_HOST" {{ $kafkaPort }}; then
+                  KAFKA_STATUS=0
+                  echo "$KAFKA_HOST is not available yet"
+                fi
+                i=$((i+1))
+              done
+              if [ "$KAFKA_STATUS" -eq 0 ]; then
+                echo "Kafka not ready. Sleeping for 10s before trying again"
+                sleep 10;
+              fi
+            done
+            echo "Kafka is up"
+            {{- end }}
+        env:
+{{- if .Values.hooks.dbCheck.env }}
+{{ toYaml .Values.hooks.dbCheck.env | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.hooks.dbCheck.resources | indent 10 }}
+{{- end }}

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
-    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-weight": "9"
 spec:
   template:
     metadata:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -203,6 +203,14 @@ snuba:
 hooks:
   enabled: true
   removeOnSuccess: true
+  dbCheck:
+    env: []
+    resources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi
   dbInit:
     env: []
     resources:


### PR DESCRIPTION
Hi @Mokto 

this PR fixes following:
1. Ensures that during upgrade\install, we don't attempt to run snuba\sentry jobs until clickhouse and kafka are both up and running
2. For fresh install, I changed hook-weights, to ensure that we run jobs first (db-init, sentry-init, etc), before rolling out other sentry components (that prevents them going into crash loop while db-init is running)
3. Fixed sentry-ingest-consumer not having annotation for `asHook` checked. 

I had an issue with upgrading from 8.0 to 8.1, as clickhouse took forever to start up, and db-init started right away. That caused migration to be stuck. I had to run a bunch of manual snuba migration revert to fix things.
So this PR addresses this issue, so that it doesn't happen again.