### PR TITLE
#388 fix metric alerts

### DIFF
--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -74,7 +74,7 @@ spec:
           - "--result-topic=transactions-subscription-results"
           - "--dataset=transactions"
           - "--commit-log-topic=snuba-commit-log"
-          - "--commit-log-group=snuba-transactions-consumers"
+          - "--commit-log-group=transactions_group"
           - "--delay-seconds=60"
           - "--schedule-ttl=60"
         ports:


### PR DESCRIPTION
This fixed the metrics alerts for us.
Fix is based on the official docker-compose distro
* https://github.com/getsentry/self-hosted/blob/master/docker-compose.yml#L252

PR inspired by
* https://github.com/sentry-kubernetes/charts/pull/574