### PR TITLE
Fix netcat variable image evaluation

### DIFF
--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
       - name: db-check
-        image: {{ template "dbCheck.image" }}
+        image: {{ template "dbCheck.image" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.hooks.dbCheck.image.pullPolicy }}
         command:
           - /bin/sh


### PR DESCRIPTION
Adding the missing . for allowing top-level scope when evaluating the dbCheck.image variable

Without this the image override defined in values.yaml doesn't work properly

https://github.com/sentry-kubernetes/charts/blob/05698720bc8a5eedcbaa847f766ac6a669360ec5/sentry/values.yaml#L241