### PR TITLE
Improve sentry configuration options

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -62,6 +62,7 @@ Parameter                          | Description                                
 `metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as sentry`
 `metrics.serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s`
 `system.secretKey` | secret key for the session cookie ([documentation](https://develop.sentry.dev/config/#general)) | `nil`
+`sentry.features.vstsLimitedScopes` | Disables the azdo-integrations with limited scopes that is the cause of so much pain | `true`
 
 ## NGINX and/or Ingress
 

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -301,6 +301,7 @@ data:
                 {{- if .Values.sentry.features.orgSubdomains }}
                 "organizations:org-subdomains",
                 {{ end -}}
+
                 "organizations:advanced-search",
                 "organizations:android-mappings",
                 "organizations:api-keys",
@@ -326,7 +327,11 @@ data:
                 "organizations:integrations-chat-unfurl",
                 "organizations:integrations-incident-management",
                 "organizations:integrations-ticket-rules",
+
+                {{- if .Values.sentry.features.vstsLimitedScopes }}
                 "organizations:integrations-vsts-limited-scopes",
+                {{ end -}}
+
                 "organizations:integrations-stacktrace-link",
                 "organizations:internal-catchall",
                 "organizations:invite-members",

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -72,6 +72,7 @@ sentry:
 
   features:
     orgSubdomains: false
+    vstsLimitedScopes: true
 
   worker:
     replicas: 3


### PR DESCRIPTION
Added changes in sentry-configmap, updated values.yml and README.md

This pull requests slightly improves the configuration options for sentry by giving the possibility to enable/disable the integration "vsts-limited-scopes".

Take a quick googlesearch on "sentry azure devops vsts invalid scope" and you'll see what I mean.. :) 