### PR TITLE
Add available arguments to snuba-replacer

### DIFF
--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -64,7 +64,26 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
-        command: ["snuba", "replacer", "--storage", "errors", "--auto-offset-reset=latest", "--max-batch-size", "{{ default "3" .Values.snuba.replacer.maxBatchSize }}"]
+        command:
+          - "snuba"
+          - "replacer"
+          - "--storage"
+          - "errors"
+          - "--auto-offset-reset=latest"
+          - "--max-batch-size"
+          - "{{ default "3" .Values.snuba.replacer.maxBatchSize }}"
+          {{- if .Values.snuba.replacer.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.snuba.replacer.maxBatchTimeMs }}"
+          {{- end }}
+          {{- if .Values.snuba.replacer.queuedMaxMessagesKbytes }}
+          - "--queued-max-messages-kbytes"
+          - "{{ .Values.snuba.replacer.queuedMaxMessagesKbytes }}"
+          {{- end }}
+          {{- if .Values.snuba.replacer.queuedMinMessages }}
+          - "--queued-min-messages"
+          - "{{ .Values.snuba.replacer.queuedMinMessages }}"
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -222,6 +222,9 @@ snuba:
     # tolerations: []
     # podLabels: []
     maxBatchSize: "3"
+    # maxBatchTimeMs: ""
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
 
   sessionsConsumer:
     replicas: 1


### PR DESCRIPTION
I made it possible to pass `--max-batch-time-ms`, `--queued-max-messages-kbytes` and `--queued-min-messages` to snuba replacer

All available arguments are followings.

```bash
docker run --rm -it getsentry/snuba:21.6.1 snuba replacer --help
(snip)
Usage: snuba replacer [OPTIONS]

Options:
  --replacements-topic TEXT       Topic to consume replacement messages from.
  --consumer-group TEXT           Consumer group use for consuming the
                                  replacements topic.

  --bootstrap-server TEXT         Kafka bootstrap server to use.
  --storage [events|errors]       The storage to consume/run replacements for
                                  (currently only events supported)

  --max-batch-size INTEGER        Max number of messages to batch in memory
                                  before writing to Kafka.

  --max-batch-time-ms INTEGER     Max length of time to buffer messages in
                                  memory before writing to Kafka.

  --auto-offset-reset [error|earliest|latest]
                                  Kafka consumer auto offset reset.
  --queued-max-messages-kbytes INTEGER
                                  Maximum number of kilobytes per
                                  topic+partition in the local consumer queue.

  --queued-min-messages INTEGER   Minimum number of messages per
                                  topic+partition librdkafka tries to maintain
                                  in the local consumer queue.

  --log-level TEXT                Logging level to use.
  --help                          Show this message and exit.
```