### PR TITLE
feat: smtp support use-ssl options

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -416,6 +416,7 @@ data:
     #######################
     SENTRY_OPTIONS['mail.backend'] = os.getenv("SENTRY_EMAIL_BACKEND", {{ .Values.mail.backend | quote }})
     SENTRY_OPTIONS['mail.use-tls'] = bool(strtobool(os.getenv("SENTRY_EMAIL_USE_TLS", {{ .Values.mail.useTls | quote }})))
+    SENTRY_OPTIONS['mail.use-ssl'] = bool(strtobool(os.getenv("SENTRY_EMAIL_USE_SSL", {{ .Values.mail.useSsl | quote }})))
     SENTRY_OPTIONS['mail.username'] = os.getenv("SENTRY_EMAIL_USERNAME", {{ .Values.mail.username | quote }})
     SENTRY_OPTIONS['mail.password'] = os.getenv("SENTRY_EMAIL_PASSWORD", {{ .Values.mail.password | quote }})
     SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port | quote }}))

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -453,6 +453,7 @@ system:
 mail:
   backend: dummy # smtp
   useTls: false
+  useSsl: false
   username: ""
   password: ""
   port: 25


### PR DESCRIPTION
[TLS in SMTP is STARTTLS that is less secure than SSL(TLS) #22492](https://github.com/getsentry/sentry/issues/22492)