### PR TITLE
Make the relay paths in the ingress compatible with traefik

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 8.1.0
+version: 8.1.1
 appVersion: 20.12.1
 dependencies:
   - name: redis

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -37,6 +37,7 @@ Parameter                          | Description                                
 `user.email` | Admin user email | `admin@sentry.local`
 `user.password` | Admin user password| `aaaa`
 `ingress.enabled` | Enabling Ingress | `false`
+`ingress.regexPathStyle` | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx` and `traefik` | `nginx`
 `nginx.enabled` | Enabling NGINX | `true`
 `metrics.enabled`| if `true`, enable Prometheus metrics | `false`
 `metrics.image.repository`         | Metrics exporter image repository                                                                          | `prom/statsd-exporter`

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -27,7 +27,11 @@ spec:
             backend:
               serviceName: {{ template "sentry.fullname" . }}-relay
               servicePort: {{ template "relay.port" . }}
+        {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "traefik" }}
+          - path: {{ default "/" .Values.ingress.path }}api/{[1-9][0-9]*}/{(.*)}
+        {{- else }}
           - path: {{ default "/" .Values.ingress.path }}api/[1-9][0-9]*/(.*)
+        {{- end }}
             backend:
               serviceName: {{ template "sentry.fullname" . }}-relay
               servicePort: {{ template "relay.port" . }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -309,6 +309,8 @@ nginx:
 
 ingress:
   enabled: false
+  # If you are using traefik ingress controller, switch this to 'traefik'
+  regexPathStyle: nginx
   # annotations:
   #   If you are using nginx ingress controller, please use at least those 2 annotations
   #   kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Fix for issue #166, introduces a new option under the ingress called `regexPathStyle` which defaults to `nginx` and if it's set to `traefik` it will generate the path with the regex in it in a format that traefik accepts.