### PR TITLE
External service account option for snuba-api

### DIFF
--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -98,6 +98,8 @@ spec:
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      {{- else if .Values.externalServiceAccount.enabled }}
+      serviceAccount: {{ .Values.externalServiceAccount.name }}
       {{- end }}
       volumes:
         - name: config


### PR DESCRIPTION
Add option for defining external serviceaccount for snuba-api deployment.