### PR TITLE
Fix #419 using correct block indicator

### DIFF
--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -60,7 +60,7 @@ spec:
         command:
           - /bin/bash
           - -ec
-          - >-
+          - |-
             check_readiness() {
               local host="$1"
               local port="$2"


### PR DESCRIPTION
using the literal `|` block indicator instead of the chomping one, to preserve the bash script correctly.