### PR TITLE
Add snuba.api.command variable to prevent issues with gosu (#67)

### DIFF
--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -64,6 +64,10 @@ spec:
       - name: {{ .Chart.Name }}-snuba
         image: "{{ template "snuba.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
+      {{- if .Values.snuba.api.command }}
+        command:
+{{ toYaml .Values.snuba.api.command | indent 8 }}
+      {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -214,6 +214,11 @@ sentry:
 snuba:
   api:
     replicas: 1
+    # set command to ["snuba","api"] if securityContext.runAsUser > 0
+    # see: https://github.com/getsentry/snuba/issues/956
+    command: {}
+    #   - snuba
+    #   - api
     env: []
     probeInitialDelaySeconds: 10
     liveness:


### PR DESCRIPTION
Fixes the problem that the default entrypoint of snuba-api (`gosu snuba snuba api`) doesn't work if `securityContext.runAsUser` is set.

see: https://github.com/getsentry/snuba/issues/956