### PR TITLE
Fix snuba cleanup env

### DIFF
--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -59,8 +59,7 @@ spec:
                 - "--clickhouse-port"
                 - {{ include "sentry.clickhouse.port" . | quote }}
             env:
-              - name: SNUBA_SETTINGS
-                value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 12 }}
 {{- if .Values.snuba.cleanupErrors.env }}
 {{ toYaml .Values.snuba.cleanupErrors.env | indent 12 }}
 {{- end }}

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -59,8 +59,7 @@ spec:
                 - "--clickhouse-port"
                 - {{ include "sentry.clickhouse.port" . | quote }}
             env:
-              - name: SNUBA_SETTINGS
-                value: /etc/snuba/settings.py
+{{ include "sentry.snuba.env" . | indent 12 }}
 {{- if .Values.snuba.cleanupTransactions.env }}
 {{ toYaml .Values.snuba.cleanupTransactions.env | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Currently if you define a custom env for the cleanup jobs, it fails because the
indentation doesn't line up.  We might as well just use the same env as for the
other snuba pods.﻿
