### PR TITLE
Feat: add service account names for cronjobs

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.4
+version: 15.0.2
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.1
+version: 15.0.4
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -126,4 +126,7 @@ spec:
           {{- if .Values.sentry.cleanup.priorityClassName }}
           priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"
           {{- end }}
+          {{- if .Values.sentry.cleanup.serviceAccount }}
+          serviceAccountName: {{ .Values.sentry.cleanup.serviceAccount.name }}
+          {{- end }}
 {{- end }}

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -95,4 +95,7 @@ spec:
           {{- if .Values.snuba.cleanupErrors.priorityClassName }}
           priorityClassName: "{{ .Values.snuba.cleanupErrors.priorityClassName }}"
           {{- end }}
+          {{- if .Values.snuba.cleanupErrors.serviceAccount }}
+          serviceAccountName: {{ .Values.snuba.cleanupErrors.serviceAccount.name }}
+          {{- end }}
 {{- end }}

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -95,4 +95,7 @@ spec:
           {{- if .Values.snuba.cleanupTransactions.priorityClassName }}
           priorityClassName: "{{ .Values.snuba.cleanupTransactions.priorityClassName }}"
           {{- end }}
+          {{- if .Values.snuba.cleanupTransactions.serviceAccount }}
+          serviceAccountName: {{ .Values.snuba.cleanupTransactions.serviceAccount.name }}
+          {{- end }}
 {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -221,6 +221,7 @@ sentry:
     days: 90
     sidecars: []
     volumes: []
+    serviceAccount: {}
 
 snuba:
   api:
@@ -406,6 +407,7 @@ snuba:
     schedule: "0 * * * *"
     sidecars: []
     volumes: []
+    serviceAccount: {}
 
   cleanupTransactions:
     concurrencyPolicy: Allow
@@ -413,6 +415,7 @@ snuba:
     schedule: "0 * * * *"
     sidecars: []
     volumes: []
+    serviceAccount: {}
 
 hooks:
   enabled: true


### PR DESCRIPTION
Adding an option to provide service account name to cronjobs allows for more customizability.
It allows users to create service accounts if required. 

The current use case is to allow these jobs to register in consul mesh, so that they can access external resources in the mesh like redis, kafka etc...