### PR TITLE
(fix) Update the snuba transactions consumer to use a commit log topic

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 14.1.0
+version: 14.1.1
 appVersion: 22.5.0
 dependencies:
   - name: redis

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -78,6 +78,8 @@ spec:
           - "transactions"
           - "--consumer-group"
           - "transactions_group"
+          - "--commit-log-topic"
+          - "snuba-commit-log"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.transactionsConsumer.autoOffsetReset }}"
           - "--max-batch-time-ms"


### PR DESCRIPTION
This PR brings the commands used for snuba-transactions-consumer up to date with the sentry on-premise docker-compose commands: https://github.com/getsentry/self-hosted/blob/master/docker-compose.yml#L247