### PR TITLE
Fix missing existingClaim usage

### DIFF
--- a/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
@@ -114,8 +114,13 @@ spec:
           name: {{ template "sentry.fullname" . }}-sentry
       - name: sentry-data
       {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
         persistentVolumeClaim:
           claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
       {{- else }}
         emptyDir: {}
       {{ end }}


### PR DESCRIPTION
Follow up of the previous [PR](https://github.com/sentry-kubernetes/charts/pull/515). There is a file missing the `existingClaim`.