### PR TITLE
set failureThreshold for readiness and liveness probe

### DIFF
--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -90,7 +90,7 @@ spec:
             subPath: config.yml
             readOnly: true
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /api/relay/healthcheck/ready/
             port: {{ template "relay.port" }}
@@ -100,7 +100,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: 5
           httpGet:
             path: /api/relay/healthcheck/ready/
             port: {{ template "relay.port" }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -86,7 +86,7 @@ spec:
           mountPath: /var/run/secrets/google
         {{ end }}
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /_health/
             port: {{ template "sentry.port" }}
@@ -96,7 +96,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: 5
           httpGet:
             path: /_health/
             port: {{ template "sentry.port" }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -65,7 +65,7 @@ spec:
           name: config
           readOnly: true
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /
             port: {{ template "snuba.port" }}
@@ -75,7 +75,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: 5
           httpGet:
             path: /
             port: {{ template "snuba.port" }}

--- a/sentry/templates/deployment-symbolicator.yaml
+++ b/sentry/templates/deployment-symbolicator.yaml
@@ -74,7 +74,7 @@ spec:
           mountPath: /var/run/secrets/google
         {{ end }}
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 10
           httpGet:
             path: /healthcheck
             port: {{ template "symbolicator.port" }}
@@ -84,7 +84,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: 5
           httpGet:
             path: /healthcheck
             port: {{ template "symbolicator.port" }}


### PR DESCRIPTION
liveness failureThreshold should be more than readiness

otherwise container will be restarted before deciding that container not ready

