### PR TITLE
Pass symbolicator config as YAML

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -31,6 +31,8 @@ If Redis auth is disabled:
 
 The following table lists the configurable parameters of the Sentry chart and their default values.
 
+Note: this table is incomplete, so have a look at the values.yaml in case you miss something
+
 Parameter                          | Description                                                                                                | Default
 :--------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------------------------------------------------
 `user.create` | if `true`, creates a default admin user defined from `email` and `password` | `true`
@@ -65,6 +67,8 @@ Parameter                          | Description                                
 `sentry.features.vstsLimitedScopes` | Disables the azdo-integrations with limited scopes that is the cause of so much pain | `true`
 `sentry.web.customCA.secretName` | Allows mounting a custom CA secret | `nil`
 `sentry.web.customCA.item` | Key of CA cert object within the secret | `ca.crt`
+`symbolicator.api.enabled` | Enable Symbolicator | `false`
+`symbolicator.api.config` | Config file for Symbolicator, see [its docs](https://getsentry.github.io/symbolicator/#configuration) | see values.yaml
 
 ## NGINX and/or Ingress
 
@@ -77,3 +81,29 @@ For your security, the [`system.secret-key`](https://develop.sentry.dev/config/#
 ```
 helm upgrade ... --set system.secretKey=xx
 ```
+
+## Symbolicator
+
+For getting native stacktraces and minidumps symbolicated with debug symbols (e.g. iOS/Android), you need to enable Symbolicator via
+```yaml
+symbolicator:
+  enabled: true
+```
+
+However, you also need to share the data between sentry-worker and sentry-web. This can be done in different ways:
+
+- Using Cloud Storage like GCP GCS or AWS S3, see `filestore.backend` in `values.yaml`
+- Using a filesystem like
+
+```yaml
+filestore:
+  filesystem:
+    persistence:
+      persistentWorkers: true
+      # storageClass: 'efs-storage' # see note below
+```
+Note: If you need to run or cannot avoid running sentry-worker and sentry-web on different cluster nodes, you need to set `filestore.filesystem.persistence.accessMode: ReadWriteMany` or might get problems. HOWEVER, [not all volume drivers support it](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes), like AWS EBS or GCP disks.
+So you would want to create and use a `StorageClass` with a supported volume driver like [AWS EFS](https://github.com/kubernetes-sigs/aws-efs-csi-driver)
+
+Its also important having `connect_to_reserved_ips: true` in the symbolicator config file, which this Chart defaults to.
+

--- a/sentry/templates/configmap-symbolicator.yaml
+++ b/sentry/templates/configmap-symbolicator.yaml
@@ -9,13 +9,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  config.yml: |-
-    # See: https://getsentry.github.io/symbolicator/#configuration
-    cache_dir: "/data"
-    bind: "0.0.0.0:{{ template "symbolicator.port" }}"
-    logging:
-      level: "{{ .Values.symbolicator.api.logging.level }}"
-    metrics:
-      statsd: null
-    sentry_dsn: null # TODO: Automatically fill this with the internal project DSN
+  config.yml: {{ toYaml .Values.symbolicator.api.config | indent 2 }}
 {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -280,9 +280,30 @@ symbolicator:
     # tolerations: []
     # podLabels: []
     # priorityClassName: "xxx"
-    logging:
-      level: warn
+    config: |-
+      # See: https://getsentry.github.io/symbolicator/#configuration
+      cache_dir: "/data"
+      bind: "0.0.0.0:3021"
+      logging:
+        level: "warn"
+      metrics:
+        statsd: null
+        prefix: "symbolicator"
+      sentry_dsn: null
+      connect_to_reserved_ips: true
+      # caches:
+      #   downloaded:
+      #     max_unused_for: 1w
+      #     retry_misses_after: 5m
+      #     retry_malformed_after: 5m
+      #   derived:
+      #     max_unused_for: 1w
+      #     retry_misses_after: 5m
+      #     retry_malformed_after: 5m
+      #   diagnostics:
+      #     retention: 1w
 
+    # TODO autoscaling in not yet implemented
     autoscaling:
       enabled: false
       minReplicas: 2


### PR DESCRIPTION
This adds more config options to symbolicator deployment.

We needed `connect_to_reserved_ips` , which wasnt supported, so I took the chance and added more along the way.

I tested symbolicator to start properly also with the `caches` enabled