### PR TITLE
Update symbolicator to 0.5.0

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -29,7 +29,7 @@ images:
     imagePullSecrets: []
   symbolicator:
     # repository: getsentry/symbolicator
-    tag: 0.3.4
+    tag: 0.5.0
     # pullPolicy: IfNotPresent
     imagePullSecrets: []
 


### PR DESCRIPTION
It's correct version that should be used with sentry 22.5.0, see https://github.com/getsentry/self-hosted/blob/22.5.0/.env#L11.