### PR TITLE
ALB Ingress : Fix annotations parsing error

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.3.1
+version: 11.3.2
 appVersion: 21.5.1
 dependencies:
   - name: redis

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
      {{ $key }}: {{ $value | quote }}
    {{- end }}
    {{- if and (eq .Values.ingress.regexPathStyle "aws-alb") (.Values.ingress.alb.httpRedirect) }}
-   alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
    {{- end }}
 spec:
   rules:


### PR DESCRIPTION
Fix parsing error when you enable alb http redirect and have custom annotations at the same time