### PR TITLE
Add missing resources to templates and values.yaml

### DIFF
--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -86,6 +86,8 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+          resources:
+{{ toYaml .Values.relay.init.resources | indent 12 }}
       containers:
       - name: {{ .Chart.Name }}-relay
         image: "{{ template "relay.image" . }}"

--- a/sentry/templates/hooks/clickhouse-init.job.yaml
+++ b/sentry/templates/hooks/clickhouse-init.job.yaml
@@ -100,4 +100,6 @@ spec:
 
             echo "clickhouse-init finished"
             {{- end }}
+        resources:
+{{ toYaml .Values.hooks.clickhouseInit.resources | indent 10 }}
 {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -64,6 +64,8 @@ relay:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
+  init:
+    resources: {}
   sidecars: [ ]
   volumes: [ ]
 
@@ -394,6 +396,7 @@ hooks:
   removeOnSuccess: true
   clickhouseInit:
     podAnnotations: {}
+    resources: {}
     affinity: {}
     nodeSelector: {}
     # tolerations: []


### PR DESCRIPTION
Currently there is no way to deploy the chart into a cluster with enabled ResourceQuota admission control plugin. This PR adds a few missing `resources:` keys to the templates and values.yaml.