### PR TITLE
Add support for pod annotations and labels

### DIFF
--- a/clickhouse/templates/deployment-tabix.yaml
+++ b/clickhouse/templates/deployment-tabix.yaml
@@ -22,9 +22,20 @@ spec:
 {{- end }}
   template:
     metadata:
+      {{- if .Values.clickhouse.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.clickhouse.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "clickhouse.name" . }}-tabix
         app.kubernetes.io/instance: {{ .Release.Name }}-tabix
+      {{- if .Values.clickhouse.podLabels }}
+      {{- range $key, $value := .Values.clickhouse.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
     {{- if .Values.affinity }}
       affinity:

--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -30,11 +30,21 @@ spec:
       {{- if and .Values.clickhouse.metrics.enabled .Values.clickhouse.metrics.podAnnotations }}
       {{- toYaml .Values.clickhouse.metrics.podAnnotations | nindent 8 }}
       {{- end }}
+      {{- if .Values.clickhouse.podAnnotations }}
+      {{- range $key, $value := .Values.clickhouse.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "clickhouse.name" . }}-replica
         app.kubernetes.io/instance: {{ .Release.Name }}-replica
       {{- if and .Values.clickhouse.metrics.enabled .Values.clickhouse.metrics.podLabels }}
       {{- toYaml .Values.clickhouse.metrics.podLabels | nindent 8 }}
+      {{- end }}
+      {{- if .Values.clickhouse.podLabels }}
+      {{- range $key, $value := .Values.clickhouse.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       {{- end }}
     spec:
     {{- if .Values.affinity }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -29,12 +29,22 @@ spec:
       {{- if and .Values.clickhouse.metrics.enabled .Values.clickhouse.metrics.podAnnotations }}
       {{- toYaml .Values.clickhouse.metrics.podAnnotations | nindent 8 }}
       {{- end }}
+      {{- if .Values.clickhouse.podAnnotations }}
+      {{- range $key, $value := .Values.clickhouse.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "clickhouse.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if and .Values.clickhouse.metrics.enabled .Values.clickhouse.metrics.podLabels }}
       {{- toYaml .Values.clickhouse.metrics.podLabels | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.clickhouse.podLabels }}
+      {{- range $key, $value := .Values.clickhouse.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
     {{- if .Values.affinity }}
       affinity:

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -433,3 +433,9 @@ tabix:
 
   ## The resource limits and requests used by tabix
   resources: {}
+
+  ## Pod annotations
+  podAnnotations:
+
+  ## Additional Labels
+  podLabels:

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -26,6 +26,9 @@ spec:
         {{- if .Values.sentry.worker.annotations }}
 {{ toYaml .Values.sentry.worker.annotations | indent 8 }}
         {{- end }}
+        {{- if .Values.hooks.dbCheck.podAnnotations }}
+{{ toYaml .Values.hooks.dbCheck.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -23,6 +23,9 @@ spec:
         {{- if .Values.sentry.worker.annotations }}
 {{ toYaml .Values.sentry.worker.annotations | indent 8 }}
         {{- end }}
+        {{- if .Values.hooks.dbInit.podAnnotations }}
+{{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -25,6 +25,9 @@ spec:
         {{- if .Values.snuba.annotations }}
 {{ toYaml .Values.snuba.annotations | indent 8 }}
         {{- end }}
+        {{- if .Values.hooks.snubaInit.podAnnotations }}
+{{ toYaml .Values.hooks.snubaInit.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -25,6 +25,9 @@ spec:
         {{- if .Values.snuba.annotations }}
 {{ toYaml .Values.snuba.annotations | indent 8 }}
         {{- end }}
+        {{- if .Values.hooks.snubaInit.podAnnotations }}
+{{ toYaml .Values.hooks.snubaInit.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -21,6 +21,9 @@ spec:
         {{- if .Values.sentry.worker.annotations }}
 {{ toYaml .Values.sentry.worker.annotations | indent 8 }}
         {{- end }}
+        {{- if .Values.hooks.dbInit.podAnnotations }}
+{{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -223,8 +223,11 @@ snuba:
 hooks:
   enabled: true
   removeOnSuccess: true
+  clickhouseInit:
+    podAnnotations:
   dbCheck:
     env: []
+    podAnnotations: []
     resources:
       limits:
         memory: 64Mi
@@ -233,6 +236,7 @@ hooks:
         memory: 64Mi
   dbInit:
     env: []
+    podAnnotations: []
     resources:
       limits:
         memory: 2048Mi
@@ -242,6 +246,7 @@ hooks:
     sidecars: [ ]
     volumes: [ ]
   snubaInit:
+    podAnnotations: []
     resources:
       limits:
         cpu: 2000m
@@ -362,7 +367,7 @@ nginx:
 ingress:
   enabled: false
   # If you are using traefik ingress controller, switch this to 'traefik'
-  # if you are using AWS ALB Ingress controller, switch this to 'aws-alb' 
+  # if you are using AWS ALB Ingress controller, switch this to 'aws-alb'
   regexPathStyle: nginx
   # annotations:
   #   If you are using nginx ingress controller, please use at least those 2 annotations


### PR DESCRIPTION
This gives support to add pod annotations and labels for clickhouse and all of the Sentry hooks. Useful to deploy with istio.