### PR TITLE
Possibility to specify security context

### DIFF
--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -52,6 +52,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.images.sentry.web.securityContext }}
+     securityContext:
+{{ toYaml .Values.sentry.web.securityContext | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-web
         image: "{{ template "sentry.image" . }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -63,6 +63,7 @@ sentry:
     resources: {}
     affinity: {}
     nodeSelector: {}
+    securityContext: {}
     # tolerations: []
     # podLabels: []
     # Mount and use custom CA


### PR DESCRIPTION
The PR makes it possible to define the securityContext in sentryWeb if necessary. Some Kubernetes instances may have special security requirements that this PR should address.

Cheers