### PR TITLE
feat: history limits for cronjobs

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.1
+version: 15.0.3
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -10,6 +10,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   schedule: "{{ .Values.sentry.cleanup.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.sentry.cleanup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.sentry.cleanup.failedJobsHistoryLimit }}
   concurrencyPolicy: "{{ .Values.sentry.cleanup.concurrencyPolicy }}"
   jobTemplate:
     spec:

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -10,6 +10,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   schedule: "{{ .Values.snuba.cleanupErrors.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.snuba.cleanupErrors.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.snuba.cleanupErrors.failedJobsHistoryLimit }}
   concurrencyPolicy: "{{ .Values.snuba.cleanupErrors.concurrencyPolicy }}"
   jobTemplate:
     spec:

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -10,6 +10,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   schedule: "{{ .Values.snuba.cleanupTransactions.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.snuba.cleanupTransactions.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.snuba.cleanupTransactions.failedJobsHistoryLimit }}
   concurrencyPolicy: "{{ .Values.snuba.cleanupTransactions.concurrencyPolicy }}"
   jobTemplate:
     spec:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -215,6 +215,8 @@ sentry:
     sidecars: []
     volumes: []
   cleanup:
+    successfulJobsHistoryLimit: 5
+    failedJobsHistoryLimit: 5
     concurrencyPolicy: Allow
     enabled: true
     schedule: "0 0 * * *"
@@ -401,6 +403,8 @@ snuba:
     env: []
 
   cleanupErrors:
+    successfulJobsHistoryLimit: 5
+    failedJobsHistoryLimit: 5
     concurrencyPolicy: Allow
     enabled: true
     schedule: "0 * * * *"
@@ -408,6 +412,8 @@ snuba:
     volumes: []
 
   cleanupTransactions:
+    successfulJobsHistoryLimit: 5
+    failedJobsHistoryLimit: 5
     concurrencyPolicy: Allow
     enabled: true
     schedule: "0 * * * *"


### PR DESCRIPTION
Adding customizability to cronjobs history limits gives us more flexibility during debugging.

The initial values are set to 5 for each respectively, this would allow more logs to be stored. Which could help in debugging.