### PR TITLE
Switch kafka consumers to auto.offset.reset=earliest

### DIFF
--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -69,7 +69,7 @@ spec:
           - "consumer"
           - "--storage"
           - "errors"
-          - "--auto-offset-reset=latest"
+          - "--auto-offset-reset=earliest"
           - "--max-batch-time-ms"
           - "750"
           {{- if .Values.snuba.consumer.maxBatchSize }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -69,7 +69,7 @@ spec:
           - "consumer"
           - "--storage"
           - "outcomes_raw"
-          - "--auto-offset-reset=latest"
+          - "--auto-offset-reset=earliest"
           - "--max-batch-size"
           - "{{ default "3" .Values.snuba.outcomesConsumer.maxBatchSize }}"
           {{- if .Values.snuba.outcomesConsumer.processes }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -69,7 +69,7 @@ spec:
           - "replacer"
           - "--storage"
           - "errors"
-          - "--auto-offset-reset=latest"
+          - "--auto-offset-reset=earliest"
           - "--max-batch-size"
           - "{{ default "3" .Values.snuba.replacer.maxBatchSize }}"
           {{- if .Values.snuba.replacer.maxBatchTimeMs }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -69,7 +69,7 @@ spec:
           - "consumer"
           - "--storage"
           - "sessions_raw"
-          - "--auto-offset-reset=latest"
+          - "--auto-offset-reset=earliest"
           - "--max-batch-time-ms"
           - "750"
           {{- if .Values.snuba.sessionsConsumer.maxBatchSize }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -71,7 +71,7 @@ spec:
           - "transactions"
           - "--consumer-group"
           - "transactions_group"
-          - "--auto-offset-reset=latest"
+          - "--auto-offset-reset=earliest"
           - "--max-batch-time-ms"
           - "750"
           {{- if .Values.snuba.transactionsConsumer.maxBatchSize }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -55,7 +55,6 @@ spec:
       containers:
       - name: snuba-init
         image: "{{ template "snuba.image" . }}"
-        # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
         command:
           - /bin/bash
           - -ec

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -55,7 +55,6 @@ spec:
       containers:
       - name: snuba-migrate
         image: "{{ template "snuba.image" . }}"
-        # command: ["./docker_entrypoint.sh", "replacer","--auto-offset-reset=latest","--max-batch-size", "3"]
         command:
           - /bin/bash
           - -ec


### PR DESCRIPTION
Setting maps to [Kafka consumer auto.offset.reset](https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#consumerconfigs_auto.offset.reset).

This fixes #315.

Could be a chart value to keep the current default, if that's the better solution.