### PR TITLE
Fixed. `Error: no such option: -c` when `sentry.ingestConsumer.concurrency` is passed

### DIFF
--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -73,7 +73,7 @@ spec:
           - "ingest-consumer"
           - "--all-consumer-types"
           {{- if .Values.sentry.ingestConsumer.concurrency }}
-          - "-c"
+          - "--concurrency"
           - "{{ .Values.sentry.ingestConsumer.concurrency }}"
           {{- end }}
           {{- if .Values.sentry.ingestConsumer.maxBatchSize }}


### PR DESCRIPTION
When I set any value in `sentry.ingestConsumer.concurrency`, the following error will occur.

```
E 2021-06-24T04:09:37.862710536Z Error: no such option: -c 
E 2021-06-24T04:09:49.563666344Z Usage: sentry run ingest-consumer [OPTIONS] 
E 2021-06-24T04:09:49.563731229Z Try 'sentry run ingest-consumer --help' for help.
```

Because `sentry run ingest-consumer` supports only `--concurrency` arg. 

https://github.com/getsentry/sentry/blob/21.6.1/src/sentry/runner/commands/run.py#L468-L474

So I fixed.