### PR TITLE
fix: Make the snuba api liveness and readiness timeouts configurable

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.3.2
+version: 11.3.3
 appVersion: 21.5.1
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -80,7 +80,7 @@ spec:
           initialDelaySeconds: {{ .Values.snuba.api.probeInitialDelaySeconds }}
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: {{ .Values.snuba.api.liveness.timeoutSeconds }}
         readinessProbe:
           failureThreshold: 10
           httpGet:
@@ -90,7 +90,7 @@ spec:
           initialDelaySeconds: {{ .Values.snuba.api.probeInitialDelaySeconds }}
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: {{ .Values.snuba.api.readiness.timeoutSeconds }}
         resources:
 {{ toYaml .Values.snuba.api.resources | indent 12 }}
 {{- if .Values.snuba.api.sidecars }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -158,6 +158,10 @@ snuba:
     replicas: 1
     env: []
     probeInitialDelaySeconds: 10
+    liveness:
+      timeoutSeconds: 2
+    readiness:
+      timeoutSeconds: 2
     resources: {}
     affinity: {}
     nodeSelector: {}


### PR DESCRIPTION
Fixes #408 by making the liveness and readiness timeouts for snuba-api configurable.

Tested it out via templating and it went smoothly, but let me know if this option add is unwarranted!