### PR TITLE
Relay Health-check liveness endpoint added

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -9,7 +9,8 @@
 
 {{- define "nginx.port" -}}{{ default "8080" .Values.nginx.containerPort }}{{- end -}}
 {{- define "relay.port" -}}3000{{- end -}}
-{{- define "relay.healthCheck.requestPath" -}}/api/relay/healthcheck/ready/{{- end -}}
+{{- define "relay.healthCheck.readinessRequestPath" -}}/api/relay/healthcheck/ready/{{- end -}}
+{{- define "relay.healthCheck.livenessRequestPath" -}}/api/relay/healthcheck/live/{{- end -}}
 {{- define "sentry.port" -}}9000{{- end -}}
 {{- define "sentry.healthCheck.requestPath" -}}/_health/{{- end -}}
 {{- define "snuba.port" -}}1218{{- end -}}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -108,7 +108,7 @@ spec:
         livenessProbe:
           failureThreshold: {{ .Values.relay.probeFailureThreshold }}
           httpGet:
-            path: {{ template "relay.healthCheck.requestPath" }}
+            path: {{ template "relay.healthCheck.livenessRequestPath" }}
             port: {{ template "relay.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}
@@ -118,7 +118,7 @@ spec:
         readinessProbe:
           failureThreshold: {{ .Values.relay.probeFailureThreshold }}
           httpGet:
-            path: {{ template "relay.healthCheck.requestPath" }}
+            path: {{ template "relay.healthCheck.readinessRequestPath" }}
             port: {{ template "relay.port" }}
             scheme: HTTP
           initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}

--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -7,7 +7,7 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
-      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "{{ template "relay.healthCheck.requestPath" . }}"
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "{{ template "relay.healthCheck.readinessRequestPath" . }}"
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "{{ template "relay.port" . }}"
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}

--- a/sentry/templates/service-relay.yaml
+++ b/sentry/templates/service-relay.yaml
@@ -3,12 +3,8 @@ kind: Service
 metadata:
   name: {{ template "sentry.fullname" . }}-relay
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
+    {{- range $key, $value := .Values.relay.service.annotations }}
       {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "aws-alb") }}
-      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "{{ template "relay.healthCheck.readinessRequestPath" . }}"
-      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "{{ template "relay.port" . }}"
     {{- end }}
     {{- if and (.Values.ingress.enabled) (eq (default "nginx" .Values.ingress.regexPathStyle) "gke") }}
       cloud.google.com/backend-config: '{"ports": {"{{ template "relay.port" . }}":"{{ include "sentry.fullname" . }}-relay"}}'


### PR DESCRIPTION
Accroding to Sentry relay [documentation](https://docs.sentry.io/product/relay/monitoring/#health-checks), there are two endpoints provided for relay health-check. Only .../ready endpoint was being called in both K8S Liveness probe and Readiness probe. So, why not use both provided endpoints...!