### PR TITLE
feat: specifying deadline for jobs and cronjobs

### DIFF
--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -13,6 +13,9 @@ spec:
   concurrencyPolicy: "{{ .Values.sentry.cleanup.concurrencyPolicy }}"
   jobTemplate:
     spec:
+      {{- if .Values.sentry.cleanup.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.sentry.cleanup.activeDeadlineSeconds }}
+      {{- end}}
       template:
         metadata:
           annotations:

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -13,6 +13,9 @@ spec:
   concurrencyPolicy: "{{ .Values.snuba.cleanupErrors.concurrencyPolicy }}"
   jobTemplate:
     spec:
+      {{- if .Values.snuba.cleanupErrors.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.snuba.cleanupErrors.activeDeadlineSeconds }}
+      {{- end}}
       template:
         metadata:
           annotations:

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -13,6 +13,9 @@ spec:
   concurrencyPolicy: "{{ .Values.snuba.cleanupTransactions.concurrencyPolicy }}"
   jobTemplate:
     spec:
+      {{- if .Values.snuba.cleanupTransactions.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.snuba.cleanupTransactions.activeDeadlineSeconds }}
+      {{- end}}
       template:
         metadata:
           annotations:

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -19,6 +19,9 @@ metadata:
     "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
     "helm.sh/hook-weight": "-1"
 spec:
+  {{- if .Values.hooks.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.hooks.activeDeadlineSeconds }}
+  {{- end}}
   template:
     metadata:
       name: {{ template "sentry.fullname" . }}-db-check

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -15,6 +15,9 @@ metadata:
     "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
     "helm.sh/hook-weight": "6"
 spec:
+  {{- if .Values.hooks.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.hooks.activeDeadlineSeconds }}
+  {{- end}}
   template:
     metadata:
       name: {{ template "sentry.fullname" . }}-db-init

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -16,6 +16,9 @@ metadata:
     "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
     "helm.sh/hook-weight": "3"
 spec:
+  {{- if .Values.hooks.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.hooks.activeDeadlineSeconds }}
+  {{- end}}
   template:
     metadata:
       name: {{ template "sentry.fullname" . }}-snuba-db-init

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -16,6 +16,9 @@ metadata:
     "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
     "helm.sh/hook-weight": "5"
 spec:
+  {{- if .Values.hooks.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.hooks.activeDeadlineSeconds }}
+  {{- end}}
   template:
     metadata:
       name: {{ template "sentry.fullname" . }}-snuba-migrate

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -13,6 +13,9 @@ metadata:
     "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
     "helm.sh/hook-weight": "9"
 spec:
+  {{- if .Values.hooks.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.hooks.activeDeadlineSeconds }}
+  {{- end}}
   template:
     metadata:
       name: {{ template "sentry.fullname" . }}-user-create

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -215,6 +215,7 @@ sentry:
     sidecars: []
     volumes: []
   cleanup:
+    activeDeadlineSeconds: 100
     concurrencyPolicy: Allow
     enabled: true
     schedule: "0 0 * * *"
@@ -401,6 +402,7 @@ snuba:
     env: []
 
   cleanupErrors:
+    activeDeadlineSeconds: 100
     concurrencyPolicy: Allow
     enabled: true
     schedule: "0 * * * *"
@@ -408,6 +410,7 @@ snuba:
     volumes: []
 
   cleanupTransactions:
+    activeDeadlineSeconds: 100
     concurrencyPolicy: Allow
     enabled: true
     schedule: "0 * * * *"
@@ -417,6 +420,7 @@ snuba:
 hooks:
   enabled: true
   removeOnSuccess: true
+  activeDeadlineSeconds: 100
   dbCheck:
     image:
       # repository: subfuzion/netcat


### PR DESCRIPTION
Specifying a deadline for jobs and cronjobs helps manage a failed job to spawn pods indefinately. This sets a time limit until which the job must execute successfully.

Enabling this keeps the cluster clean even when a job fails.