### PR TITLE
Fix snuba metrics collection

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.3.0
+version: 11.3.1
 appVersion: 21.5.1
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -36,4 +36,9 @@ data:
     {{- end }}
     REDIS_DB = int(env("REDIS_DB", 1))
 
+{{- if .Values.metrics.enabled }}
+    DOGSTATSD_HOST = "{{ template "sentry.fullname" . }}-metrics"
+    DOGSTATSD_PORT = 9125
+{{- end }}
+
 {{ .Values.config.snubaSettingsPy | indent 4 }}


### PR DESCRIPTION
Add statsd collector host/port to snuba config if metrics enabled in chart

It defaults to localhost:8125 and produces lots of error messages in shuba components logs (.. dropping packet) if statsd is not available, so lets configure it right if it’s available :)