### PR TITLE
Add support for sidecars and volumes

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -65,8 +65,6 @@ Parameter                          | Description                                
 `sentry.features.vstsLimitedScopes` | Disables the azdo-integrations with limited scopes that is the cause of so much pain | `true`
 `sentry.web.customCA.secretName` | Allows mounting a custom CA secret | `nil`
 `sentry.web.customCA.item` | Key of CA cert object within the secret | `ca.crt`
-`sentry.sidecars` | List of container definitions to add to sentry deployments and jobs | `[]`
-`sentry.volumes` | List of volume definitions to add to sentry deployments and jobs | `[]`
 
 ## NGINX and/or Ingress
 

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -65,6 +65,8 @@ Parameter                          | Description                                
 `sentry.features.vstsLimitedScopes` | Disables the azdo-integrations with limited scopes that is the cause of so much pain | `true`
 `sentry.web.customCA.secretName` | Allows mounting a custom CA secret | `nil`
 `sentry.web.customCA.item` | Key of CA cert object within the secret | `ca.crt`
+`sentry.sidecars` | List of container definitions to add to sentry deployments and jobs | `[]`
+`sentry.volumes` | List of volume definitions to add to sentry deployments and jobs | `[]`
 
 ## NGINX and/or Ingress
 

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -84,8 +84,8 @@ spec:
             {{ end }}
             resources:
 {{ toYaml .Values.sentry.cleanup.resources | indent 14 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 10 }}
+{{- if .Values.sentry.cleanup.sidecars }}
+{{ toYaml .Values.sentry.cleanup.sidecars | indent 10 }}
 {{- end }}
           restartPolicy: Never
           volumes:
@@ -104,8 +104,8 @@ spec:
             secret:
               secretName: {{ .Values.filestore.gcs.secretName }}
           {{ end }}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 10 }}
+{{- if .Values.sentry.cleanup.volumes }}
+{{ toYaml .Values.sentry.cleanup.volumes | indent 10 }}
 {{- end }}
           {{- if .Values.sentry.cleanup.priorityClassName }}
           priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -84,6 +84,9 @@ spec:
             {{ end }}
             resources:
 {{ toYaml .Values.sentry.cleanup.resources | indent 14 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 10 }}
+{{- end }}
           restartPolicy: Never
           volumes:
           - name: config
@@ -101,6 +104,9 @@ spec:
             secret:
               secretName: {{ .Values.filestore.gcs.secretName }}
           {{ end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 10 }}
+{{- end }}
           {{- if .Values.sentry.cleanup.priorityClassName }}
           priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"
           {{- end }}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -125,9 +125,9 @@ spec:
           defaultMode: 0644
       - name: credentials
         emptyDir: {}
-      {{- if .Values.relay.priorityClassName }}
-      priorityClassName: "{{ .Values.relay.priorityClassName }}"
-      {{- end }}
 {{- if .Values.sentry.volumes }}
 {{ toYaml .Values.sentry.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.relay.priorityClassName }}
+      priorityClassName: "{{ .Values.relay.priorityClassName }}"
+      {{- end }}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.relay.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.relay.sidecars }}
+{{ toYaml .Values.relay.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
@@ -125,8 +125,8 @@ spec:
           defaultMode: 0644
       - name: credentials
         emptyDir: {}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.relay.volumes }}
+{{ toYaml .Values.relay.volumes | indent 6 }}
 {{- end }}
       {{- if .Values.relay.priorityClassName }}
       priorityClassName: "{{ .Values.relay.priorityClassName }}"

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -115,6 +115,9 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.relay.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
@@ -125,3 +128,6 @@ spec:
       {{- if .Values.relay.priorityClassName }}
       priorityClassName: "{{ .Values.relay.priorityClassName }}"
       {{- end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -86,8 +86,8 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.cron.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.sentry.cron.sidecars }}
+{{ toYaml .Values.sentry.cron.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
@@ -105,8 +105,8 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.sentry.cron.volumes }}
+{{ toYaml .Values.sentry.cron.volumes | indent 6 }}
 {{- end }}
       {{- if .Values.sentry.cron.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.cron.priorityClassName }}"

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -1,4 +1,3 @@
-{{- $redisHost := include "sentry.redis.host" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -87,6 +86,9 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.cron.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
@@ -103,6 +105,9 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.sentry.cron.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.cron.priorityClassName }}"
       {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -102,8 +102,8 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumer.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.sentry.ingestConsumer.sidecars }}
+{{ toYaml .Values.sentry.ingestConsumer.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
@@ -121,8 +121,8 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.sentry.ingestConsumer.volumes }}
+{{ toYaml .Values.sentry.ingestConsumer.volumes | indent 6 }}
 {{- end }}
       {{- if .Values.sentry.ingestConsumer.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestConsumer.priorityClassName }}"

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -102,6 +102,9 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumer.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
@@ -118,6 +121,9 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.sentry.ingestConsumer.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestConsumer.priorityClassName }}"
       {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -87,6 +87,9 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForward.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
@@ -103,6 +106,9 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.sentry.postProcessForward.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.postProcessForward.priorityClassName }}"
       {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -87,8 +87,8 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForward.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.sentry.postProcessForward.sidecars }}
