### PR TITLE
fix: the default clickhouse installation is distributed, only turn on single node when clickhouse is disabled

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 14.1.0
+version: 14.1.1
 appVersion: 22.5.0
 dependencies:
   - name: redis

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -44,7 +44,11 @@ data:
             "errors_v2_ro",
             "profiles",
         },
-        {{- if .Values.externalClickhouse.singleNode }}
+        {{- /*
+          The default clickhouse installation runs in distributed mode, while the external
+          clickhouse configured can be configured any way you choose
+        */}}
+        {{- if and .Values.externalClickhouse.singleNode (not .Values.clickhouse.enabled) }}
         "single_node": True,
         {{- else }}
         "single_node": False,


### PR DESCRIPTION
We went through an upgrade of sentry today and ran into a large bug when running snuba migrations where the migrations failed to run or recognize that any earlier migrations had been run.

After looking into it further, we found that this diff was being applied to our snuba settings:
```
         },
-         "single_node": False,
+         "single_node": True,
           "cluster_name": "sentry-clickhouse",
          "distributed_cluster_name": "sentry-clickhouse",
        },
```

This is very bad for us as we are running the default clickhouse installation with the chart which runs in distributed mode _not_ single node mode. Swapping the value back to False in the configmap allowed the migrations to run and the upgrade to complete.

This PR honors the promise made in the `values.yaml` that the `externalClickhouse` values will _only_ be used if `clickhouse.enabled` is set to `false`.