### PR TITLE
Add securityContext to all hooks

### DIFF
--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -53,6 +53,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.hooks.dbCheck.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       containers:
       - name: db-check
         image: {{ template "dbCheck.image" . }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -57,6 +57,10 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       containers:
       - name: db-init-job
         image: "{{ template "sentry.image" . }}"

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -59,6 +59,10 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       containers:
       - name: snuba-init
         image: "{{ template "snuba.image" . }}"

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -59,6 +59,10 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       containers:
       - name: snuba-migrate
         image: "{{ template "snuba.image" . }}"

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -47,6 +47,10 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       containers:
       - name: user-create-job
         image: "{{ template "sentry.image" . }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -419,6 +419,7 @@ hooks:
         memory: 64Mi
     affinity: {}
     nodeSelector: {}
+    securityContext: {}
     # tolerations: []
   dbInit:
     env: []


### PR DESCRIPTION
allows to run hook jobs with "restricted" PodSecurityPolicy