### PR TITLE
Fix deprecated api`s version batch/v1beta1

### DIFF
--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sentry.cleanup.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry-cleanup

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.snuba.cleanupErrors.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba-cleanup-errors

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.snuba.cleanupTransactions.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba-cleanup-transactions


### PR DESCRIPTION
Helm 3.8 lint says: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob