### PR TITLE
Add probe arguments to sentry-web and sentry-relay

### DIFF
--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -99,25 +99,25 @@ spec:
             subPath: config.yml
             readOnly: true
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: {{ .Values.relay.probeFailureThreshold }}
           httpGet:
             path: /api/relay/healthcheck/ready/
             port: {{ template "relay.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          periodSeconds: {{ .Values.relay.probePeriodSeconds }}
+          successThreshold: {{ .Values.relay.probeSuccessThreshold }}
+          timeoutSeconds: {{ .Values.relay.probeTimeoutSeconds }}
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: {{ .Values.relay.probeFailureThreshold }}
           httpGet:
             path: /api/relay/healthcheck/ready/
             port: {{ template "relay.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          periodSeconds: {{ .Values.relay.probePeriodSeconds }}
+          successThreshold: {{ .Values.relay.probeSuccessThreshold }}
+          timeoutSeconds: {{ .Values.relay.probeTimeoutSeconds }}
         resources:
 {{ toYaml .Values.relay.resources | indent 12 }}
 {{- if .Values.relay.sidecars }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -99,25 +99,25 @@ spec:
           mountPath: /etc/pki/ca-trust/custom
         {{ end }}
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: {{ .Values.sentry.web.probeFailureThreshold }}
           httpGet:
             path: /_health/
             port: {{ template "sentry.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.sentry.web.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          periodSeconds: {{ .Values.sentry.web.probePeriodSeconds }}
+          successThreshold: {{ .Values.sentry.web.probeSuccessThreshold }}
+          timeoutSeconds: {{ .Values.sentry.web.probeTimeoutSeconds }}
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: {{ .Values.sentry.web.probeFailureThreshold }}
           httpGet:
             path: /_health/
             port: {{ template "sentry.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.sentry.web.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          periodSeconds: {{ .Values.sentry.web.probePeriodSeconds }}
+          successThreshold: {{ .Values.sentry.web.probeSuccessThreshold }}
+          timeoutSeconds: {{ .Values.sentry.web.probeTimeoutSeconds }}
         resources:
 {{ toYaml .Values.sentry.web.resources | indent 12 }}
 {{- if .Values.sentry.web.sidecars }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -37,7 +37,11 @@ relay:
   replicas: 1
   mode: managed
   env: []
+  probeFailureThreshold: 5
   probeInitialDelaySeconds: 10
+  probePeriodSeconds: 10
+  probeSuccessThreshold: 1
+  probeTimeoutSeconds: 2
   resources: {}
   affinity: {}
   nodeSelector: {}
@@ -60,7 +64,11 @@ sentry:
     strategyType: RollingUpdate
     replicas: 1
     env: []
+    probeFailureThreshold: 5
     probeInitialDelaySeconds: 10
+    probePeriodSeconds: 10
+    probeSuccessThreshold: 1
+    probeTimeoutSeconds: 2
     resources: {}
     affinity: {}
     nodeSelector: {}


### PR DESCRIPTION
Now, only `initialDelaySeconds` can be set in `sentry-web` and `sentry-relay` Probes.

* https://github.com/sentry-kubernetes/charts/blob/11.4.0/sentry/templates/deployment-sentry-web.yaml#L101-L120
* https://github.com/sentry-kubernetes/charts/blob/11.4.0/sentry/templates/deployment-relay.yaml#L101-L120

So I added other parameters because I want to be able to set other parameters freely.