### PR TITLE
Add affinity, nodeSelector and tolerations to values of hooks

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -34,6 +34,18 @@ spec:
         app: sentry
         release: "{{ .Release.Name }}"
     spec:
+      {{- if .Values.hooks.clickhouseInit.affinity }}
+      affinity:
+{{ toYaml .Values.hooks.clickhouseInit.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.clickhouseInit.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hooks.clickhouseInit.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.clickhouseInit.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.clickhouseInit.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.clickhouse.clickhouse.imagePullSecrets }}
       imagePullSecrets:

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -36,6 +36,18 @@ spec:
 {{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hooks.dbCheck.affinity }}
+      affinity:
+{{ toYaml .Values.hooks.dbCheck.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.dbCheck.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hooks.dbCheck.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.dbCheck.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.dbCheck.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.hooks.dbCheck.image.imagePullSecrets }}
       imagePullSecrets:

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -33,6 +33,18 @@ spec:
 {{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hooks.dbInit.affinity }}
+      affinity:
+{{ toYaml .Values.hooks.dbInit.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.dbInit.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hooks.dbInit.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.dbInit.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.dbInit.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.images.sentry.imagePullSecrets }}
       imagePullSecrets:

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -35,6 +35,18 @@ spec:
 {{ toYaml .Values.snuba.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hooks.snubaInit.affinity }}
+      affinity:
+{{ toYaml .Values.hooks.snubaInit.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.snubaInit.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.snubaInit.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.images.snuba.imagePullSecrets }}
       imagePullSecrets:

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -35,6 +35,18 @@ spec:
 {{ toYaml .Values.snuba.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hooks.snubaInit.affinity }}
+      affinity:
+{{ toYaml .Values.hooks.snubaInit.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.snubaInit.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.snubaInit.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.images.snuba.imagePullSecrets }}
       imagePullSecrets:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -246,6 +246,9 @@ hooks:
   removeOnSuccess: true
   clickhouseInit:
     podAnnotations: {}
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
   dbCheck:
     image:
       # repository: subfuzion/netcat
@@ -260,6 +263,9 @@ hooks:
       requests:
         cpu: 100m
         memory: 64Mi
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
   dbInit:
     env: []
     podAnnotations: {}
@@ -271,6 +277,9 @@ hooks:
         memory: 2048Mi
     sidecars: [ ]
     volumes: [ ]
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
   snubaInit:
     podAnnotations: {}
     resources:
@@ -280,6 +289,9 @@ hooks:
       requests:
         cpu: 700m
         memory: 1Gi
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
 
 system:
   ## be sure to include the scheme on the url, for example: "https://sentry.example.com"


### PR DESCRIPTION
Deprecated chart supported `affinity` and `tolerations` in hooks. 

https://github.com/helm/charts/blob/f4f301ae450101b981805bd045451f08c0d74afa/stable/sentry/templates/hooks/db-init.job.yaml#L31-L38

So I added a commonly used selector.