### PR TITLE
fix snuba init scripts with externalClickhouse non-default databasename

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -6,7 +6,7 @@
 {{- $clickhouseClusterName := include "sentry.clickhouse.cluster.name" . -}}
 {{- $tables := "discover errors groupassignee groupedmessage outcomes_hourly migrations outcomes_mv_hourly outcomes_raw sentry sessions_hourly sessions_hourly_mv sessions_raw transactions" -}}
 {{- $dropQuery := "DROP TABLE IF EXISTS ${tbl}_dist" -}}
-{{- $createQuery := $clickhouseClusterName | printf "CREATE TABLE ${tbl}_dist AS ${tbl}_local ENGINE = Distributed('%s', default, ${tbl}_local, rand())" -}}
+{{- $createQuery := printf "CREATE TABLE ${tbl}_dist AS ${tbl}_local ENGINE = Distributed('%s', '%s', ${tbl}_local, rand())" $clickhouseClusterName $clickhouseDB -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -71,6 +71,9 @@ spec:
 {{- if .Values.snuba.dbInitJob.env }}
 {{ toYaml .Values.snuba.dbInitJob.env | indent 8 }}
 {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ template "sentry.fullname" . }}-snuba-env
         volumeMounts:
         - mountPath: /etc/snuba
           name: config

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -71,6 +71,9 @@ spec:
 {{- if .Values.snuba.migrateJob.env }}
 {{ toYaml .Values.snuba.migrateJob.env | indent 8 }}
 {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ template "sentry.fullname" . }}-snuba-env
         volumeMounts:
         - mountPath: /etc/snuba
           name: config


### PR DESCRIPTION
Hello!

it's a small fix if externalClikchouse database name is not "default"
without it I had issue
`snuba.clickhouse.errors.ClickhouseError: [60] DB::Exception: Table default.sentry_local doesn't exist. Stack trace:`

And also  it's a fix for hooks job if externalClickhouse has an authorization
Is a continuation for https://github.com/sentry-kubernetes/charts/pull/334