### PR TITLE
Allow to expose the service via NodePort

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: "v2"
 appVersion: "19.14"
 description: ClickHouse is an open source column-oriented database management system
   capable of real time generation of analytical data reports using SQL queries
@@ -10,4 +11,4 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.1.0
+version: 3.1.1

--- a/clickhouse/templates/svc-clickhouse.yaml
+++ b/clickhouse/templates/svc-clickhouse.yaml
@@ -6,20 +6,36 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    {{ .Values.annotations }}
 spec:
+  {{ if eq .Values.clickhouse.service.type "NodePort"}}
+  type: NodePort
+  {{ else }}
+  type: ClusterIP
+  {{ end }}
   ports:
   - port: {{ .Values.clickhouse.tcp_port }}
     targetPort: tcp-port
     protocol: TCP
     name: tcp-port
+    {{ if eq .Values.clickhouse.service.type "NodePort"}}
+    nodePort: {{ .Values.clickhouse.service.NodePorts.tcp_port }}
+    {{ end }}
   - port: {{ .Values.clickhouse.http_port }}
     targetPort: http-port
     protocol: TCP
     name: http-port
+    {{ if eq .Values.clickhouse.service.type "NodePort"}}
+    nodePort: {{ .Values.clickhouse.service.NodePorts.http_port }}
+    {{ end }}
   - port: {{ .Values.clickhouse.interserver_http_port }}
     targetPort: inter-http-port
     protocol: TCP
     name: inter-http-port
+    {{ if eq .Values.clickhouse.service.type "NodePort"}}
+    nodePort: {{ .Values.clickhouse.service.NodePorts.interserver_http_port }}
+    {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "clickhouse.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -48,10 +48,21 @@ clickhouse:
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
   ##
   # rollingUpdatePartition:
-  
+
   # Security Context
   securityContext: {}
-    
+
+
+  ## Configure the clickhouse service.
+
+  service:
+    type: ClusterIP
+    NodePorts:
+      ## Uncomment when NodePort is selected.
+      # tcp_port: 30010
+      # http_port: 30011
+      # interserver_http_port: 30012
+
   ## Prometheus Exporter / Metrics
   ##
   metrics:


### PR DESCRIPTION
By default the clickhouse service only expose using ClusterIP.
I changed the service to allow use NodePort method. 