### PR TITLE
Add maxBatchSize to snuba.replacer and snuba.outcomesConsumer

### DIFF
--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -64,7 +64,7 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "consumer", "--storage", "outcomes_raw", "--auto-offset-reset=latest", "--max-batch-size",  "3"]
+        command: ["snuba", "consumer", "--storage", "outcomes_raw", "--auto-offset-reset=latest", "--max-batch-size", "{{ default "3" .Values.snuba.outcomesConsumer.maxBatchSize }}"]
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -64,7 +64,7 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "replacer", "--storage", "errors", "--auto-offset-reset=latest", "--max-batch-size",  "3"]
+        command: ["snuba", "replacer", "--storage", "errors", "--auto-offset-reset=latest", "--max-batch-size", "{{ default "3" .Values.snuba.replacer.maxBatchSize }}"]
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -196,6 +196,7 @@ snuba:
     securityContext: {}
     # tolerations: []
     # podLabels: []
+    maxBatchSize: "3"
 
   replacer:
     replicas: 1
@@ -206,6 +207,7 @@ snuba:
     securityContext: {}
     # tolerations: []
     # podLabels: []
+    maxBatchSize: "3"
 
   sessionsConsumer:
     replicas: 1


### PR DESCRIPTION
I run Sentry in my company. 

Kafka consumer is delayed because our Sentry is receiving a lot of errors...

![image](https://user-images.githubusercontent.com/608755/121669745-98845e80-cae7-11eb-9b86-ef2cd80a423c.png)

As the Consumer continues to delay, we will also get an error like https://github.com/getsentry/onpremise/issues/478 on `sentry-snuba-outcomes-consumer`.

In my research, it was improved by increasing the `--max-batch-size` of` sentry-snuba-outcomes-consumer`.

![image](https://user-images.githubusercontent.com/608755/121670417-5dcef600-cae8-11eb-95ff-2e66b55cd9d5.png)

So I want to be able to pass any value to  `--max-batch-size`