### PR TITLE
Moving single_node definition outside cluster block

### DIFF
--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -44,8 +44,12 @@ data:
             "errors_v2_ro",
             "profiles",
         },
-        {{- if or .Values.clickhouse.enabled (not .Values.externalClickhouse.singleNode) }}
+        {{- if .Values.externalClickhouse.singleNode }}
+        "single_node": True,
+        {{- else }}
         "single_node": False,
+        {{- end }}
+        {{- if or .Values.clickhouse.enabled (not .Values.externalClickhouse.singleNode) }}
         "cluster_name": {{ include "sentry.clickhouse.cluster.name" . | quote }},
         "distributed_cluster_name": {{ include "sentry.clickhouse.cluster.name" . | quote }},
         {{- end }}


### PR DESCRIPTION
Hello. I get a error when trying deploy sentry with external non-clusterized ClickHouse. My sentry-snuba-api pod becomes into crashLoopBack state with message:
```
./docker_entrypoint.sh: line 15: exec: api: not found
```
So, if I will try exec `scuba --help` command in pod container, I will see:
```
root@sentry-snuba-api-5cd7bc4d7-rlbmq:/usr/src/snuba# snuba --help
Traceback (most recent call last):
  File "/usr/local/bin/snuba", line 33, in <module>
    sys.exit(load_entry_point('snuba', 'console_scripts', 'snuba')())
  File "/usr/local/bin/snuba", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/src/snuba/snuba/cli/__init__.py", line 21, in <module>
    module = __import__(module_name, globals(), locals(), ["__name__"])
  File "/usr/src/snuba/snuba/cli/bootstrap.py", line 9, in <module>
    from snuba.migrations.connect import check_clickhouse_connections
  File "/usr/src/snuba/snuba/migrations/connect.py", line 7, in <module>
    from snuba.clusters.cluster import ClickhouseClientSettings, CLUSTERS
  File "/usr/src/snuba/snuba/clusters/cluster.py", line 330, in <module>
    CLUSTERS = [
  File "/usr/src/snuba/snuba/clusters/cluster.py", line 339, in <listcomp>
    single_node=cluster["single_node"],
KeyError: 'single_node'
root@sentry-snuba-api-5cd7bc4d7-rlbmq:/usr/src/snuba#
```
This patch fixed behaviour for me.