### PR TITLE
Partition count for subscription consumer transactions

### DIFF
--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -67,6 +67,7 @@ spec:
         command:
           - "snuba"
           - "subscriptions"
+          - "--partitions={{ .Values.snuba.subscriptionConsumerTransactions.partitions }}"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
           - "--consumer-group=snuba-transactions-subscriptions-consumers"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -326,6 +326,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    partitions: 1
 
   sessionsConsumer:
     replicas: 1


### PR DESCRIPTION
snuba-subscription-consumer-transactions requires same fix as #566 when running with partitioned topic.