### PR TITLE
feat: upgrade Sentry version to 21.3.1

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.0.0
-appVersion: 21.3.0
+version: 11.0.1
+appVersion: 21.3.1
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Sentry 21.3.1 fixes this bug which is present in 21.3.0:
  https://github.com/getsentry/sentry/issues/24639