### PR TITLE
upgrade sentry to 21.6.1

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 11.3.3
-appVersion: 21.5.1
+version: 11.4.0
+appVersion: 21.6.1
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
I've upgraded the appVersion only, as it seems that no other change is needed.