### PR TITLE
Add available args to snuba consumers

### DIFF
--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -76,6 +76,30 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.consumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.snuba.consumer.processes }}
+          - "--processes"
+          - "{{ .Values.snuba.consumer.processes }}"
+          {{- end }}
+          {{- if .Values.snuba.consumer.inputBlockSize }}
+          - "--input-block-size"
+          - "{{ .Values.snuba.consumer.inputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.consumer.outputBlockSize }}
+          - "--output-block-size"
+          - "{{ .Values.snuba.consumer.outputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.consumer.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.snuba.consumer.maxBatchTimeMs }}"
+          {{- end }}
+          {{- if .Values.snuba.consumer.queuedMaxMessagesKbytes }}
+          - "--queued-max-messages-kbytes"
+          - "{{ .Values.snuba.consumer.queuedMaxMessagesKbytes }}"
+          {{- end }}
+          {{- if .Values.snuba.consumer.queuedMinMessages }}
+          - "--queued-min-messages"
+          - "{{ .Values.snuba.consumer.queuedMinMessages }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -64,7 +64,38 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "consumer", "--storage", "outcomes_raw", "--auto-offset-reset=latest", "--max-batch-size", "{{ default "3" .Values.snuba.outcomesConsumer.maxBatchSize }}"]
+        command:
+          - "snuba"
+          - "consumer"
+          - "--storage"
+          - "outcomes_raw"
+          - "--auto-offset-reset=latest"
+          - "--max-batch-size"
+          - "{{ default "3" .Values.snuba.outcomesConsumer.maxBatchSize }}"
+          {{- if .Values.snuba.outcomesConsumer.processes }}
+          - "--processes"
+          - "{{ .Values.snuba.outcomesConsumer.processes }}"
+          {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.inputBlockSize }}
+          - "--input-block-size"
+          - "{{ .Values.snuba.outcomesConsumer.inputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.outputBlockSize }}
+          - "--output-block-size"
+          - "{{ .Values.snuba.outcomesConsumer.outputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.snuba.outcomesConsumer.maxBatchTimeMs }}"
+          {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.queuedMaxMessagesKbytes }}
+          - "--queued-max-messages-kbytes"
+          - "{{ .Values.snuba.outcomesConsumer.queuedMaxMessagesKbytes }}"
+          {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.queuedMinMessages }}
+          - "--queued-min-messages"
+          - "{{ .Values.snuba.outcomesConsumer.queuedMinMessages }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -76,6 +76,30 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.sessionsConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.processes }}
+          - "--processes"
+          - "{{ .Values.snuba.sessionsConsumer.processes }}"
+          {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.inputBlockSize }}
+          - "--input-block-size"
+          - "{{ .Values.snuba.sessionsConsumer.inputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.outputBlockSize }}
+          - "--output-block-size"
+          - "{{ .Values.snuba.sessionsConsumer.outputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.snuba.sessionsConsumer.maxBatchTimeMs }}"
+          {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.queuedMaxMessagesKbytes }}
+          - "--queued-max-messages-kbytes"
+          - "{{ .Values.snuba.sessionsConsumer.queuedMaxMessagesKbytes }}"
+          {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.queuedMinMessages }}
+          - "--queued-min-messages"
+          - "{{ .Values.snuba.sessionsConsumer.queuedMinMessages }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -78,6 +78,30 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.transactionsConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.processes }}
+          - "--processes"
+          - "{{ .Values.snuba.transactionsConsumer.processes }}"
+          {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.inputBlockSize }}
+          - "--input-block-size"
+          - "{{ .Values.snuba.transactionsConsumer.inputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.outputBlockSize }}
+          - "--output-block-size"
+          - "{{ .Values.snuba.transactionsConsumer.outputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.snuba.transactionsConsumer.maxBatchTimeMs }}"
+          {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.queuedMaxMessagesKbytes }}
+          - "--queued-max-messages-kbytes"
+          - "{{ .Values.snuba.transactionsConsumer.queuedMaxMessagesKbytes }}"
+          {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.queuedMinMessages }}
+          - "--queued-min-messages"
+          - "{{ .Values.snuba.transactionsConsumer.queuedMinMessages }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -188,6 +188,12 @@ snuba:
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    # maxBatchTimeMs: ""
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
 
   outcomesConsumer:
     replicas: 1
@@ -199,6 +205,12 @@ snuba:
     # tolerations: []
     # podLabels: []
     maxBatchSize: "3"
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    # maxBatchTimeMs: ""
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
 
   replacer:
     replicas: 1
@@ -221,6 +233,12 @@ snuba:
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    # maxBatchTimeMs: ""
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
 
   transactionsConsumer:
     replicas: 1
@@ -232,6 +250,12 @@ snuba:
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    # maxBatchTimeMs: ""
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
 
   dbInitJob:
     env: []


### PR DESCRIPTION
I made it possible to pass `--processes`, `--input-block-size`, `--output-block-size`, `--max-batch-time-ms`, `-queued-max-messages-kbytes` and `--queued-min-messages` to snuba consumers

All available arguments are follwoings.

```
$ docker run --rm -it getsentry/snuba:21.6.1 snuba consumer --help
Usage: snuba consumer [OPTIONS]

Options:
  --raw-events-topic TEXT         Topic to consume raw events from.
  --replacements-topic TEXT       Topic to produce replacement messages info.
  --commit-log-topic TEXT         Topic for committed offsets to be written
                                  to, triggering post-processing task(s)

  --control-topic TEXT            Topic used to control the snapshot
  --consumer-group TEXT           Consumer group use for consuming the raw
                                  events topic.

  --bootstrap-server TEXT         Kafka bootstrap server to use.
  --storage [groupedmessages|groupassignees|errors|events|outcomes_raw|querylog|sessions_raw|transactions|spans]
                                  The storage to target
  --max-batch-size INTEGER        Max number of messages to batch in memory
                                  before writing to Kafka.

  --max-batch-time-ms INTEGER     Max length of time to buffer messages in
                                  memory before writing to Kafka.

  --auto-offset-reset [error|earliest|latest]
                                  Kafka consumer auto offset reset.
  --queued-max-messages-kbytes INTEGER
                                  Maximum number of kilobytes per
                                  topic+partition in the local consumer queue.

  --queued-min-messages INTEGER   Minimum number of messages per
                                  topic+partition librdkafka tries to maintain
                                  in the local consumer queue.

  --log-level TEXT                Logging level to use.
  --stateful-consumer BOOLEAN     Runs a stateful consumer (that manages
                                  snapshots) instead of a basic one.

  --processes INTEGER
  --input-block-size INTEGER
  --output-block-size INTEGER
  --profile-path DIRECTORY
  --help                          Show this message and exit.
```