### PR TITLE
Fix get-secretkey Note for MacOS

### DIFF
--- a/sentry/templates/NOTES.txt
+++ b/sentry/templates/NOTES.txt
@@ -1,3 +1,3 @@
 * When running upgrades, make sure to give back the `system.secretKey` value.
 
-kubectl -n {{ .Release.Namespace }} get configmap {{ template "sentry.fullname" . }}-sentry -o json | grep -m1 -Po '(?<=system.secret-key: )[^\\]*'
+kubectl -n {{ .Release.Namespace }} get configmap {{ template "sentry.fullname" . }}-sentry -o go-template='{{ index .data "config.yml" }}' | awk '$1=="system.secret-key:" {print $2}' | tr -d '"'


### PR DESCRIPTION
The note on how to get the secretkey does not work on macOS. When I run it, I get this output:

```
$ kubectl -n smith get configmap sentry-sentry -o json | grep -m1 -Po '(?<=system.secret-key: )[^\\]*'
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]             
```

Instead, I propose to use `kubectl get … -o go-template` to get the value at the config.yml index, and then awk and tr to clean up the output.