### PR TITLE
#410 - Sanitise redis password with urlquery function

### DIFF
--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -30,7 +30,7 @@ data:
           value: 50000000  # 50MB or bust
 
       {{- if $redisPass }}
-      redis: "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
+      redis: "redis://:{{ $redisPass | urlquery }}@{{ $redisHost }}:{{ $redisPort }}"
       {{- else }}
       redis: "redis://{{ $redisHost }}:{{ $redisPort }}"
       {{- end }}

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -169,7 +169,7 @@ data:
     {{- if or (.Values.rabbitmq.enabled) (.Values.rabbitmq.host) }}
     BROKER_URL = os.environ.get("BROKER_URL", "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ template "sentry.rabbitmq.host" . }}:5672//")
     {{- else if $redisPass }}
-    BROKER_URL = os.environ.get("BROKER_URL", "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/0")
+    BROKER_URL = os.environ.get("BROKER_URL", "redis://:{{ $redisPass | urlquery }}@{{ $redisHost }}:{{ $redisPort }}/0")
     {{- else }}
     BROKER_URL = os.environ.get("BROKER_URL", "redis://{{ $redisHost }}:{{ $redisPort }}/0")
     {{- end }}


### PR DESCRIPTION
This PR addresses issue #410 - sanitising the supplied redis password with the Helm `urlquery` function to accommodate characters such as `/`. It's been tested locally and on our staging cluster with success. We can connect to our external redis service using a complex password and we've seen no evidence of other errors in the logs of the various service components.