### PR TITLE
Fix dbCheck image can be pulled from custom repository (#358)

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -35,6 +35,12 @@
 {{- .Values.images.symbolicator.tag -}}
 {{- end -}}
 
+{{- define "dbCheck.image" -}}
+{{- default "subfuzion/netcat" .Values.hooks.dbCheck.image.repository -}}
+:
+{{- default "latest" .Values.hooks.dbCheck.image.tag -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -37,13 +37,14 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Never
-      {{- if .Values.images.sentry.imagePullSecrets }}
+      {{- if .Values.hooks.dbCheck.image.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+{{ toYaml .Values.hooks.dbCheck.image.imagePullSecrets | indent 8 }}
       {{- end }}
       containers:
       - name: db-check
-        image: subfuzion/netcat:latest
+        image: {{ template "dbCheck.image" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.hooks.dbCheck.image.pullPolicy }}
         command:
           - /bin/sh
           - -c

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -226,6 +226,11 @@ hooks:
   clickhouseInit:
     podAnnotations: {}
   dbCheck:
+    image:
+      # repository: subfuzion/netcat
+      # tag: latest
+      # pullPolicy: IfNotPresent
+      imagePullSecrets: []
     env: []
     podAnnotations: {}
     resources:


### PR DESCRIPTION
This allows Sentry to be installed with this helm chart in air gapped
environment

Closes #358