### PR TITLE
Add BackendConfig when GKE Ingress controller is enabled

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -9,7 +9,9 @@
 
 {{- define "nginx.port" -}}{{ default "8080" .Values.nginx.containerPort }}{{- end -}}
 {{- define "relay.port" -}}3000{{- end -}}
+{{- define "relay.healthCheck.requestPath" -}}/api/relay/healthcheck/ready/{{- end -}}
 {{- define "sentry.port" -}}9000{{- end -}}
+{{- define "sentry.healthCheck.requestPath" -}}/_health/{{- end -}}
 {{- define "snuba.port" -}}1218{{- end -}}
 {{- define "symbolicator.port" -}}3021{{- end -}}
 

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -101,7 +101,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /api/relay/healthcheck/ready/
+            path: {{ template "relay.healthCheck.requestPath" }}
             port: {{ template "relay.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}
@@ -111,7 +111,7 @@ spec:
         readinessProbe:
           failureThreshold: 10
           httpGet:
-            path: /api/relay/healthcheck/ready/
+            path: {{ template "relay.healthCheck.requestPath" }}
             port: {{ template "relay.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -101,7 +101,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /_health/
+            path: {{ template "sentry.healthCheck.requestPath" }}
             port: {{ template "sentry.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.sentry.web.probeInitialDelaySeconds }}
@@ -111,7 +111,7 @@ spec:
         readinessProbe:
           failureThreshold: 10
           httpGet:
-            path: /_health/
+            path: {{ template "sentry.healthCheck.requestPath" }}
             port: {{ template "sentry.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.sentry.web.probeInitialDelaySeconds }}

--- a/sentry/templates/gke/backendconfig-sentry-relay.yaml
+++ b/sentry/templates/gke/backendconfig-sentry-relay.yaml
@@ -1,0 +1,17 @@
+{{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ include "sentry.fullname" . }}-relay
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: {{ template "relay.healthCheck.requestPath" }}
+    port: {{ template "relay.port" . }}
+{{- end }}

--- a/sentry/templates/gke/backendconfig-sentry-web.yaml
+++ b/sentry/templates/gke/backendconfig-sentry-web.yaml
@@ -1,0 +1,17 @@
+{{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ include "sentry.fullname" . }}-web
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: {{ template "sentry.healthCheck.requestPath" }}
+    port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -3,9 +3,12 @@ kind: Service
 metadata:
   name: {{ template "sentry.fullname" . }}-relay
   annotations:
-   {{- range $key, $value := .Values.service.annotations }}
-     {{ $key }}: {{ $value | quote }}
-   {{- end }}
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
+      cloud.google.com/backend-config: '{"ports": {"{{ template "relay.port" . }}":"{{ include "sentry.fullname" . }}-relay"}}'
+    {{- end }}
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/sentry/templates/service-sentry.yaml
+++ b/sentry/templates/service-sentry.yaml
@@ -3,9 +3,12 @@ kind: Service
 metadata:
   name: {{ template "sentry.fullname" . }}-web
   annotations:
-   {{- range $key, $value := .Values.service.annotations }}
-     {{ $key }}: {{ $value | quote }}
-   {{- end }}
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
+      cloud.google.com/backend-config: '{"ports": {"{{ .Values.service.externalPort }}":"{{ include "sentry.fullname" . }}-web"}}'
+    {{- end }}
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"


### PR DESCRIPTION
Hello, i'm doing some test on this chart to deploy it on GKE (1.19.10-gke.1000). When the **Ingress** and the health checks to **sentry-web** and **sentry-relay** has been created the health check to **sentry-relay** service is misconfigured. The health check try to connect to **sentry-relay** on port 80 with path / (the default) ignoring the configuration on **readinessProbe**. There are many cases that may cause this behaviour, so the best choice on GKE is to use **BackendConfig CRD** to configure the health checks.

Here some reference from google documentations:
https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#health_checks
https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#direct_health

If you find any issue on my changes let's me know, hope this help