### PR TITLE
Feat: configurable service account for snuba deployments

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.1
+version: 15.0.3
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -108,7 +108,7 @@ spec:
 {{ toYaml .Values.snuba.api.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.api.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -128,7 +128,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.consumer.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.consumer.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -124,7 +124,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.outcomesConsumer.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.outcomesConsumer.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -109,7 +109,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.replacer.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.replacer.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -128,7 +128,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.sessionsConsumer.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.sessionsConsumer.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -93,7 +93,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.subscriptionConsumerEvents.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -93,7 +93,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.subscriptionConsumerTransactions.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -130,7 +130,7 @@ spec:
         resources:
 {{ toYaml .Values.snuba.transactionsConsumer.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ or .Values.snuba.transactionsConsumer.serviceAccount.name (printf "%s-snuba" .Values.serviceAccount.name) }}
       {{- end }}
       volumes:
         - name: config

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -252,6 +252,7 @@ snuba:
       targetCPUUtilizationPercentage: 50
     sidecars: []
     volumes: []
+    serviceAccount: {}
 
   consumer:
     replicas: 1
@@ -278,6 +279,7 @@ snuba:
     #   - name: dshm
     #     emptyDir:
     #       medium: Memory
+    serviceAccount: {}
 
   outcomesConsumer:
     replicas: 1
@@ -304,6 +306,7 @@ snuba:
     #   - name: dshm
     #     emptyDir:
     #       medium: Memory
+    serviceAccount: {}
 
   replacer:
     replicas: 1
@@ -319,6 +322,7 @@ snuba:
     # maxBatchTimeMs: ""
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    serviceAccount: {}
 
   subscriptionConsumerEvents:
     replicas: 1
@@ -330,6 +334,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    serviceAccount: {}
 
   subscriptionConsumerTransactions:
     replicas: 1
@@ -341,6 +346,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    serviceAccount: {}
 
   sessionsConsumer:
     replicas: 1
@@ -367,6 +373,7 @@ snuba:
     #   - name: dshm
     #     emptyDir:
     #       medium: Memory
+    serviceAccount: {}
 
   transactionsConsumer:
     replicas: 1
@@ -393,6 +400,7 @@ snuba:
     #   - name: dshm
     #     emptyDir:
     #       medium: Memory
+    serviceAccount: {}
 
   dbInitJob:
     env: []


### PR DESCRIPTION
Currently there is no option to configure service account for individual snuba apps, they all use the same name 'sentry-snuba'. This makes it difficult when these pods try to access external services in Consul mesh.
By adding configurable service account, this allows customizability for individual needs.