### PR TITLE
Fix podAnnotations

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -26,6 +26,10 @@ spec:
   template:
     metadata:
       name: {{ template "sentry.fullname" . }}-clickhouse-init
+      annotations:
+        {{- if .Values.hooks.clickhouseInit.podAnnotations }}
+{{ toYaml .Values.hooks.clickhouseInit.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -224,10 +224,10 @@ hooks:
   enabled: true
   removeOnSuccess: true
   clickhouseInit:
-    podAnnotations:
+    podAnnotations: {}
   dbCheck:
     env: []
-    podAnnotations: []
+    podAnnotations: {}
     resources:
       limits:
         memory: 64Mi
@@ -236,7 +236,7 @@ hooks:
         memory: 64Mi
   dbInit:
     env: []
-    podAnnotations: []
+    podAnnotations: {}
     resources:
       limits:
         memory: 2048Mi
@@ -246,7 +246,7 @@ hooks:
     sidecars: [ ]
     volumes: [ ]
   snubaInit:
-    podAnnotations: []
+    podAnnotations: {}
     resources:
       limits:
         cpu: 2000m
@@ -461,7 +461,7 @@ clickhouse:
             - ::/0
             profile: default
             quota: default
-          
+
     persistentVolumeClaim:
       enabled: true
       dataPersistentVolume:


### PR DESCRIPTION
This fixes the default values for pod annotations (silly type mismatch) and also includes it for clickhouse-init job.