### PR TITLE
Disable tabix by default to follow the documentation

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -10,4 +10,4 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 2.0.0
+version: 3.0.0

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -352,7 +352,7 @@ clickhouse:
 tabix:
   ##
   ## Enable Tabix
-  enabled: true
+  enabled: false
   ##
   ## ## The instance number of Tabix
   replicas: "1"


### PR DESCRIPTION
When creating a Sentry installation, tabix got started automatically. This will disable it by default for the following reasons:
1. According to its description this is an interface to clickhouse which is not needed for the installation to be running. 
2. According to the documentation the default value is `false`, but has been committed as `true` when the config has ben originally introduced in https://github.com/liwenhe1993/charts/commit/2bd23144c0af9be0c9922e80fc05b1243be5e062#diff-75686b5e78374f74437276f4f27b17ee827032a0d137c1c637451d7cc64b29c4R286. This PR will ensure that the documented value is correct.