### PR TITLE
automatically enable regex for nginx ingress controller

### DIFF
--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -9,6 +9,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
  annotations:
+   {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "nginx" }}
+     nginx.ingress.kubernetes.io/use-regex: "true"
+   {{- end }}
    {{- range $key, $value := .Values.ingress.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}


### PR DESCRIPTION
without this piece of configuration, traffic cannot be correctly routed to sentry-relay.

this is all the issues and posts that I came across during the debug process, for reference's sake:

* https://github.com/getsentry/onpremise/issues/447
* https://github.com/getsentry/onpremise/issues/598
* https://forum.sentry.io/t/issue-with-csrf-token-after-sentry-upgrade/11133/5
* https://forum.sentry.io/t/events-get-forbidden-status-on-kubernetes/12219/7
* https://forum.sentry.io/t/event-submission-rejected-by-csrf/10482
