### PR TITLE
upgrade sentry to 21.5.1

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.2.2
-appVersion: 21.4.1
+version: 11.3.0
+appVersion: 21.5.1
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -365,3 +365,13 @@ Set RabbitMQ host
 {{ .Values.rabbitmq.host }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common Snuba environment variables
+*/}}
+{{- define "sentry.snuba.env" -}}
+- name: SNUBA_SETTINGS
+  value: /etc/snuba/settings.py
+- name: DEFAULT_BROKERS
+  value: {{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) | quote }}
+{{- end -}}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -36,7 +36,4 @@ data:
     {{- end }}
     REDIS_DB = int(env("REDIS_DB", 1))
 
-    # Processor/Writer Options
-    DEFAULT_BROKERS = [{{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) | quote }}]
-
 {{ .Values.config.snubaSettingsPy | indent 4 }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -60,8 +60,7 @@ spec:
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.api.env }}
 {{ toYaml .Values.snuba.api.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -68,8 +68,7 @@ spec:
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.consumer.env }}
 {{ toYaml .Values.snuba.consumer.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -68,8 +68,7 @@ spec:
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.outcomesConsumer.env }}
 {{ toYaml .Values.snuba.outcomesConsumer.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -68,8 +68,7 @@ spec:
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.replacer.env }}
 {{ toYaml .Values.snuba.replacer.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -68,8 +68,7 @@ spec:
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.sessionsConsumer.env }}
 {{ toYaml .Values.snuba.sessionsConsumer.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -68,8 +68,7 @@ spec:
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.transactionsConsumer.env }}
 {{ toYaml .Values.snuba.transactionsConsumer.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -64,10 +64,9 @@ spec:
         env:
         - name: LOG_LEVEL
           value: debug
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
         - name: CLICKHOUSE_SINGLE_NODE
           value: "true"
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.dbInitJob.env }}
 {{ toYaml .Values.snuba.dbInitJob.env | indent 8 }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -64,10 +64,9 @@ spec:
         env:
         - name: LOG_LEVEL
           value: debug
-        - name: SNUBA_SETTINGS
-          value: /etc/snuba/settings.py
         - name: CLICKHOUSE_SINGLE_NODE
           value: "true"
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.snuba.migrateJob.env }}
 {{ toYaml .Values.snuba.migrateJob.env | indent 8 }}
 {{- end }}


### PR DESCRIPTION
While upgrading to 21.5 I encoutered some problems with `DEFAULT_BROKERS` setting which was not loaded from the `settings.py` in config map.

Inspecting the source code of snuba I discovered that this setting is now loaded from env vars, so I moved it into the env block and de-duplicated all the snuba env var blocks into an helper.