### PR TITLE
Fix metrics serviceAccount

### DIFF
--- a/sentry/templates/deployment-metrics.yaml
+++ b/sentry/templates/deployment-metrics.yaml
@@ -88,6 +88,6 @@ spec:
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-metrics
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Followup to #405

Metrics deployment used common prefix only for SA, while it should be like `{{ prefix }}-metrics`.

CC @Phylu