### PR TITLE
Service Annotation for sentry-web and sentry-relay

### DIFF
--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -7,8 +7,8 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
-      alb.ingress.kubernetes.io/healthcheck-path: "{{ template "relay.healthCheck.requestPath" . }}"
-      alb.ingress.kubernetes.io/healthcheck-port: "{{ template "relay.port" . }}"
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "{{ template "relay.healthCheck.requestPath" . }}"
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "{{ template "relay.port" . }}"
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ template "relay.port" . }}":"{{ include "sentry.fullname" . }}-relay"}}'

--- a/sentry/templates/service-sentry.yaml
+++ b/sentry/templates/service-sentry.yaml
@@ -7,8 +7,8 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
-      alb.ingress.kubernetes.io/healthcheck-path: "{{ template "sentry.healthCheck.requestPath" . }}"
-      alb.ingress.kubernetes.io/healthcheck-port: "{{ .Values.service.externalPort }}"
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "{{ template "sentry.healthCheck.requestPath" . }}"
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "{{ .Values.service.externalPort }}"
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ .Values.service.externalPort }}":"{{ include "sentry.fullname" . }}-web"}}'


### PR DESCRIPTION
Based on these aws-load-balancer-controller [docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations) the annotations for `Service` kind are different from what is mentioned in the above code.

This fixes both the `sentry-web` and `sentry-relay` services.