### PR TITLE
Reference the kebab case deployment consumer that exists

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 9.1.0
+version: 9.1.1
 appVersion: 21.2.0
 dependencies:
   - name: redis

--- a/sentry/templates/hpa-ingestConsumer.yaml
+++ b/sentry/templates/hpa-ingestConsumer.yaml
@@ -7,7 +7,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-ingestConsumer
+    name: {{ template "sentry.fullname" . }}-ingest-consumer
   minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}


### PR DESCRIPTION
The HPA for the ingest-consumer references the wrong deployment (which causes autoscaling for the ingest-consumer to be ineffective). The deployment used in the chart is `-ingest-consumer` and not `-ingestConsumer`.

This PR fixes the reference to the deployment name in the HPA yaml.