### PR TITLE
Allow install clickhouse with external zookeeper

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
   - name: zookeeper
     repository: https://charts.bitnami.com/bitnami
     version: 9.0.0
-    condition: clickhouse.enabled,zookeeper.enabled
+    condition: zookeeper.enabled
   - name: rabbitmq
     repository: https://charts.bitnami.com/bitnami
     version: 8.9.1


### PR DESCRIPTION
Helm evaluates conditions by first seen instead of logical AND. If user wants to install clickhouse with external zookeeper, it wasn't possible to disable zookeeper installation by setting `zookeeper.enabled: false`, because `clickhouse.enabled: true` was evaluated first.

By dropping `clickhouse.enabled` from condition, zookeeper can be disabled as expected by setting `zookeeper.enabled: false`.

Backward compatibility is preserved, as default values already define `zookeeper.enabled: true`.