### PR TITLE
Support service annotations per service

### DIFF
--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- range $key, $value := .Values.service.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- range $key, $value := .Values.relay.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ template "relay.port" . }}":"{{ include "sentry.fullname" . }}-relay"}}'
     {{- end }}

--- a/sentry/templates/service-sentry.yaml
+++ b/sentry/templates/service-sentry.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- range $key, $value := .Values.service.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- range $key, $value := .Values.sentry.web.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ .Values.service.externalPort }}":"{{ include "sentry.fullname" . }}-web"}}'
     {{- end }}

--- a/sentry/templates/service-snuba.yaml
+++ b/sentry/templates/service-snuba.yaml
@@ -6,6 +6,9 @@ metadata:
    {{- range $key, $value := .Values.service.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}
+   {{- range $key, $value := .Values.snuba.api.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -56,6 +56,8 @@ relay:
   affinity: {}
   nodeSelector: {}
   securityContext: {}
+  service:
+    annotations: {}
   # tolerations: []
   # podLabels: []
 
@@ -83,6 +85,8 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    service:
+      annotations: {}
     # tolerations: []
     # podLabels: []
     # Mount and use custom CA
@@ -219,6 +223,8 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    service:
+      annotations: {}
     # tolerations: []
     # podLabels: []
 


### PR DESCRIPTION
This allows applying different service annotations to different
services instead of forcing all of them to use the same ones.﻿
