### PR TITLE
Add volumes settings to snuba and ingest consumers

### DIFF
--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -109,6 +109,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.ingestConsumer.volumeMounts }}
+{{ toYaml .Values.sentry.ingestConsumer.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumer.resources | indent 12 }}
 {{- if .Values.sentry.ingestConsumer.sidecars }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -114,9 +114,15 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.consumer.volumeMounts }}
+{{ toYaml .Values.snuba.consumer.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.consumer.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.consumer.volumes }}
+{{ toYaml .Values.snuba.consumer.volumes | indent 8 }}
+{{- end }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -110,9 +110,15 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.outcomesConsumer.volumeMounts }}
+{{ toYaml .Values.snuba.outcomesConsumer.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.outcomesConsumer.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.outcomesConsumer.volumes }}
+{{ toYaml .Values.snuba.outcomesConsumer.volumes | indent 8 }}
+{{- end }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -114,9 +114,15 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.sessionsConsumer.volumeMounts }}
+{{ toYaml .Values.snuba.sessionsConsumer.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.sessionsConsumer.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.sessionsConsumer.volumes }}
+{{ toYaml .Values.snuba.sessionsConsumer.volumes | indent 8 }}
+{{- end }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -116,9 +116,15 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.transactionsConsumer.volumeMounts }}
+{{ toYaml .Values.snuba.transactionsConsumer.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.transactionsConsumer.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.transactionsConsumer.volumes }}
+{{ toYaml .Values.snuba.transactionsConsumer.volumes | indent 8 }}
+{{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -125,6 +125,11 @@ sentry:
       targetCPUUtilizationPercentage: 50
     sidecars: [ ]
     volumes: [ ]
+
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+
   cron:
     replicas: 1
     env: []
@@ -195,6 +200,14 @@ snuba:
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
 
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # volumes:
+    #   - name: dshm
+    #     emptyDir:
+    #       medium: Memory
+
   outcomesConsumer:
     replicas: 1
     env: []
@@ -211,6 +224,14 @@ snuba:
     # maxBatchTimeMs: ""
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # volumes:
+    #   - name: dshm
+    #     emptyDir:
+    #       medium: Memory
 
   replacer:
     replicas: 1
@@ -240,6 +261,14 @@ snuba:
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
 
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # volumes:
+    #   - name: dshm
+    #     emptyDir:
+    #       medium: Memory
+
   transactionsConsumer:
     replicas: 1
     env: []
@@ -256,6 +285,14 @@ snuba:
     # maxBatchTimeMs: ""
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # volumes:
+    #   - name: dshm
+    #     emptyDir:
+    #       medium: Memory
 
   dbInitJob:
     env: []


### PR DESCRIPTION
I added volumes settings ( `volumes` and `volumeMounts` ) to snuba and ingest consumers

# Context
Consumers couldn't be to start with `No space left on device` depending on the settings.

```
2021-07-01 20:51:45.974 JSTTraceback (most recent call last): 
File "/usr/local/bin/snuba", line 33, in <module> sys.exit(load_entry_point('snuba', 'console_scripts', 'snuba')()) 
File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__ return self.main(*args, **kwargs) 
File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main rv = self.invoke(ctx) 
File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke return _process_result(sub_ctx.command.invoke(sub_ctx)) 
File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke return ctx.invoke(self.callback, **ctx.params) 
File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke return callback(*args, **kwargs) 
File "/usr/src/snuba/snuba/cli/consumer.py", line 172, in consumer consumer.run() 
File "/usr/src/snuba/arroyo/processing/processor.py", line 108, in run self._run_once() 
File "/usr/src/snuba/arroyo/processing/processor.py", line 138, in _run_once self.__message = self.__consumer.poll(timeout=1.0) 
File "/usr/src/snuba/snuba/utils/streams/kafka_consumer_with_commit_log.py", line 28, in poll return super().poll(timeout) 
File "/usr/src/snuba/arroyo/backends/kafka/consumer.py", line 374, in poll message: Optional[ConfluentMessage] = self.__consumer.poll( 
File "/usr/src/snuba/arroyo/backends/kafka/consumer.py", line 285, in assignment_callback on_assign(offsets) 
File "/usr/src/snuba/arroyo/processing/processor.py", line 62, in on_partitions_assigned self.__processing_strategy = self.__processor_factory.create(self.__commit) 
File "/usr/src/snuba/arroyo/processing/strategies/streaming/factory.py", line 99, in create strategy = ParallelTransformStep( 
File "/usr/src/snuba/arroyo/processing/strategies/streaming/transform.py", line 288, in __init__ self.__pool = Pool( 
File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 191, in __init__ self._setup_queues() 
File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 343, in _setup_queues self._inqueue = self._ctx.SimpleQueue() 
File "/usr/local/lib/python3.8/multiprocessing/context.py", line 113, in SimpleQueue return SimpleQueue(ctx=self.get_context()) 
File "/usr/local/lib/python3.8/multiprocessing/queues.py", line 336, in __init__ self._rlock = ctx.Lock() 
File "/usr/local/lib/python3.8/multiprocessing/context.py", line 68, in Lock return Lock(ctx=self.get_context()) 
File "/usr/local/lib/python3.8/multiprocessing/synchronize.py", line 162, in __init__ SemLock.__init__(self, SEMAPHORE, 1, 1, ctx=ctx) 
File "/usr/local/lib/python3.8/multiprocessing/synchronize.py", line 57, in __init__ sl = self._semlock = _multiprocessing.SemLock( OSError: [Errno 28] No space left on device
```

# Cause
It was because [multiprocessing](https://docs.python.org/3/library/multiprocessing.html) used up `/dev/shm`

https://stackoverflow.com/questions/43573500/no-space-left-while-using-multiprocessing-array-in-shared-memory

Actually `/dev/shm` was only 64MB.

```bash
root@sentry-snuba-outcomes-consumer-6f8cfc6cfb-v4r7v:/usr/src/snuba# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         500G  4.2G  496G   1% /
tmpfs            64M     0   64M   0% /dev
tmpfs            40G     0   40G   0% /sys/fs/cgroup
/dev/sda1       500G  4.2G  496G   1% /etc/snuba
shm              64M  2.7M   62M   5% /dev/shm
tmpfs            40G   12K   40G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs            40G     0   40G   0% /proc/acpi
tmpfs            40G     0   40G   0% /proc/scsi
tmpfs            40G     0   40G   0% /sys/firmware

root@sentry-snuba-outcomes-consumer-6f8cfc6cfb-v4r7v:/usr/src/snuba# df -hi
Filesystem     Inodes IUsed IFree IUse% Mounted on
overlay           32M  128K   32M    1% /
tmpfs            9.9M    17  9.9M    1% /dev
tmpfs            9.9M    17  9.9M    1% /sys/fs/cgroup
/dev/sda1         32M  128K   32M    1% /etc/snuba
shm              9.9M    27  9.9M    1% /dev/shm
tmpfs            9.9M     9  9.9M    1% /run/secrets/kubernetes.io/serviceaccount
tmpfs            9.9M     1  9.9M    1% /proc/acpi
tmpfs            9.9M     1  9.9M    1% /proc/scsi
tmpfs            9.9M     1  9.9M    1% /sys/firmware
```

64MB is docker's default size.

# Workaround
I was able to solve the problem by mounting memory in the container referring to the following

https://stackoverflow.com/questions/46085748/define-size-for-dev-shm-on-container-engine

# My setting
This is my actual setting .

```yaml
sentry:
  consumer:
    volumeMounts:
      - mountPath: /dev/shm
        name: dshm
    volumes:
      - name: dshm
        emptyDir:
          medium: Memory
```

Actually `/dev/shm` increased as following. (64MB -> 79GB 💪 )

```bash
root@sentry-sessions-consumer-596698b79d-glzq6:/usr/src/snuba# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         248G  4.1G  244G   2% /
tmpfs            64M     0   64M   0% /dev
tmpfs            79G     0   79G   0% /sys/fs/cgroup
/dev/sda1       248G  4.1G  244G   2% /etc/snuba
tmpfs            79G  312K   79G   1% /dev/shm
tmpfs            79G   12K   79G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs            79G     0   79G   0% /proc/acpi
tmpfs            79G     0   79G   0% /proc/scsi
tmpfs            79G     0   79G   0% /sys/firmware

root@sentry-sessions-consumer-596698b79d-glzq6:/usr/src/snuba# df -hi
Filesystem     Inodes IUsed IFree IUse% Mounted on
overlay           16M  126K   16M    1% /
tmpfs             20M    17   20M    1% /dev
tmpfs             20M    17   20M    1% /sys/fs/cgroup
/dev/sda1         16M  126K   16M    1% /etc/snuba
tmpfs             20M    27   20M    1% /dev/shm
tmpfs             20M     9   20M    1% /run/secrets/kubernetes.io/serviceaccount
tmpfs             20M     1   20M    1% /proc/acpi
tmpfs             20M     1   20M    1% /proc/scsi
tmpfs             20M     1   20M    1% /sys/firmware
```
