### PR TITLE
Fix embedded redis auth after redis chart upgrade

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -269,7 +269,7 @@ Set redis password
 */}}
 {{- define "sentry.redis.password" -}}
 {{- if .Values.redis.enabled -}}
-{{ .Values.redis.password }}
+{{ .Values.redis.auth.password }}
 {{- else -}}
 {{ .Values.externalRedis.password }}
 {{- end -}}


### PR DESCRIPTION
Otherwise duplicating old key is necessary:
```yaml
redis:
  # new format
  auth:
    enabled: true
    password: xxx

  # old, necessary to keep till this change merged
  password: xxx
```