### PR TITLE
Support GKE Ingress controller

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -39,7 +39,7 @@ Parameter                          | Description                                
 `user.email` | Admin user email | `admin@sentry.local`
 `user.password` | Admin user password| `aaaa`
 `ingress.enabled` | Enabling Ingress | `false`
-`ingress.regexPathStyle` | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx`, `aws-alb` and `traefik` | `nginx`
+`ingress.regexPathStyle` | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx`, `aws-alb`, `gke` and `traefik` | `nginx`
 `nginx.enabled` | Enabling NGINX | `true`
 `metrics.enabled`| if `true`, enable Prometheus metrics | `false`
 `metrics.image.repository`         | Metrics exporter image repository                                                                          | `prom/statsd-exporter`

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
             backend:
               serviceName: {{ template "sentry.fullname" . }}-nginx
               servicePort: {{ .Values.nginx.service.port }}
-    {{- else if eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb" }}
+    {{- else if or (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
     {{- if .Values.ingress.alb.httpRedirect }}
           - path: "/*"
             backend:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -407,6 +407,7 @@ ingress:
   enabled: false
   # If you are using traefik ingress controller, switch this to 'traefik'
   # if you are using AWS ALB Ingress controller, switch this to 'aws-alb'
+  # if you are using GKE Ingress controller, switch this to 'gke'
   regexPathStyle: nginx
   #If you are using AWS ALB Ingress controller, switch to true if you want activate the http to https redirection.
   alb:


### PR DESCRIPTION
# Context
I'm deploying Sentry to GKE, and I want to use [GKE Ingress Controller](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress).

When I used `nginx` or `traefik` for `ingress.regexPathStyle`, I got the following error.

![image](https://user-images.githubusercontent.com/608755/119985076-272fb080-bffd-11eb-8ead-61d2c8d6270e.png)

Response of `/api/0/assistant/` is following.

```json
{"detail":"CSRF Failed: Referer checking failed - https://sentry.example.com/organizations/pixiv/issues/?project=1&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3Ame_or_none&sort=inbox does not match any trusted origins."}
```

This problem was the same as https://forum.sentry.io/t/event-submission-rejected-by-csrf/10482

# Why?
https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#multiple_backend_services says following.

```
The only supported wildcard character for the path field of an Ingress is the * character. The * character must follow a forward slash (/) and must be the last character in the pattern. For example, /*, /foo/*, and /foo/bar/* are valid patterns, but *, /foo/bar*, and /foo/*/bar are not.
```

Below is ingress error on GKE console.

![image](https://user-images.githubusercontent.com/608755/119986706-26981980-bfff-11eb-81ec-d83d7f318d0a.png)

```
Error syncing to GCP: error running load balancer syncing routine: loadbalancer 3w55v5a5-default-sentry-tfvslgqr does not exist: UpdateURLMap: googleapi: Error 400: Invalid value for field 'resource': '{ "name": "k8s2-um-3w55v5a5-default-sentry-tfvslgqr", "hostRule": [{ "host": ["prestage.errortr...'. Invalid path pattern, invalid
````

# Workaround
After some trials, I found that it works with the same settings as `aws-alb`

Below is my setting that actually worked with GKE Ingress Controller.

```yaml
spec:
  rules:
  - host: sentry.example.com
    http:
      paths:
      - backend:
          serviceName: sentry-web
          servicePort: 9000
        path: /api/0/*
      - backend:
          serviceName: sentry-relay
          servicePort: 3000
        path: /api/*
      - backend:
          serviceName: sentry-web
          servicePort: 9000
        path: /*
```

So I made `ingress.regexPathStyle` accept `gke` as well.