### PR TITLE
Service annotations for sentry web and relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/
 
 For now the full list of values is not documented but you can get inspired by the values.yaml specific to each directory.
 
+## Upgrading from 12.x.x version of this Chart to 13.0.0
+
+The service annotions have been moved from the `service` section to the respective service's service sub-section. So what was:
+
+```yaml
+service:
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /_health/
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+```
+
+will now be set per service:
+
+```yaml
+sentry:
+  web:
+    service:
+      annotations:
+        alb.ingress.kubernetes.io/healthcheck-path: /_health/
+        alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+
+relay:
+  service:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: /api/relay/healthcheck/ready/
+      alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+```
+
 ## Upgrading from 10.x.x version of this Chart to 11.0.0
 
 If you were using clickhouse tabix externally, we disabled it per default.
@@ -42,7 +70,6 @@ clickhouse.clickhouse.configmap.remote_servers.replica.backup
 - The sentry.configYml value is now in a real yaml format
 - If you were previously using `relay.asHook`, the value is now `asHook`
 
-
 ## Upgrading from 4.x.x version of this Chart to 5.0.0
 
 As Relay is now part of this chart your need to make sure you enable either Nginx or the Ingress. Please read the next paragraph for more informations.
@@ -68,28 +95,30 @@ resources moved to separate config branches: `externalClickhouse`, `externalKafk
 
 Here is a mapping table of old values and new values:
 
-| Before                          | After                                |
-| ------------------------------- | ------------------------------------ |
-| `postgresql.postgresqlHost`     | `externalPostgresql.host`            |
-| `postgresql.postgresqlPort`     | `externalPostgresql.port`            |
-| `postgresql.postgresqlUsername` | `externalPostgresql.username`        |
-| `postgresql.postgresqlPassword` | `externalPostgresql.password`        |
-| `postgresql.postgresqlDatabase` | `externalPostgresql.database`        |
-| `postgresql.postgresSslMode`    | `externalPostgresql.sslMode`         |
-| `redis.host`                    | `externalRedis.host`                 |
-| `redis.port`                    | `externalRedis.port`                 |
-| `redis.password`                | `externalRedis.password`             |
-
+| Before                          | After                         |
+| ------------------------------- | ----------------------------- |
+| `postgresql.postgresqlHost`     | `externalPostgresql.host`     |
+| `postgresql.postgresqlPort`     | `externalPostgresql.port`     |
+| `postgresql.postgresqlUsername` | `externalPostgresql.username` |
+| `postgresql.postgresqlPassword` | `externalPostgresql.password` |
+| `postgresql.postgresqlDatabase` | `externalPostgresql.database` |
+| `postgresql.postgresSslMode`    | `externalPostgresql.sslMode`  |
+| `redis.host`                    | `externalRedis.host`          |
+| `redis.port`                    | `externalRedis.port`          |
+| `redis.password`                | `externalRedis.password`      |
 
 ## Upgrading from deprecated 9.0 -> 10.0 Chart
-As this chart runs in helm 3 and also tries its best to follow on from the original Sentry chart. There are some steps that needs to be taken in order to correctly upgrade. 
+
+As this chart runs in helm 3 and also tries its best to follow on from the original Sentry chart. There are some steps that needs to be taken in order to correctly upgrade.
 
 From the previous upgrade, make sure to get the following from your previous installation:
- - Redis Password (If Redis auth was enabled)
- - Postgresql Password 
-Both should be in the `secrets` of your original 9.0 release. Make a note of both of these values.
+
+- Redis Password (If Redis auth was enabled)
+- Postgresql Password
+  Both should be in the `secrets` of your original 9.0 release. Make a note of both of these values.
 
 #### Upgrade Steps
+
 Due to an issue where transferring from Helm 2 to 3. Statefulsets that use the following: `heritage: {{ .Release.Service }}` in the metadata field will error out with a `Forbidden` error during the upgrade. The only workaround is to delete the existing statefulsets (Don't worry, PVC will be retained):
 
 > `kubectl delete --all sts -n <Sentry Namespace>`
@@ -105,8 +134,9 @@ If Redis auth enabled:
 > `helm upgrade -n <Sentry namespace> <Sentry Release> . --set redis.usePassword=true --set redis.password=<Redis Password> --set postgresql.postgresqlPassword=<Postgresql Password>`
 
 If Redis auth is disabled:
+
 > `helm upgrade -n <Sentry namespace> <Sentry Release> . --set postgresql.postgresqlPassword=<Postgresql Password>`
- 
+
 Please also follow the steps for Major version 3 to 4 migration
 
 ## PostgresSQL
@@ -123,9 +153,9 @@ You may enable mounting of the sentry-data PV across worker and cron pods by cha
 
 ## Roadmap
 
-- [X] Lint in Pull requests
-- [X] Public availability through Github Pages
-- [X] Automatic deployment through Github Actions
+- [x] Lint in Pull requests
+- [x] Public availability through Github Pages
+- [x] Automatic deployment through Github Actions
 - [ ] Symbolicator deployment
-- [X] Testing the chart in a production environment
+- [x] Testing the chart in a production environment
 - [ ] Improving the README

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 12.0.0
+version: 13.0.0
 appVersion: 21.8.0
 dependencies:
   - name: redis

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -264,3 +264,5 @@ relay:
 ```
 
 Which are load balancer annotations specified in the service configuration for the load balancer to pick while creating the target groups.
