### PR TITLE
Add labels and annotations to let upgrades from asHook True to False to succeed

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 9.1.1
+version: 9.1.2
 appVersion: 21.2.0
 dependencies:
   - name: redis

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 9.1.0
+version: 9.1.1
 appVersion: 21.2.0
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "25"
   {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "10"
   {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "10"
   {{- end }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "10"
   {{- end }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "17"
   {{- end }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "18"
   {{- end }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "16"
   {{- end }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -7,8 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
   {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "12"
   {{- end }}


### PR DESCRIPTION
This fixes issues:

* https://github.com/sentry-kubernetes/charts/issues/217
* https://github.com/sentry-kubernetes/charts/issues/270

When installing with `asHook=true` we add the mandatory Helm annotations to the necessary deployments, so that upgrading the value to `asHook=false` does not fail.

Additionally, we set the label `app.kubernetes.io/managed-by: "Helm"` as Helm should always manage these deployments.