### PR TITLE
Add note about scheme for system.url-prefix

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -230,6 +230,7 @@ hooks:
         memory: 1Gi
 
 system:
+  ## be sure to include the scheme on the url, for example: "https://sentry.example.com"
   url: ""
   adminEmail: ""
   ## This should only be used if you’re installing Sentry behind your company’s firewall.


### PR DESCRIPTION
Not including a scheme leads to multiple subtle issues as described in https://github.com/getsentry/sentry/issues/23365

I think it can save users a headache if they are instructed to add the scheme to the URI config value. It's called URI and that might imply it needs a scheme, but I just had a hostname and that lead to multiple issues where sentry was using _some_ URIs that has a double hostname.

ref: https://develop.sentry.dev/config/#general