### PR TITLE
Pass external postgres password to cleanup job

### DIFF
--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -72,6 +72,9 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
                   key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
+            {{- else if .Values.externalPostgresql.password }}
+            - name: POSTGRES_PASSWORD
+              value: {{ include "sentry.postgresql.password" . | quote }}
             {{- end }}
             {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
I noticed that external postgres password is passed to sentry configmap, but not to sentry cleanup job. This PR adds this possibility if the password is set in values file