### PR TITLE
Add maxBatchSize to some deployments

### DIFF
--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -76,6 +76,10 @@ spec:
           - "-c"
           - "{{ .Values.sentry.ingestConsumer.concurrency }}"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
+          {{- end }}
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -64,7 +64,18 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "consumer", "--storage", "errors", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
+        command:
+          - "snuba"
+          - "consumer"
+          - "--storage"
+          - "errors"
+          - "--auto-offset-reset=latest"
+          - "--max-batch-time-ms"
+          - "750"
+          {{- if .Values.snuba.consumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.snuba.consumer.maxBatchSize }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -64,7 +64,18 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "consumer", "--storage", "sessions_raw", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
+        command:
+          - "snuba"
+          - "consumer"
+          - "--storage"
+          - "sessions_raw"
+          - "--auto-offset-reset=latest"
+          - "--max-batch-time-ms"
+          - "750"
+          {{- if .Values.snuba.sessionsConsumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.snuba.sessionsConsumer.maxBatchSize }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -64,7 +64,20 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "consumer", "--storage", "transactions", "--consumer-group", "transactions_group", "--auto-offset-reset=latest", "--max-batch-time-ms", "750"]
+        command:
+          - "snuba"
+          - "consumer"
+          - "--storage"
+          - "transactions"
+          - "--consumer-group"
+          - "transactions_group"
+          - "--auto-offset-reset=latest"
+          - "--max-batch-time-ms"
+          - "750"
+          {{- if .Values.snuba.transactionsConsumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.snuba.transactionsConsumer.maxBatchSize }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -114,6 +114,7 @@ sentry:
     securityContext: {}
     # tolerations: []
     # podLabels: []
+    # maxBatchSize: ""
 
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
@@ -186,6 +187,7 @@ snuba:
     securityContext: {}
     # tolerations: []
     # podLabels: []
+    # maxBatchSize: ""
 
   outcomesConsumer:
     replicas: 1
@@ -216,6 +218,7 @@ snuba:
     securityContext: {}
     # tolerations: []
     # podLabels: []
+    # maxBatchSize: ""
 
   transactionsConsumer:
     replicas: 1
@@ -226,6 +229,7 @@ snuba:
     securityContext: {}
     # tolerations: []
     # podLabels: []
+    # maxBatchSize: ""
 
   dbInitJob:
     env: []


### PR DESCRIPTION
This patch is similar to #412, but I added `maxBatchSize` to other than`snuba.replacer` and `snuba.outcomesConsumer` too.