### PR TITLE
Remove extra quotation mark in ConfigMap

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.4.0
+version: 11.4.1
 appVersion: 21.6.1
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -34,23 +34,23 @@ data:
     ##########
     {{- if .Values.github.appId }}
     github-app.id: {{ .Values.github.appId }}
-    {{ end }}
+    {{- end }}
     {{- if .Values.github.appName }}
     github-app.name: {{ .Values.github.appName | quote }}
-    {{ end }}
+    {{- end }}
     {{- if .Values.github.privateKey }}
     github-app.private-key: |-
-      {{ .Values.github.privateKey | nindent 8 }}
-    {{ end }}
+{{ .Values.github.privateKey | indent 8 }}
+    {{- end }}
     {{- if .Values.github.webhookSecret }}
     github-app.webhook-secret: {{ .Values.github.webhookSecret | quote }}
-    {{ end }}
+    {{- end }}
     {{- if .Values.github.clientId }}
     github-app.client-id: {{ .Values.github.clientId | quote }}
-    {{ end }}
+    {{- end }}
     {{- if .Values.github.clientSecret }}
     github-app.client-secret: {{ .Values.github.clientSecret | quote }}
-    {{ end }}
+    {{- end }}
 
     ##########
     # Google #

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -40,7 +40,7 @@ data:
     {{ end }}
     {{- if .Values.github.privateKey }}
     github-app.private-key: |-
-      {{ .Values.github.privateKey | nindent 8 }}"
+      {{ .Values.github.privateKey | nindent 8 }}
     {{ end }}
     {{- if .Values.github.webhookSecret }}
     github-app.webhook-secret: {{ .Values.github.webhookSecret | quote }}


### PR DESCRIPTION
Due to this quotation mark, GitHub integration does not work, Sentry fails with "Could not deserialize key data" error