### PR TITLE
Implement dnsPolicy and dnsConfig

### DIFF
--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -40,6 +40,13 @@ spec:
           tolerations:
 {{ toYaml .Values.sentry.cleanup.tolerations | indent 12 }}
             {{- end }}
+            {{- if .Values.dnsPolicy }}
+          dnsPolicy: {{ .Values.dnsPolicy | quote }}
+            {{- end }}
+            {{- if .Values.dnsConfig }}
+          dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 12 }}
+            {{- end }}
             {{- if .Values.images.sentry.imagePullSecrets }}
           imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 12 }}

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -39,6 +39,13 @@ spec:
           tolerations:
 {{ toYaml .Values.snuba.cleanupErrors.tolerations | indent 12 }}
             {{- end }}
+            {{- if .Values.dnsPolicy }}
+          dnsPolicy: {{ .Values.dnsPolicy | quote }}
+            {{- end }}
+            {{- if .Values.dnsConfig }}
+          dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 12 }}
+            {{- end }}
             {{- if .Values.images.snuba.imagePullSecrets }}
           imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 12 }}

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -39,6 +39,13 @@ spec:
           tolerations:
 {{ toYaml .Values.snuba.cleanupTransactions.tolerations | indent 12 }}
             {{- end }}
+            {{- if .Values.dnsPolicy }}
+          dnsPolicy: {{ .Values.dnsPolicy | quote }}
+            {{- end }}
+            {{- if .Values.dnsConfig }}
+          dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 12 }}
+            {{- end }}
             {{- if .Values.images.snuba.imagePullSecrets }}
           imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 12 }}

--- a/sentry/templates/deployment-metrics.yaml
+++ b/sentry/templates/deployment-metrics.yaml
@@ -45,6 +45,13 @@ spec:
       {{- if .Values.metrics.schedulerName }}
       schedulerName: "{{ .Values.metrics.schedulerName }}"
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.metrics.securityContext }}
       securityContext:
 {{ toYaml .Values.metrics.securityContext | indent 8 }}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -79,6 +79,13 @@ spec:
               mountPath: /work/.relay/config.yml
               subPath: config.yml
               readOnly: true
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-relay
         image: "{{ template "relay.image" . }}"

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -48,6 +48,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.sentry.cron.securityContext }}
       securityContext:
 {{ toYaml .Values.sentry.cron.securityContext | indent 8 }}

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -59,6 +59,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.sentry.ingestConsumer.securityContext }}
       securityContext:
 {{ toYaml .Values.sentry.ingestConsumer.securityContext | indent 8 }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -57,6 +57,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.sentry.postProcessForward.securityContext }}
       securityContext:
 {{ toYaml .Values.sentry.postProcessForward.securityContext | indent 8 }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -52,6 +52,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.sentry.web.securityContext }}
       securityContext:
 {{ toYaml .Values.sentry.web.securityContext | indent 8 }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -50,6 +50,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.sentry.worker.securityContext }}
       securityContext:
 {{ toYaml .Values.sentry.worker.securityContext | indent 8 }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -49,6 +49,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.api.securityContext }}
       securityContext:
 {{ toYaml .Values.snuba.api.securityContext | indent 8 }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -56,6 +56,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.consumer.securityContext }}
       securityContext:
 {{ toYaml .Values.snuba.consumer.securityContext | indent 8 }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -56,6 +56,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.outcomesConsumer.securityContext }}
       securityContext:
 {{ toYaml .Values.snuba.outcomesConsumer.securityContext | indent 8 }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -56,6 +56,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.replacer.securityContext }}
       securityContext:
 {{ toYaml .Values.snuba.replacer.securityContext | indent 8 }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -56,6 +56,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.sessionsConsumer.securityContext }}
       securityContext:
 {{ toYaml .Values.snuba.sessionsConsumer.securityContext | indent 8 }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -56,6 +56,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.transactionsConsumer.securityContext }}
       securityContext:
 {{ toYaml .Values.snuba.transactionsConsumer.securityContext | indent 8 }}

--- a/sentry/templates/deployment-symbolicator.yaml
+++ b/sentry/templates/deployment-symbolicator.yaml
@@ -49,6 +49,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.symbolicator.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.symbolicator.api.securityContext }}
       securityContext:
 {{ toYaml .Values.symbolicator.api.securityContext | indent 8 }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -50,6 +50,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       containers:
       - name: db-init-job
         image: "{{ template "sentry.image" . }}"

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -52,6 +52,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       containers:
       - name: snuba-init
         image: "{{ template "snuba.image" . }}"

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -52,6 +52,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       containers:
       - name: snuba-migrate
         image: "{{ template "snuba.image" . }}"

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -36,6 +36,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       containers:
       - name: user-create-job
         image: "{{ template "sentry.image" . }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -850,3 +850,9 @@ metrics:
     # honorLabels: true
 
 revisionHistoryLimit: 10
+
+# dnsPolicy: "ClusterFirst"
+# dnsConfig:
+#   nameservers: []
+#   searches: []
+#   options: []


### PR DESCRIPTION
Added dnsPolicy and dnsConfig properties in order to configure [DNS for pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)