### PR TITLE
clickhouse: fix metrics pod resources indention

### DIFF
--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -118,7 +118,8 @@ spec:
             containerPort: {{ .Values.clickhouse.metrics.image.port }}
             protocol: TCP
         {{- if .Values.clickhouse.metrics.resources }}
-        resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 8 }}
+        resources: 
+{{ toYaml .Values.clickhouse.metrics.resources | indent 10 }}
         {{- end }}
       {{- end }}
     {{- if .Values.clickhouse.nodeSelector }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -117,7 +117,8 @@ spec:
             containerPort: {{ .Values.clickhouse.metrics.image.port }}
             protocol: TCP
         {{- if .Values.clickhouse.metrics.resources }}
-        resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 8 }}
+        resources:
+{{ toYaml .Values.clickhouse.metrics.resources | indent 10 }}
       {{- end }}
       {{- end }}
     {{- if .Values.clickhouse.nodeSelector }}


### PR DESCRIPTION
clickhouse: fix metrics pod resources indention