### PR TITLE
September release

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 12.0.0
-appVersion: 21.8.0
+version: 12.0.1
+appVersion: 21.9.0
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -420,6 +420,7 @@ data:
     SENTRY_OPTIONS['mail.password'] = os.getenv("SENTRY_EMAIL_PASSWORD", {{ .Values.mail.password | quote }})
     SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port | quote }}))
     SENTRY_OPTIONS['mail.host'] = os.getenv("SENTRY_EMAIL_HOST", {{ .Values.mail.host | quote }})
+    SENTRY_OPTIONS['mail.list-namespace'] = os.getenv("SENTRY_EMAIL_HOST", {{ .Values.mail.listNamespace | quote }})
     SENTRY_OPTIONS['mail.from'] = os.getenv("SENTRY_EMAIL_FROM", {{ .Values.mail.from | quote }})
 
     #########################

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -457,6 +457,7 @@ mail:
   password: ""
   port: 25
   host: ""
+  listNamespace: localhost
   from: ""
 
 symbolicator:


### PR DESCRIPTION
added `mail.list-namespace` configuration option as per latest onpremise release (introduced here: https://github.com/getsentry/onpremise/pull/1076)