### PR TITLE
Upgrade Sentry to 21.4.1

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.2.0
-appVersion: 21.4.0
+version: 11.2.1
+appVersion: 21.4.1
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
The sentry team released v21.4.0 with a significant bug, which was fixed in 21.4.1.
https://github.com/getsentry/sentry/issues/25223