### PR TITLE
Fix missing env(CLICKHOUSE_HOST) in snuba config

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 9.0.0
+version: 9.0.1
 appVersion: 21.1.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -19,7 +19,7 @@ data:
     DEBUG = env("DEBUG", "0").lower() in ("1", "true")
 
     # Clickhouse Options
-    CLUSTERS[0]["host"] = {{ include "sentry.clickhouse.host" . | quote }}
+    CLUSTERS[0]["host"] = env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }})
     CLUSTERS[0]["port"] = int({{ include "sentry.clickhouse.port" . }})
     # FIXME: Snuba will be able to migrate multi node clusters in the future
     CLUSTERS[0]["single_node"] = env("CLICKHOUSE_SINGLE_NODE", "false").lower() == "true"


### PR DESCRIPTION
Fix missing env(CLICKHOUSE_HOST) in snuba config which prevent migration to be run correctly.

Migration job container [use the `CLICKHOUSE_HOST` env variable ](https://github.com/sentry-kubernetes/charts/blob/develop/sentry/templates/hooks/snuba-migrate.job.yaml#L50)to target specific host but this variable isn't used in the snuba configuration. This lead to a situation where migration are run on random host and create an issue where some host aren't up to date.