### PR TITLE
resource requests for statefulSet clickhouse initContainer

### DIFF
--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -70,6 +70,10 @@ spec:
         - -c
         - |
           mkdir -p /etc/clickhouse-server/metrica.d
+        {{- if .Values.clickhouse.init.resources }}
+        resources:
+{{ toYaml .Values.clickhouse.init.resources | indent 10 }}
+        {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}-replica
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -69,6 +69,10 @@ spec:
         - -c
         - |
           mkdir -p /etc/clickhouse-server/metrica.d
+        {{- if .Values.clickhouse.init.resources }}
+        resources:
+{{ toYaml .Values.clickhouse.init.resources | indent 10 }}
+        {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -129,6 +129,7 @@ clickhouse:
   #imagePullSecrets:
   ## Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated.
   ## More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+    resources: {}
   livenessProbe:
     enabled: true
     initialDelaySeconds: "30"


### PR DESCRIPTION
Added possibility to set resource requests on the initContainer of the clickhouse statefulSet to avoid errors when working with quotas.