### PR TITLE
Add urlquery method to redis configuration of relay service

### DIFF
--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -30,7 +30,7 @@ data:
           value: 50000000  # 50MB or bust
 
       {{- if $redisPass }}
-      redis: "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
+      redis: "redis://:{{ urlquery $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
       {{- else }}
       redis: "redis://{{ $redisHost }}:{{ $redisPort }}"
       {{- end }}


### PR DESCRIPTION
When I use external redis and my password contains the '@' character, the relay service cannot resolve to the correct redis host. An error will be reported as follows:
```bash
 [r2d2] ERROR: failed to lookup address information: Name or service not known
```
Therefore, add the 'urlquery' method to the password field for escape processing.