### PR TITLE
fixed re-generation of secret key

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.0
+version: 15.0.1
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.2.2
+version: 15.2.3
 appVersion: 22.8.0
 dependencies:
   - name: memcached

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.2.3
+version: 16.0.0
 appVersion: 22.8.0
 dependencies:
   - name: memcached

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -63,7 +63,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | `serviceAccount.enabled`                      | If `true`, a custom Service Account will be used.                                                                                                                   | `false`                        |
 | `serviceAccount.name`                         | The base name of the ServiceAccount to use. Will be appended with e.g. `snuba` or `web` for the pods accordingly.                                                   | `"sentry"`                     |
 | `serviceAccount.automountServiceAccountToken` | Automount API credentials for a Service Account.                                                                                                                    | `true`                         |
-| `system.secretKey`                            | secret key for the session cookie ([documentation](https://develop.sentry.dev/config/#general))                                                                     | `nil`                          |
+| `sentry.existingSecret`                       | Existing kubernetes secret to be used for secret key for the session cookie ([documentation](https://develop.sentry.dev/config/#general))                                                                     | `nil`                          |
 | `sentry.features.vstsLimitedScopes`           | Disables the azdo-integrations with limited scopes that is the cause of so much pain                                                                                | `true`                         |
 | `sentry.web.customCA.secretName`              | Allows mounting a custom CA secret                                                                                                                                  | `nil`                          |
 | `sentry.web.customCA.item`                    | Key of CA cert object within the secret                                                                                                                             | `ca.crt`                       |
@@ -76,11 +76,10 @@ By default, NGINX is enabled to allow sending the incoming requests to [Sentry R
 
 ## Sentry secret key
 
-For your security, the [`system.secret-key`](https://develop.sentry.dev/config/#general) is generated for you on the first installation. Another one will be regenerated on each upgrade invalidating all the current sessions unless it's been provided. The value is stored in the `sentry-sentry` configmap.
+If no `sentry.existingSecret` value is specified, for your security, the [`system.secret-key`](https://develop.sentry.dev/config/#general) is generated for you on the first installation and stored in a kubernetes secret.
 
-```
-helm upgrade ... --set system.secretKey=xx
-```
+If `sentry.existingSecret` / `sentry.existingSecretKey` values are provided, those secrets will be used.
+
 
 ## Symbolicator and or JavaScript source maps
 

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -15,7 +15,6 @@ data:
     {{- if .Values.system.adminEmail }}
     system.admin-email: {{ .Values.system.adminEmail | quote }}
     {{- end }}
-    system.secret-key: {{ .Values.system.secretKey | default (randAlphaNum 50) | quote }}
     {{- if .Values.system.url }}
     system.url-prefix: {{ .Values.system.url | quote }}
     {{- end }}
@@ -163,6 +162,13 @@ data:
     ###########
     # General #
     ###########
+
+
+    secret_key = env('SENTRY_SECRET_KEY')
+    if not secret_key:
+      raise Exception('Error: SENTRY_SECRET_KEY is undefined')
+
+    SENTRY_OPTIONS['system.secret-key'] = secret_key
 
     # Instruct Sentry that this install intends to be run by a single organization
     # and thus various UI optimizations should be enabled.

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -66,6 +66,19 @@ spec:
               value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
             - name: C_FORCE_ROOT
               value: "true"
+            {{- if .Values.sentry.existingSecret }}
+            - name: SENTRY_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sentry.existingSecret }}
+                  key: {{ default "key" .Values.sentry.existingSecretKey }}
+            {{- else }}
+            - name: SENTRY_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "sentry.fullname" . }}-sentry-secret
+                  key: "key"
+            {{- end }}
             {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -70,6 +70,19 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         - name: C_FORCE_ROOT
           value: "true"
         {{- if .Values.postgresql.enabled }}

--- a/sentry/templates/deployment-sentry-ingest-consumer.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer.yaml
@@ -92,6 +92,19 @@ spec:
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
         - name: C_FORCE_ROOT
           value: "true"
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/sentry/templates/deployment-sentry-post-process-forwarder.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder.yaml
@@ -76,6 +76,19 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
@@ -76,6 +76,19 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
@@ -76,6 +76,19 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -73,6 +73,19 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -76,6 +76,19 @@ spec:
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         - name: C_FORCE_ROOT
           value: "true"
         {{- if .Values.postgresql.enabled }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -67,6 +67,19 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         command: ["sentry","upgrade","--noinput"]
         env:
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/sentry/templates/hooks/sentry-secret-create.yaml
+++ b/sentry/templates/hooks/sentry-secret-create.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.sentry.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-secret
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  key: {{ randAlphaNum 50 | b64enc | quote }}
+{{- end -}}

--- a/sentry/templates/hooks/sentry-secret-create.yaml
+++ b/sentry/templates/hooks/sentry-secret-create.yaml
@@ -8,6 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
+    "helm.sh/hook-weight": "3"
 type: Opaque
 data:
   key: {{ randAlphaNum 50 | b64enc | quote }}

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -71,6 +71,19 @@ spec:
               exit 1; \
             fi
         env:
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
         {{- if .Values.user.existingSecret }}
         - name: ADMIN_PASSWORD
           valueFrom:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -7,7 +7,7 @@ user:
 
   ## set this value to an existingSecret name to create the admin user with the password in the secret
   # existingSecret: sentry-admin-password
-  
+
   ## set this value to an existingSecretKey which holds the password to be used for sentry admin user default key is `admin-password`
   # existingSecretKey: admin-password
 
@@ -572,7 +572,7 @@ nginx:
   replicaCount: 1
   service:
     type: ClusterIP
-    ports: 
+    ports:
       http: 80
   ## Use this to enable an extra service account
   # serviceAccount:
@@ -748,7 +748,7 @@ kafka:
   socketRequestMaxBytes: "50000000"
 
   service:
-    ports: 
+    ports:
       client: 9092
 
   ## Use this to enable an extra service account

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -77,8 +77,8 @@ relay:
 
 sentry:
   # to not generate a sentry-secret, use these 2 values to reference an existing secret
-  #existingSecret: "my-secret"
-  #existingSecretKey: "my-secret-key"
+  # existingSecret: "my-secret"
+  # existingSecretKey: "my-secret-key"
   singleOrganization: true
   web:
     # if using filestore backend filesystem with RWO access, set strategyType to Recreate

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -76,6 +76,9 @@ relay:
   volumes: []
 
 sentry:
+  # to not generate a sentry-secret, use these 2 values to reference an existing secret
+  #existingSecret: "my-secret"
+  #existingSecretKey: "my-secret-key"
   singleOrganization: true
   web:
     # if using filestore backend filesystem with RWO access, set strategyType to Recreate


### PR DESCRIPTION
This PR uses the [environment variable](https://github.com/thinkingmachines/sentry-onpremise/blob/master/sentry.conf.py#L286) mechanism to load the secret key and avoids using `randAlphaNum` secret-key generation, which breaks workflows with tools like argocd. 

Instead, it makes it possible to either use an existing secret for the sentry `secret-key`, or generate one as a helm hook.