+{{ toYaml .Values.sentry.postProcessForward.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
@@ -106,8 +106,8 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.sentry.postProcessForward.volumes }}
+{{ toYaml .Values.sentry.postProcessForward.volumes | indent 6 }}
 {{- end }}
       {{- if .Values.sentry.postProcessForward.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.postProcessForward.priorityClassName }}"

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -115,6 +115,9 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.sentry.web.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
@@ -139,3 +142,6 @@ spec:
       {{- if .Values.sentry.web.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.web.priorityClassName }}"
       {{- end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -115,8 +115,8 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.sentry.web.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.sentry.web.sidecars }}
+{{ toYaml .Values.sentry.web.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
@@ -142,6 +142,6 @@ spec:
       {{- if .Values.sentry.web.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.web.priorityClassName }}"
       {{- end }}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.sentry.web.volumes }}
+{{ toYaml .Values.sentry.web.volumes | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -92,6 +92,9 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.worker.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
@@ -111,3 +114,6 @@ spec:
       {{- if .Values.sentry.worker.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.worker.priorityClassName }}"
       {{- end }}
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -92,8 +92,8 @@ spec:
         {{ end }}
         resources:
 {{ toYaml .Values.sentry.worker.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.sentry.worker.sidecars }}
+{{ toYaml .Values.sentry.worker.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
@@ -114,6 +114,6 @@ spec:
       {{- if .Values.sentry.worker.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.worker.priorityClassName }}"
       {{- end }}
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.sentry.worker.volumes }}
+{{ toYaml .Values.sentry.worker.volumes | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -86,13 +86,13 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.snuba.api.resources | indent 12 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.snuba.api.sidecars }}
+{{ toYaml .Values.snuba.api.sidecars | indent 6 }}
 {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 8 }}
+{{- if .Values.snuba.api.volumes }}
+{{ toYaml .Values.snuba.api.volumes | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -86,7 +86,13 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.snuba.api.resources | indent 12 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 8 }}
+{{- end }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -57,8 +57,14 @@ spec:
           readOnly: true
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
+{{- if .Values.sentry.sidecars }}
+{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-sentry
+{{- if .Values.sentry.volumes }}
+{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- end }}
 {{- end -}}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -57,14 +57,14 @@ spec:
           readOnly: true
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
-{{- if .Values.sentry.sidecars }}
-{{ toYaml .Values.sentry.sidecars | indent 6 }}
+{{- if .Values.hooks.dbInit.sidecars }}
+{{ toYaml .Values.hooks.dbInit.sidecars | indent 6 }}
 {{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-sentry
-{{- if .Values.sentry.volumes }}
-{{ toYaml .Values.sentry.volumes | indent 6 }}
+{{- if .Values.hooks.dbInit.volumes }}
+{{ toYaml .Values.hooks.dbInit.volumes | indent 6 }}
 {{- end }}
 {{- end -}}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -135,6 +135,8 @@ sentry:
     enabled: true
     schedule: "0 0 * * *"
     days: 90
+  sidecars: []
+  volumes: []
 
 snuba:
   api:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -49,6 +49,8 @@ relay:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
+  sidecars: [ ]
+  volumes: [ ]
 
 sentry:
   singleOrganization: true
@@ -73,6 +75,8 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+    sidecars: [ ]
+    volumes: [ ]
 
   features:
     orgSubdomains: false
@@ -95,6 +99,8 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+    sidecars: [ ]
+    volumes: [ ]
 
   ingestConsumer:
     replicas: 1
@@ -113,7 +119,8 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
-
+    sidecars: [ ]
+    volumes: [ ]
   cron:
     replicas: 1
     env: []
@@ -122,6 +129,8 @@ sentry:
     nodeSelector: {}
     # tolerations: []
     # podLabels: []
+    sidecars: [ ]
+    volumes: [ ]
   postProcessForward:
     replicas: 1
     env: []
@@ -131,12 +140,14 @@ sentry:
     # tolerations: []
     # podLabels: []
     # commitBatchSize: 1
+    sidecars: [ ]
+    volumes: [ ]
   cleanup:
     enabled: true
     schedule: "0 0 * * *"
     days: 90
-  sidecars: []
-  volumes: []
+    sidecars: []
+    volumes: []
 
 snuba:
   api:
@@ -154,6 +165,8 @@ snuba:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+    sidecars: [ ]
+    volumes: [ ]
 
   consumer:
     replicas: 1
@@ -226,6 +239,8 @@ hooks:
       requests:
         cpu: 300m
         memory: 2048Mi
+    sidecars: [ ]
+    volumes: [ ]
   snubaInit:
     resources:
       limits:


### PR DESCRIPTION
This is a bit involved, but let me explain the situation:

- we're using AWS Elasticcache for Redis with in-transit and at-rest encryption enabled
- while some parts of sentry allow using `rediss` as the protocol, others don't
- the only option for us is injecting an `stunnel` (not part of this PR) container that runs next to the sentry code and proxies Redis requests to Elasticcache

Thank you for considering the change. 