### PR TITLE
Clickhouse and podsecuritypolicy

### DIFF
--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -74,9 +74,7 @@ spec:
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}
         imagePullPolicy: {{ .Values.clickhouse.imagePullPolicy }}
         command:
-          - /bin/bash
-          - -c
-          - export SHARD=${HOSTNAME##*-} && /entrypoint.sh
+{{ toYaml .Values.clickhouse.command | indent 10 }}
         ports:
         - name: http-port
           containerPort: {{ .Values.clickhouse.http_port | default "8123" }}

--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -65,19 +65,10 @@ spec:
       - name: {{ . | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.clickhouse.initContainers }}
       initContainers:
-      - name: init
-        image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
-        imagePullPolicy: {{ .Values.clickhouse.init.imagePullPolicy }}
-        args:
-        - /bin/sh
-        - -c
-        - |
-          mkdir -p /etc/clickhouse-server/metrica.d
-        {{- if .Values.clickhouse.init.resources }}
-        resources:
-{{ toYaml .Values.clickhouse.init.resources | indent 10 }}
-        {{- end }}
+{{ toYaml .Values.clickhouse.initContainers | indent 6 }}
+    {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}-replica
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -64,19 +64,10 @@ spec:
       - name: {{ . | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.clickhouse.initContainers }}
       initContainers:
-      - name: init
-        image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
-        imagePullPolicy: {{ .Values.clickhouse.init.imagePullPolicy }}
-        args:
-        - /bin/sh
-        - -c
-        - |
-          mkdir -p /etc/clickhouse-server/metrica.d
-        {{- if .Values.clickhouse.init.resources }}
-        resources:
-{{ toYaml .Values.clickhouse.init.resources | indent 10 }}
-        {{- end }}
+{{ toYaml .Values.clickhouse.initContainers | indent 6 }}
+    {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -73,9 +73,7 @@ spec:
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}
         imagePullPolicy: {{ .Values.clickhouse.imagePullPolicy }}
         command:
-          - /bin/bash
-          - -c
-          - export SHARD=${HOSTNAME##*-} && /entrypoint.sh
+{{ toYaml .Values.clickhouse.command | indent 10 }}
         ports:
         - name: http-port
           containerPort: {{ .Values.clickhouse.http_port | default "8123" }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -56,6 +56,26 @@ clickhouse:
   # Security Context
   securityContext: {}
 
+  # Command
+  #
+  # clickhouse < 21.2 entrypoint checks if /var/lib/clickhouse is owned by the clickhouse user
+  # but kubernetes only allows to control the filesystem group - the owner will always be "root"
+  #
+  # the permission check can be dropped with this workaround:
+  #
+  # command:
+  #   - /bin/bash
+  #   - -c
+  #   - |
+  #     export SHARD=${HOSTNAME##*-}
+  #     cp /entrypoint.sh /tmp/entrypoint.sh
+  #     sed -i '/elif [ "$(stat -c %u "$dir")" != "$USER" ]/,+2d' /tmp/entrypoint.sh
+  #     /tmp/entrypoint.sh
+  command:
+    - /bin/bash
+    - -c
+    - export SHARD=${HOSTNAME##*-} && /entrypoint.sh
+
   ## Prometheus Exporter / Metrics
   ##
   metrics:

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -129,14 +129,10 @@ clickhouse:
   ## The resource limits and requests used by clickhouse
   resources: {}
 
-  init:
-    image: "busybox"
-    imageVersion: "1.31.0"
-    imagePullPolicy: "IfNotPresent"
-  # imagePullSecrets:
+  initContainers: []
+
   ## Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated.
   ## More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-    resources: {}
   livenessProbe:
     enabled: true
     initialDelaySeconds: "30"


### PR DESCRIPTION
my approach to solve the PodSecurityPolicies issues described in #67:
* remove the existing init container (#609)
* introduction of `clickhouse.command` helm value so ppl can use their own hacks to disable the directory-ownership-check present in the entrypoint script of <21.2 clickhouse images
* add `clickhouse.initContainers` in case anyone needs it