### PR TITLE
Added support for aws alb ingress controller

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -37,7 +37,7 @@ Parameter                          | Description                                
 `user.email` | Admin user email | `admin@sentry.local`
 `user.password` | Admin user password| `aaaa`
 `ingress.enabled` | Enabling Ingress | `false`
-`ingress.regexPathStyle` | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx` and `traefik` | `nginx`
+`ingress.regexPathStyle` | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx`, `aws-alb` and `traefik` | `nginx`
 `nginx.enabled` | Enabling NGINX | `true`
 `metrics.enabled`| if `true`, enable Prometheus metrics | `false`
 `metrics.image.repository`         | Metrics exporter image repository                                                                          | `prom/statsd-exporter`

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -53,7 +53,6 @@ spec:
               serviceName: {{ template "sentry.fullname" . }}-web
               servicePort: {{ .Values.service.externalPort }}
     {{- end }}
-    {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -22,8 +22,7 @@ spec:
             backend:
               serviceName: {{ template "sentry.fullname" . }}-nginx
               servicePort: {{ .Values.nginx.service.port }}
-    {{- else }}
-    {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb" }}
+    {{- else if eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb" }}
           - path: /api/0/*
             backend:
               serviceName: {{ template "sentry.fullname" . }}-web

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -23,6 +23,20 @@ spec:
               serviceName: {{ template "sentry.fullname" . }}-nginx
               servicePort: {{ .Values.nginx.service.port }}
     {{- else }}
+    {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb" }}
+          - path: /api/0/*
+            backend:
+              serviceName: {{ template "sentry.fullname" . }}-web
+              servicePort: {{ .Values.service.externalPort }}
+          - path: /api/*
+            backend:
+              serviceName: {{ template "sentry.fullname" . }}-relay
+              servicePort: {{ template "relay.port" . }}
+          - path: "/*"
+            backend:
+              serviceName: {{ template "sentry.fullname" . }}-web
+              servicePort: {{ .Values.service.externalPort }}
+    {{- else }}
           - path: {{ default "/" .Values.ingress.path }}api/store
             backend:
               serviceName: {{ template "sentry.fullname" . }}-relay
@@ -39,6 +53,7 @@ spec:
             backend:
               serviceName: {{ template "sentry.fullname" . }}-web
               servicePort: {{ .Values.service.externalPort }}
+    {{- end }}
     {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -324,6 +324,7 @@ nginx:
 ingress:
   enabled: false
   # If you are using traefik ingress controller, switch this to 'traefik'
+  # if you are using AWS ALB Ingress controller, switch this to 'aws-alb' 
   regexPathStyle: nginx
   # annotations:
   #   If you are using nginx ingress controller, please use at least those 2 annotations


### PR DESCRIPTION
Hi.
Please find a proposition to support [AWS Load balancer controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) directly from the chart configuration.

The AWS LB support is enabled by setting `regexPathStyle` to `aws-alb`