### PR TITLE
fix: added conditional pod annotations to jobs

### DIFF
--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -23,11 +23,10 @@ spec:
     metadata:
       name: {{ template "sentry.fullname" . }}-db-check
       annotations:
-        {{- if .Values.sentry.worker.annotations }}
-{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbCheck.podAnnotations }}
 {{ toYaml .Values.hooks.dbCheck.podAnnotations | indent 8 }}
+        {{- else if .Values.sentry.worker.annotations }}
+{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -20,11 +20,10 @@ spec:
       name: {{ template "sentry.fullname" . }}-db-init
       annotations:
         checksum/configmap.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
-        {{- if .Values.sentry.worker.annotations }}
-{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbInit.podAnnotations }}
 {{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
+        {{- else if .Values.sentry.worker.annotations }}
+{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -22,11 +22,10 @@ spec:
       annotations:
         checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
-        {{- if .Values.snuba.annotations }}
-{{ toYaml .Values.snuba.annotations | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.snubaInit.podAnnotations }}
 {{ toYaml .Values.hooks.snubaInit.podAnnotations | indent 8 }}
+        {{- else if .Values.snuba.annotations }}
+{{ toYaml .Values.snuba.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -22,11 +22,12 @@ spec:
       annotations:
         checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-snuba.yaml") . | sha256sum }}
-        {{- if .Values.snuba.annotations }}
-{{ toYaml .Values.snuba.annotations | indent 8 }}
-        {{- end }}
-        {{- if .Values.hooks.snubaInit.podAnnotations }}
+        {{- if .Values.hooks.snubaMigrate.podAnnotations }}
+{{ toYaml .Values.hooks.snubaMigrate.podAnnotations | indent 8 }}
+        {{- else if .Values.hooks.snubaInit.podAnnotations }}
 {{ toYaml .Values.hooks.snubaInit.podAnnotations | indent 8 }}
+        {{- else if .Values.snuba.annotations }}
+{{ toYaml .Values.snuba.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -18,11 +18,12 @@ spec:
       name: {{ template "sentry.fullname" . }}-user-create
       annotations:
         checksum/configmap.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
-        {{- if .Values.sentry.worker.annotations }}
-{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
-        {{- end }}
-        {{- if .Values.hooks.dbInit.podAnnotations }}
+        {{- if .Values.hooks.userCreate.podAnnotations }}
+{{ toYaml .Values.hooks.userCreate.podAnnotations | indent 8 }}
+        {{- else if .Values.hooks.dbInit.podAnnotations }}
 {{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
+        {{- else if .Values.sentry.worker.annotations }}
+{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -461,6 +461,10 @@ hooks:
     affinity: {}
     nodeSelector: {}
     # tolerations: []
+  snubaMigrate:
+    podAnnotations: {}
+  userCreate:
+    podAnnotations: {}
 
 system:
   ## be sure to include the scheme on the url, for example: "https://sentry.example.com"


### PR DESCRIPTION
In the current hooks templates, there is no option to use only the job specific annotations when we have two annotations specified in the values file.

By using conditionals, we can set either the job specific or app specific annotation. 
This helps in using the two separate annotations without interference.