### PR TITLE
suppot partitions parameter for consumer events

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 13.0.1
+version: 13.1.0
 appVersion: 21.8.0
 dependencies:
   - name: redis

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 13.0.2
+version: 13.0.1
 appVersion: 21.8.0
 dependencies:
   - name: redis

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 13.0.1
+version: 13.0.2
 appVersion: 21.8.0
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -67,6 +67,7 @@ spec:
         command:
           - "snuba"
           - "subscriptions"
+          - "--partitions={{ .Values.snuba.subscriptionConsumerEvents.partitions}}"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
           - "--consumer-group=snuba-events-subscriptions-consumers"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -314,6 +314,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    partitions: 1
 
   subscriptionConsumerTransactions:
     replicas: 1


### PR DESCRIPTION
refs: https://forum.sentry.io/t/perfomance-metric-alarm-related-to-snuba-events-subscriptions-consumers-snuba-transactions-subscriptions-consumers/15102

Hi!
sentry-snuba-subscription-consumer-events expect partition of kafka topic is 1,but kafka should has some partition if you want to fault tolerance.
So I add paramter for kafka partition.
thanks.