### PR TITLE
do not reference CLICKHOUSE_PORT since it's set by kubernetes

### DIFF
--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -19,8 +19,8 @@ data:
     DEBUG = env("DEBUG", "0").lower() in ("1", "true")
 
     # Clickhouse Options
-    CLUSTERS[0]["host"] = env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }})
-    CLUSTERS[0]["port"] = int(env("CLICKHOUSE_PORT", {{ include "sentry.clickhouse.port" . }}))
+    CLUSTERS[0]["host"] = {{ include "sentry.clickhouse.host" . | quote }}
+    CLUSTERS[0]["port"] = int({{ include "sentry.clickhouse.port" . }})
     # FIXME: Snuba will be able to migrate multi node clusters in the future
     CLUSTERS[0]["single_node"] = env("CLICKHOUSE_SINGLE_NODE", "false").lower() == "true"
 


### PR DESCRIPTION
when deployed on kubernetes along with Clickhouse, the CLICKHOUSE_PORT
variable will by default be something like tcp://x.x.x.x:x, which cannot
be converted to str, and has no meaning in sentry helm chart config