### PR TITLE
Add global env list for external databases

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -154,8 +154,8 @@ Set postgresql username
 {{- define "sentry.postgresql.username" -}}
 {{- if .Values.postgresql.enabled -}}
 {{- default "postgres" .Values.postgresql.postgresqlUsername }}
-{{- else -}}
-{{ required "A valid .Values.externalPostgresql.username is required" .Values.externalPostgresql.username }}
+{{- else if .Values.externalPostgresql.username -}}
+{{- .Values.externalPostgresql.username }}
 {{- end -}}
 {{- end -}}
 
@@ -165,8 +165,8 @@ Set postgresql password
 {{- define "sentry.postgresql.password" -}}
 {{- if .Values.postgresql.enabled -}}
 {{- default "" .Values.postgresql.postgresqlPassword }}
-{{- else -}}
-{{ required "A valid .Values.externalPostgresql.password is required" .Values.externalPostgresql.password }}
+{{- else if .Values.externalPostgresql.password -}}
+{{- .Values.externalPostgresql.password }}
 {{- end -}}
 {{- end -}}
 

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -132,7 +132,7 @@ data:
         "default": {
             "ENGINE": "sentry.db.postgres",
             "NAME": {{ include "sentry.postgresql.database" . | quote }},
-            "USER": {{ include "sentry.postgresql.username" . | quote }},
+            "USER": os.environ.get("POSTGRES_USER", {{ include "sentry.postgresql.username" . | quote }}),
             "PASSWORD": os.environ.get("POSTGRES_PASSWORD", {{ include "sentry.postgresql.password" . | quote }}),
             "HOST": {{ include "sentry.postgresql.host" . | quote }},
             "PORT": {{ template "sentry.postgresql.port" . }},

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -21,6 +21,9 @@ data:
     # Clickhouse Options
     CLUSTERS[0]["host"] = env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }})
     CLUSTERS[0]["port"] = int({{ include "sentry.clickhouse.port" . }})
+    CLUSTERS[0]["user"] = env("CLICKHOUSE_USER", "default")
+    CLUSTERS[0]["password"] = env("CLICKHOUSE_PASSWORD", "")
+    CLUSTERS[0]["database"] = env("CLICKHOUSE_DATABASE", "default")
     # FIXME: Snuba will be able to migrate multi node clusters in the future
     CLUSTERS[0]["single_node"] = env("CLICKHOUSE_SINGLE_NODE", "false").lower() == "true"
 

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -69,6 +69,9 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
             {{ end }}
+{{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.cleanup.env }}
 {{ toYaml .Values.sentry.cleanup.env | indent 12 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -71,6 +71,9 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
+{{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.cron.env }}
 {{ toYaml .Values.sentry.cron.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -87,6 +87,9 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
+{{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.ingestConsumer.env }}
 {{ toYaml .Values.sentry.ingestConsumer.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -72,6 +72,9 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
+{{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.postProcessForward.env }}
 {{ toYaml .Values.sentry.postProcessForward.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -76,6 +76,9 @@ spec:
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/ca-trust/custom/{{ default "ca.crt" .Values.sentry.web.customCA.item }}
         {{ end }}
+{{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.web.env }}
 {{ toYaml .Values.sentry.web.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -77,6 +77,9 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
+{{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.worker.env }}
 {{ toYaml .Values.sentry.worker.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -59,10 +59,14 @@ spec:
             echo "clickhouse-init finished"
             {{- else }}
             echo "clickhouse-init started"
-            
+
+            CLICKHOUSE_CONN="--database=${CLICKHOUSE_DATABASE:-default}"
+            [ -n "$CLICKHOUSE_USER" ] && CLICKHOUSE_CONN="$CLICKHOUSE_CONN --username=$CLICKHOUSE_USER"
+            [ -n "$CLICKHOUSE_PASSWORD" ] && CLICKHOUSE_CONN="$CLICKHOUSE_CONN --password=$CLICKHOUSE_PASSWORD"
+
             for tbl in {{ $tables }}; do
-              clickhouse-client --database=default --host={{ $clickhouseHost }} --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
-              clickhouse-client --database=default --host={{ $clickhouseHost }} --port={{ $clickhousePort }} --query="{{ $createQuery }}";
+              clickhouse-client ${CLICKHOUSE_CONN} --host={{ $clickhouseHost }} --port={{ $clickhousePort }} --query="{{ $dropQuery }}";
+              clickhouse-client ${CLICKHOUSE_CONN} --host={{ $clickhouseHost }} --port={{ $clickhousePort }} --query="{{ $createQuery }}";
             done
             
             echo "clickhouse-init finished"

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -48,6 +48,9 @@ spec:
               name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
+        {{- if .Values.externalPostgresql.env }}
+{{ toYaml .Values.externalPostgresql.env | indent 8 }}
+        {{- end }}
         {{- if .Values.hooks.dbInit.env }}
 {{ toYaml .Values.hooks.dbInit.env | indent 8 }}
         {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -443,6 +443,7 @@ externalClickhouse:
   ## or by executing `select * from system.clusters`
   ##
   # clusterName: test_shard_localhost
+  env: []
 
 # Settings for Kafka.
 # See https://github.com/bitnami/charts/tree/master/bitnami/kafka
@@ -511,6 +512,7 @@ externalPostgresql:
   # password: postgres
   database: sentry
   # sslMode: require
+  env: []
 
 rabbitmq:
   ## If disabled, Redis will be used instead as the broker.


### PR DESCRIPTION
Hello.
I would wanted to specify some env variables for all services in sentry chart, which use current external service.
For example, I use postgres operator, it's automatically create secret with user auth credentials. Another example - clickhouse operator with authentication.
I want to write that creds in one place, and it must be added into all containers manifests, which will be connecting to this external service.