### PR TITLE
sentry: use metrics.service.annotations value

### DIFF
--- a/sentry/templates/service-metrics.yaml
+++ b/sentry/templates/service-metrics.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
  name: {{ template "sentry.fullname" . }}-metrics
+  {{- if .Values.metrics.service.annotations }}
+ annotations: {{ toYaml .Values.metrics.service.annotations | nindent 4 }}
+  {{- end }}
  labels:
     app: {{ template "sentry.fullname" . }}-metrics
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"


### PR DESCRIPTION
`metrics.service.annotations` is declared in #85, but it was not used.