### PR TITLE
echo to stdout to understand when clickhouse-init job started/finished

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -43,6 +43,8 @@ spec:
           - -ec
           - >-
             {{- if .Values.clickhouse.enabled }}
+            echo "clickhouse-init started"
+            
             for tbl in {{ $tables }}; do
               for ((i=0;i<{{ .Values.clickhouse.clickhouse.replicas }};i++)); do
                 clickhouse-client --database=default --host={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
@@ -53,10 +55,16 @@ spec:
                 {{- end }}
               done
             done
+            
+            echo "clickhouse-init finished"
             {{- else }}
+            echo "clickhouse-init started"
+            
             for tbl in {{ $tables }}; do
               clickhouse-client --database=default --host={{ $clickhouseHost }} --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
               clickhouse-client --database=default --host={{ $clickhouseHost }} --port={{ $clickhousePort }} --query="{{ $createQuery }}";
             done
+            
+            echo "clickhouse-init finished"
             {{- end }}
 {{- end }}


### PR DESCRIPTION
Echo message to stdout to understand when clickhouse-init job started and finished

Usecase: to find via Loki (or other log aggregator) that job was triggered and finished

<img width="1979" alt="clickhouse-init" src="https://user-images.githubusercontent.com/6387460/107965757-f1ba0680-6fbb-11eb-9c4f-b0f3e13224ba.png">

with empty stdout it's quite hard to understand deploy behviour


