### PR TITLE
Add support for multiple external kafkas

### DIFF
--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -25,7 +25,7 @@ data:
 
       kafka_config:
         - name: "bootstrap.servers"
-          value: {{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}
+          value: {{ (include "sentry.kafka.bootstrap_servers_string" .) | quote }}
         - name: "message.max.bytes"
           value: 50000000  # 50MB or bust
 

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -193,7 +193,7 @@ data:
     SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 
     DEFAULT_KAFKA_OPTIONS = {
-        "bootstrap.servers": {{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) | quote }},
+        "bootstrap.servers": {{ (include "sentry.kafka.bootstrap_servers_string" .) | quote }},
         "message.max.bytes": 50000000,
         "socket.timeout.ms": 1000,
     }

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -92,12 +92,13 @@ spec:
             done
             echo "Clickhouse is up"
 
-            {{- if .Values.kafka.enabled }}
             echo "Checking if kafka is up"
             KAFKA_STATUS=0
             while [ $KAFKA_STATUS -eq 0 ]; do
               KAFKA_STATUS=1
-              i=0; while [ $i -lt {{ .Values.kafka.replicaCount }} ]; do
+              {{- if .Values.kafka.enabled }}
+              KAFKA_REPLICAS={{ .Values.kafka.replicaCount }}
+              i=0; while [ $i -lt $KAFKA_REPLICAS ]; do
                 KAFKA_HOST={{ $kafkaHost }}-$i.{{ $kafkaHost }}-headless
                 if ! nc -z "$KAFKA_HOST" {{ $kafkaPort }}; then
                   KAFKA_STATUS=0
@@ -105,13 +106,27 @@ spec:
                 fi
                 i=$((i+1))
               done
+              {{- else if (not (kindIs "slice" .Values.externalKafka)) }}
+              KAFKA_HOST={{ .Values.externalKafka.host }}
+              if ! nc -z "$KAFKA_HOST" {{ $kafkaPort }}; then
+                KAFKA_STATUS=0
+                echo "$KAFKA_HOST is not available yet"
+              fi
+              {{- else }}
+              {{- range $elem := .Values.externalKafka }}
+              KAFKA_HOST={{ $elem.host }}
+              if ! nc -z "$KAFKA_HOST" {{ $elem.port }}; then
+                KAFKA_STATUS=0
+                echo "$KAFKA_HOST is not available yet"
+              fi
+              {{- end }}
+              {{- end }}
               if [ "$KAFKA_STATUS" -eq 0 ]; then
                 echo "Kafka not ready. Sleeping for 10s before trying again"
                 sleep 10;
               fi
             done
             echo "Kafka is up"
-            {{- end }}
         env:
 {{- if .Values.hooks.dbCheck.env }}
 {{ toYaml .Values.hooks.dbCheck.env | indent 8 }}


### PR DESCRIPTION
The main motivation for this change is to enable AWS MSK used as external kafka. This change keeps config backward compatible, which means if a simple structure given under the `externalKafka` then it used as before. However if a list of these structures given, then all of the items used.

Example inputs:
- simple:
  ```
  externalKafka:
    host: broker-1
    port: 9094
  ```

- multiple kafka brokers:
  ```yaml
  externalKafka:
    - host: broker-1
      port: 9094
    - host: broker-2
      port: 9094
    - host: broker-3
      port: 9094
  ```