### PR TITLE
Fix healthchecks under AWS ALB

### DIFF
--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- range $key, $value := .Values.service.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
+      alb.ingress.kubernetes.io/healthcheck-path: "{{ template "relay.healthCheck.requestPath" . }}"
+      alb.ingress.kubernetes.io/healthcheck-port: "{{ template "relay.port" . }}"
+    {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ template "relay.port" . }}":"{{ include "sentry.fullname" . }}-relay"}}'
     {{- end }}

--- a/sentry/templates/service-sentry.yaml
+++ b/sentry/templates/service-sentry.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- range $key, $value := .Values.service.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
+      alb.ingress.kubernetes.io/healthcheck-path: "{{ template "sentry.healthCheck.requestPath" . }}"
+      alb.ingress.kubernetes.io/healthcheck-port: "{{ .Values.service.externalPort }}"
+    {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ .Values.service.externalPort }}":"{{ include "sentry.fullname" . }}-web"}}'
     {{- end }}


### PR DESCRIPTION
This fixes the perpetually failing healthchecks under AWS ALB.  This sets the appropriate URI Path to the services respective healthcheck endpoint and explicitly sets the appropriate port.