### PR TITLE
deploy replica services only when replica is deployed

### DIFF
--- a/clickhouse/templates/svc-clickhouse-replica-headless.yaml
+++ b/clickhouse/templates/svc-clickhouse-replica-headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -24,3 +25,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "clickhouse.name" . }}-replica
     app.kubernetes.io/instance: {{ .Release.Name }}-replica
+{{- end }}

--- a/clickhouse/templates/svc-clickhouse-replica-metrics.yaml
+++ b/clickhouse/templates/svc-clickhouse-replica-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
 {{- if .Values.clickhouse.metrics.enabled }}
 apiVersion: v1
 kind: Service
@@ -25,5 +26,5 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "clickhouse.name" . }}-replica
     app.kubernetes.io/instance: {{ .Release.Name }}-replica
----
+{{- end }}
 {{- end }}

--- a/clickhouse/templates/svc-clickhouse-replica.yaml
+++ b/clickhouse/templates/svc-clickhouse-replica.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "clickhouse.name" . }}-replica
     app.kubernetes.io/instance: {{ .Release.Name }}-replica
+{{- end }}


### PR DESCRIPTION
this removes all clickhouse-replica services if the replica statefulset is not deployed.

we monitor services with no endpoints, this would prevent deploying services that are neither used nor have any targets.