### PR TITLE
Sentry 22.6.0

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry
 description: A Helm chart for Kubernetes
 type: application
 version: 14.1.2
-appVersion: 22.5.0
+appVersion: 22.6.0
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -43,6 +43,8 @@ data:
             "errors_v2",
             "errors_v2_ro",
             "profiles",
+            "replays",
+            "generic_metrics_sets",
         },
         {{- /*
           The default clickhouse installation runs in distributed mode, while the external

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -66,18 +66,17 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
         command:
           - "snuba"
-          - "subscriptions"
+          - "subscriptions-scheduler-executor"
           - "--partitions={{ .Values.snuba.subscriptionConsumerEvents.partitions}}"
-          - "--auto-offset-reset"
-          - "{{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
-          - "--consumer-group=snuba-events-subscriptions-consumers"
-          - "--topic=events"
-          - "--result-topic=events-subscription-results"
+          - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
           - "--dataset=events"
-          - "--commit-log-topic=snuba-commit-log"
-          - "--commit-log-group=snuba-consumers"
+          - "--entity=events"
+          - "--no-strict-offset-reset"
+          - "--consumer-group=snuba-events-subscriptions-consumers"
+          - "--followed-consumer-group=snuba-consumers"
           - "--delay-seconds=60"
           - "--schedule-ttl=60"
+          - "--stale-threshold-seconds=900"
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -67,7 +67,6 @@ spec:
         command:
           - "snuba"
           - "subscriptions-scheduler-executor"
-          - "--partitions={{ .Values.snuba.subscriptionConsumerEvents.partitions}}"
           - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
           - "--dataset=events"
           - "--entity=events"

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -67,7 +67,6 @@ spec:
         command:
           - "snuba"
           - "subscriptions-scheduler-executor"
-          - "--partitions={{ .Values.snuba.subscriptionConsumerTransactions.partitions }}"
           - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
           - "--dataset=transactions"
           - "--entity=transactions"

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -66,18 +66,17 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
         command:
           - "snuba"
-          - "subscriptions"
+          - "subscriptions-scheduler-executor"
           - "--partitions={{ .Values.snuba.subscriptionConsumerTransactions.partitions }}"
-          - "--auto-offset-reset"
-          - "{{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
-          - "--consumer-group=snuba-transactions-subscriptions-consumers"
-          - "--topic=events"
-          - "--result-topic=transactions-subscription-results"
+          - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
           - "--dataset=transactions"
-          - "--commit-log-topic=snuba-commit-log"
-          - "--commit-log-group=transactions_group"
+          - "--entity=transactions"
+          - "--no-strict-offset-reset"
+          - "--consumer-group=snuba-transactions-subscriptions-consumers"
+          - "--followed-consumer-group=transactions_group"
           - "--delay-seconds=60"
           - "--schedule-ttl=60"
+          - "--stale-threshold-seconds=900"
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -35,7 +35,7 @@ images:
     imagePullSecrets: []
   symbolicator:
     # repository: getsentry/symbolicator
-    tag: 0.5.0
+    tag: 0.5.1
     # pullPolicy: IfNotPresent
     imagePullSecrets: []
 

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -325,7 +325,6 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
-    partitions: 1
 
   subscriptionConsumerTransactions:
     replicas: 1
@@ -337,7 +336,6 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
-    partitions: 1
 
   sessionsConsumer:
     replicas: 1


### PR DESCRIPTION
Ref:
- https://github.com/sentry-kubernetes/charts/issues/647
- https://github.com/getsentry/self-hosted/pull/1507
- https://github.com/getsentry/self-hosted/commit/eaed29a058c3b7769cc777cd8ef1100cec5b80d7

@Mokto I didn't update chart version, so there won't be a conflict with other PRs, like #639 and #581.

Also I would appreciate some additional testing, as my deployment is quite specific where only sentry and clickhouse are deployed via chart, rest of dependencies are externalized.