### PR TITLE
Add http port parameter for external clickhouse

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -265,6 +265,17 @@ Set ClickHouse port
 {{- end -}}
 
 {{/*
+Set ClickHouse HTTP port
+*/}}
+{{- define "sentry.clickhouse.http_port" -}}
+{{- if .Values.clickhouse.enabled -}}
+{{- default 8123 .Values.clickhouse.clickhouse.http_port }}
+{{- else -}}
+{{ required "A valid .Values.externalClickhouse.httpPort is required" .Values.externalClickhouse.httpPort }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set ClickHouse Database
 */}}
 {{- define "sentry.clickhouse.database" -}}
@@ -288,7 +299,7 @@ Set ClickHouse User
 {{- define "sentry.clickhouse.username" -}}
 {{- if .Values.clickhouse.enabled -}}
   {{- if .Values.clickhouse.clickhouse.configmap.users.enabled -}}
-{{ (index .Values.clickhouse.clickhouse.configmap.users.user 0).name }} 
+{{ (index .Values.clickhouse.clickhouse.configmap.users.user 0).name }}
   {{- else -}}
 default
   {{- end -}}
@@ -303,7 +314,7 @@ Set ClickHouse Password
 {{- define "sentry.clickhouse.password" -}}
 {{- if .Values.clickhouse.enabled -}}
   {{- if .Values.clickhouse.clickhouse.configmap.users.enabled -}}
-{{ (index .Values.clickhouse.clickhouse.configmap.users.user 0).config.password }} 
+{{ (index .Values.clickhouse.clickhouse.configmap.users.user 0).config.password }}
   {{- else -}}
   {{- end -}}
 {{- else -}}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -21,6 +21,7 @@ data:
     # Clickhouse Options
     CLUSTERS[0]["host"] = env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }})
     CLUSTERS[0]["port"] = int({{ include "sentry.clickhouse.port" . }})
+    CLUSTERS[0]["http_port"] = int({{ include "sentry.clickhouse.http_port" . }})
     CLUSTERS[0]["database"] = env("CLICKHOUSE_DATABASE", "default")
     CLUSTERS[0]["user"] = env("CLICKHOUSE_USER", "default")
     CLUSTERS[0]["password"] = env("CLICKHOUSE_PASSWORD", "")

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -507,6 +507,7 @@ externalClickhouse:
   ##
   host: "clickhouse"
   tcpPort: 9000
+  httpPort: 8123
   username: default
   password: ""
   database: default


### PR DESCRIPTION
Without setting `CLUSTERS[0]["http_port"]` the default 8123 is used, leading to a `Connection refused` error when a non-default port is used by clickhouse server.