+
+NOTE: AWS ALB Controller's Service annotations don't apply here as we want the `aws-load-balancer-controller` to pick-up the services and apply the appropriate healthcheck-path per service and not create a load balancer for the service itself. The service annotations will only apply when you want the service to be load balanced.

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -1,17 +1,22 @@
 # Install
+
 ## Add repo
+
 ```
 helm repo add sentry https://sentry-kubernetes.github.io/charts
 ```
+
 ## Without overrides
+
 ```
 helm install sentry sentry/sentry
 ```
+
 ## With your own vaLues file
-``` 
+
+```
 helm install sentry sentry/sentry -f values.yaml
 ```
-
 
 ## Upgrading from 11.x.x version of this Chart to 12.0.0
 
@@ -31,7 +36,7 @@ From the previous upgrade, make sure to get the following from your previous ins
 
 - Redis Password (If Redis auth was enabled)
 - Postgresql Password
-Both should be in the `secrets` of your original 9.0 release. Make a note of both of these values.
+  Both should be in the `secrets` of your original 9.0 release. Make a note of both of these values.
 
 #### Upgrade Steps
 
@@ -50,6 +55,7 @@ If Redis auth enabled:
 > helm upgrade -n <Sentry namespace> <Sentry Release> . --set redis.usePassword=true --set redis.password=<Redis Password>
 
 If Redis auth is disabled:
+
 > helm upgrade -n <Sentry namespace> <Sentry Release> .
 
 ## Configuration
@@ -58,46 +64,46 @@ The following table lists the configurable parameters of the Sentry chart and th
 
 Note: this table is incomplete, so have a look at the values.yaml in case you miss something
 
-Parameter                          | Description                                                                                                | Default
-:--------------------------------- | :--------------------------------------------------------------------------------------------------------- | :---------------------------------------------------
-`user.create` | if `true`, creates a default admin user defined from `email` and `password` | `true`
-`user.email` | Admin user email | `admin@sentry.local`
-`user.password` | Admin user password| `aaaa`
-`ingress.enabled` | Enabling Ingress | `false`
-`ingress.regexPathStyle` | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx`, `aws-alb`, `gke` and `traefik` | `nginx`
-`nginx.enabled` | Enabling NGINX | `true`
-`metrics.enabled`| if `true`, enable Prometheus metrics | `false`
-`metrics.image.repository`         | Metrics exporter image repository                                                                          | `prom/statsd-exporter`
-`metrics.image.tag`                | Metrics exporter image tag                                                                                 | `v0.10.5`
-`metrics.image.PullPolicy`         | Metrics exporter image pull policy                                                                         | `IfNotPresent`
-`metrics.nodeSelector`| Node labels for metrics pod assignment| `{}`
-`metrics.tolerations` | Toleration labels for metrics pod assignment| `[]`
-`metrics.affinity` | Affinity settings for metrics | `{}`
-`metrics.resources`| Metrics resource requests/limit| `{}`
-`metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
-`metrics.service.clusterIP` | cluster IP address to assign to service (set to `"-"` to pass an empty value) | `nil`
-`metrics.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the metrics service | `false`
-`metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
-`metrics.service.additionalLabels` | labels for metrics service | `{}`
-`metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`metrics.service.servicePort` | Prometheus metrics service port | `9913`
-`metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
-`metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
-`metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
-`metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
-`metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as sentry`
-`metrics.serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s`
-`serviceAccount.annotations` |  Additional Service Account annotations. | `{}`
-`serviceAccount.enabled` | If `true`, a custom Service Account will be used. | `false`
-`serviceAccount.name` | The base name of the ServiceAccount to use. Will be appended with e.g. `snuba` or `web` for the pods accordingly. | `"sentry"`
-`serviceAccount.automountServiceAccountToken` | Automount API credentials for a Service Account. | `true`
-`system.secretKey` | secret key for the session cookie ([documentation](https://develop.sentry.dev/config/#general)) | `nil`
-`sentry.features.vstsLimitedScopes` | Disables the azdo-integrations with limited scopes that is the cause of so much pain | `true`
-`sentry.web.customCA.secretName` | Allows mounting a custom CA secret | `nil`
-`sentry.web.customCA.item` | Key of CA cert object within the secret | `ca.crt`
-`symbolicator.api.enabled` | Enable Symbolicator | `false`
-`symbolicator.api.config` | Config file for Symbolicator, see [its docs](https://getsentry.github.io/symbolicator/#configuration) | see values.yaml
+| Parameter                                     | Description                                                                                                                                                         | Default                        |
+| :-------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----------------------------- |
+| `user.create`                                 | if `true`, creates a default admin user defined from `email` and `password`                                                                                         | `true`                         |
+| `user.email`                                  | Admin user email                                                                                                                                                    | `admin@sentry.local`           |
+| `user.password`                               | Admin user password                                                                                                                                                 | `aaaa`                         |
+| `ingress.enabled`                             | Enabling Ingress                                                                                                                                                    | `false`                        |
+| `ingress.regexPathStyle`                      | Allows setting the style the regex paths are rendered in the ingress for the ingress controller in use. Possible values are `nginx`, `aws-alb`, `gke` and `traefik` | `nginx`                        |
+| `nginx.enabled`                               | Enabling NGINX                                                                                                                                                      | `true`                         |
+| `metrics.enabled`                             | if `true`, enable Prometheus metrics                                                                                                                                | `false`                        |
+| `metrics.image.repository`                    | Metrics exporter image repository                                                                                                                                   | `prom/statsd-exporter`         |
+| `metrics.image.tag`                           | Metrics exporter image tag                                                                                                                                          | `v0.10.5`                      |
+| `metrics.image.PullPolicy`                    | Metrics exporter image pull policy                                                                                                                                  | `IfNotPresent`                 |
+| `metrics.nodeSelector`                        | Node labels for metrics pod assignment                                                                                                                              | `{}`                           |
+| `metrics.tolerations`                         | Toleration labels for metrics pod assignment                                                                                                                        | `[]`                           |
+| `metrics.affinity`                            | Affinity settings for metrics                                                                                                                                       | `{}`                           |
+| `metrics.resources`                           | Metrics resource requests/limit                                                                                                                                     | `{}`                           |
+| `metrics.service.annotations`                 | annotations for Prometheus metrics service                                                                                                                          | `{}`                           |
+| `metrics.service.clusterIP`                   | cluster IP address to assign to service (set to `"-"` to pass an empty value)                                                                                       | `nil`                          |
+| `metrics.service.omitClusterIP`               | (Deprecated) To omit the `clusterIP` from the metrics service                                                                                                       | `false`                        |
+| `metrics.service.externalIPs`                 | Prometheus metrics service external IP addresses                                                                                                                    | `[]`                           |
+| `metrics.service.additionalLabels`            | labels for metrics service                                                                                                                                          | `{}`                           |
+| `metrics.service.loadBalancerIP`              | IP address to assign to load balancer (if supported)                                                                                                                | `""`                           |
+| `metrics.service.loadBalancerSourceRanges`    | list of IP CIDRs allowed access to load balancer (if supported)                                                                                                     | `[]`                           |
+| `metrics.service.servicePort`                 | Prometheus metrics service port                                                                                                                                     | `9913`                         |
+| `metrics.service.type`                        | type of Prometheus metrics service to create                                                                                                                        | `ClusterIP`                    |
+| `metrics.serviceMonitor.enabled`              | Set this to `true` to create ServiceMonitor for Prometheus operator                                                                                                 | `false`                        |
+| `metrics.serviceMonitor.additionalLabels`     | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                                               | `{}`                           |
+| `metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels.                                                                                           | `false`                        |
+| `metrics.serviceMonitor.namespace`            | namespace where servicemonitor resource should be created                                                                                                           | `the same namespace as sentry` |
+| `metrics.serviceMonitor.scrapeInterval`       | interval between Prometheus scraping                                                                                                                                | `30s`                          |
+| `serviceAccount.annotations`                  | Additional Service Account annotations.                                                                                                                             | `{}`                           |
+| `serviceAccount.enabled`                      | If `true`, a custom Service Account will be used.                                                                                                                   | `false`                        |
+| `serviceAccount.name`                         | The base name of the ServiceAccount to use. Will be appended with e.g. `snuba` or `web` for the pods accordingly.                                                   | `"sentry"`                     |
+| `serviceAccount.automountServiceAccountToken` | Automount API credentials for a Service Account.                                                                                                                    | `true`                         |
+| `system.secretKey`                            | secret key for the session cookie ([documentation](https://develop.sentry.dev/config/#general))                                                                     | `nil`                          |
+| `sentry.features.vstsLimitedScopes`           | Disables the azdo-integrations with limited scopes that is the cause of so much pain                                                                                | `true`                         |
+| `sentry.web.customCA.secretName`              | Allows mounting a custom CA secret                                                                                                                                  | `nil`                          |
+| `sentry.web.customCA.item`                    | Key of CA cert object within the secret                                                                                                                             | `ca.crt`                       |
+| `symbolicator.api.enabled`                    | Enable Symbolicator                                                                                                                                                 | `false`                        |
+| `symbolicator.api.config`                     | Config file for Symbolicator, see [its docs](https://getsentry.github.io/symbolicator/#configuration)                                                               | see values.yaml                |
 
 ## NGINX and/or Ingress
 
@@ -114,6 +120,7 @@ helm upgrade ... --set system.secretKey=xx
 ## Symbolicator
 
 For getting native stacktraces and minidumps symbolicated with debug symbols (e.g. iOS/Android), you need to enable Symbolicator via
+
 ```yaml
 symbolicator:
   enabled: true
@@ -131,7 +138,127 @@ filestore:
       persistentWorkers: true
       # storageClass: 'efs-storage' # see note below
 ```
+
 Note: If you need to run or cannot avoid running sentry-worker and sentry-web on different cluster nodes, you need to set `filestore.filesystem.persistence.accessMode: ReadWriteMany` or might get problems. HOWEVER, [not all volume drivers support it](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes), like AWS EBS or GCP disks.
 So you would want to create and use a `StorageClass` with a supported volume driver like [AWS EFS](https://github.com/kubernetes-sigs/aws-efs-csi-driver)
 
 Its also important having `connect_to_reserved_ips: true` in the symbolicator config file, which this Chart defaults to.
+
+## Example using Terraform and AWS
+
+`templates/values.yaml` file
+
+```yaml
+prefix: ${module_prefix}
+
+user:
+  create: true
+  email: ${sentry_email}
+  password: ${sentry_password}
+
+nginx:
+  enabled: false
+
+rabbitmq:
+  enabled: false
+
+sentry:
+  web:
+    service:
+      annotations:
+        alb.ingress.kubernetes.io/healthcheck-path: /_health/
+        alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+
+relay:
+  service:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: /api/relay/healthcheck/ready/
+      alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+
+postgresql:
+  enabled: true
+  nameOverride: sentry-postgresql
+  postgresqlUsername: postgres
+  postgresqlPassword: ${postgres_password}
+  postgresqlDatabase: sentry
+  replication:
+    enabled: false
+
+ingress:
+  enabled: true
+  hostname: ${sentry_dns_name}
+  regexPathStyle: aws-alb
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/tags: ${tags}
+    alb.ingress.kubernetes.io/inbound-cidrs: ${allowed_cidr_blocks_str}
+    alb.ingress.kubernetes.io/subnets: ${public_subnet_ids_str}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/certificate-arn: ${subdomain_cert_arn}
+    external-dns.alpha.kubernetes.io/hostname: ${sentry_dns_name}
+```
+
+`helm.tf` file
+
+```hcl
+resource "helm_release" "sentry" {
+  name  = "sentry"
+  chart = "${path.module}/helm_sentry/"
+  repository = "https://sentry-kubernetes.github.io/charts"
+  version    = "13.0.0"
+  timeout           = 600
+  wait              = false
+  dependency_update = true
+
+  values = [
+    templatefile(
+      "${path.module}/templates/sentry_values.yaml",
+      {
+        module_prefix   = "${var.module_prefix}",
+        sentry_email    = "${var.sentry_email}",
+        sentry_password = "${var.sentry_password}",
+
+        sentry_dns_name         = "${local.sentry_dns_name}",
+        subdomain_cert_arn      = "${var.subdomain_cert_arn}",
+        allowed_cidr_blocks_str = "${join(",", var.allowed_cidr_blocks)}",
+        private_subnet_ids_str  = "${join(",", var.private_subnet_ids)}",
+        public_subnet_ids_str   = "${join(",", var.public_subnet_ids)}",
+        tags                    = "environment=${var.env}"
+        # postgres_db_host        = "${module.sentry_rds_pg.this_rds_cluster_endpoint}",
+        # postgres_db_name        = "${local.db_name}",
+        postgres_username = "${local.db_user}",
+        postgres_password = "${local.db_pass}",
+      }
+    )
+  ]
+
+  depends_on = [
+    helm_release.lb_controller,
+    helm_release.external_dns,
+  ]
+}
+```
+
+notes:
+
+1. Ensure the control plane and node security groups are appropriately configured as documented [here](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#control-plane-worker-node-sgs).
+2. Annotations for ingress are as mentioned [here](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/)
+3. `healthcheck-path` and `healthcheck-port` annotations can be setup per target group using the alb annotations in the corresponding services as mentioned [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1056#issuecomment-551585078). For example, here we have:
+
+```yaml
+sentry:
+  web:
+    service:
+      annotations:
+        alb.ingress.kubernetes.io/healthcheck-path: /_health/
+        alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+
+relay:
+  service:
+    annotations:
+      alb.ingress.kubernetes.io/healthcheck-path: /api/relay/healthcheck/ready/
+      alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+```

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -146,7 +146,7 @@ Its also important having `connect_to_reserved_ips: true` in the symbolicator co
 
 ## Example using Terraform and AWS
 
-`templates/values.yaml` file
+`./templates/sentry_values.yaml` file
 
 ```yaml
 prefix: ${module_prefix}
@@ -201,9 +201,9 @@ ingress:
     external-dns.alpha.kubernetes.io/hostname: ${sentry_dns_name}
 ```
 
-`helm.tf` file
+`./helm.tf` file
 
-```hcl
+```terraform
 resource "helm_release" "sentry" {
   name  = "sentry"
   chart = "${path.module}/helm_sentry/"

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -262,3 +262,5 @@ relay:
       alb.ingress.kubernetes.io/healthcheck-path: /api/relay/healthcheck/ready/
       alb.ingress.kubernetes.io/healthcheck-port: traffic-port
 ```
+
+Which are load balancer annotations specified in the service configuration for the load balancer to pick while creating the target groups.

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -263,4 +263,4 @@ relay:
       alb.ingress.kubernetes.io/healthcheck-port: traffic-port
 ```
 
-Which are load balancer annotations specified in the service configuration for the load balancer to pick while creating the target groups.
+Which are load balancer annotations specified in the service configuration for the load balancer to pick-up while creating the target groups.

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -144,7 +144,7 @@ So you would want to create and use a `StorageClass` with a supported volume dri
 
 Its also important having `connect_to_reserved_ips: true` in the symbolicator config file, which this Chart defaults to.
 
-## Example using Terraform and AWS
+# Usage with Terraform + AWS
 
 `./templates/sentry_values.yaml` file
 
@@ -242,7 +242,7 @@ resource "helm_release" "sentry" {
 }
 ```
 
-notes:
+### Notes
 
 1. Ensure the control plane and node security groups are appropriately configured as documented [here](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#control-plane-worker-node-sgs).
 2. Annotations for ingress are as mentioned [here](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/)

--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -3,12 +3,8 @@ kind: Service
 metadata:
   name: {{ template "sentry.fullname" . }}-relay
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
+    {{- range $key, $value := .Values.relay.service.annotations }}
       {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
-      alb.ingress.kubernetes.io/healthcheck-path: "{{ template "relay.healthCheck.requestPath" . }}"
-      alb.ingress.kubernetes.io/healthcheck-port: "{{ template "relay.port" . }}"
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ template "relay.port" . }}":"{{ include "sentry.fullname" . }}-relay"}}'

--- a/sentry/templates/service-sentry.yaml
+++ b/sentry/templates/service-sentry.yaml
@@ -3,12 +3,8 @@ kind: Service
 metadata:
   name: {{ template "sentry.fullname" . }}-web
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
+    {{- range $key, $value := .Values.sentry.web.service.annotations }}
       {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
-      alb.ingress.kubernetes.io/healthcheck-path: "{{ template "sentry.healthCheck.requestPath" . }}"
-      alb.ingress.kubernetes.io/healthcheck-port: "{{ .Values.service.externalPort }}"
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ .Values.service.externalPort }}":"{{ include "sentry.fullname" . }}-web"}}'

--- a/sentry/templates/service-snuba.yaml
+++ b/sentry/templates/service-snuba.yaml
@@ -6,6 +6,9 @@ metadata:
    {{- range $key, $value := .Values.service.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}
+   {{- range $key, $value := .Values.snuba.api.service.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -56,6 +56,8 @@ relay:
   affinity: {}
   nodeSelector: {}
   securityContext: {}
+  service:
+    annotations: {}
   # tolerations: []
   # podLabels: []
 
@@ -83,6 +85,8 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    service:
+      annotations: {}
     # tolerations: []
     # podLabels: []
     # Mount and use custom CA
@@ -219,6 +223,8 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    service:
+      annotations: {}
     # tolerations: []
     # podLabels: []
 


### PR DESCRIPTION
Moving sentry-web service level annotations to `.Values.relay.service.annotations` and sentry-relay service level annotations to `.Values.sentry.web.service.annotations` as per the `aws-load-balancer-controller` [documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/).