### PR TITLE
Correct Indentation Level - Db Init Job

### DIFF
--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -71,7 +71,7 @@ spec:
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
         {{- if .Values.hooks.dbInit.env }}
-{{ toYaml .Values.hooks.dbInit.env | indent 10 }}
+{{ toYaml .Values.hooks.dbInit.env | indent 8 }}
         {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry


### PR DESCRIPTION
When using a env var with the sentry-db-init job, helm throws the error:

```
Error: YAML parse error on sentry/templates/hooks/sentry-db-init.job.yaml: error converting YAML to JSON: yaml: line 37: did not find expected key
```

This pr resolves this problem.