### PR TITLE
feat: add sidecars to jobs

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.1
+version: 15.0.5
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -137,4 +137,7 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.dbCheck.resources | indent 10 }}
+      {{- if .Values.hooks.dbCheck.sidecars }}
+      {{ toYaml .Values.hooks.dbCheck.sidecars | indent 6 }}
+      {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -87,4 +87,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+      {{- if .Values.hooks.snubaInit.sidecars }}
+      {{ toYaml .Values.hooks.snubaInit.sidecars | indent 6 }}
+      {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -87,4 +87,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+      {{- if .Values.hooks.migrateJob.sidecars }}
+      {{ toYaml .Values.hooks.migrateJob.sidecars | indent 6 }}
+      {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -87,7 +87,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
-      {{- if .Values.hooks.migrateJob.sidecars }}
-      {{ toYaml .Values.hooks.migrateJob.sidecars | indent 6 }}
+      {{- if .Values.hooks.snubaMigrate.sidecars }}
+      {{ toYaml .Values.hooks.snubaMigrate.sidecars | indent 6 }}
       {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -101,4 +101,7 @@ spec:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-sentry
+      {{- if .Values.hooks.userCreate.sidecars }}
+      {{ toYaml .Values.hooks.userCreate.sidecars | indent 6 }}
+      {{- end }}
 {{- end -}}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -435,6 +435,7 @@ hooks:
     nodeSelector: {}
     securityContext: {}
     # tolerations: []
+    sidecars: []
   dbInit:
     env: []
     podAnnotations: {}
@@ -461,6 +462,11 @@ hooks:
     affinity: {}
     nodeSelector: {}
     # tolerations: []
+    sidecars: []
+  snubaMigrate:
+    sidecars: []
+  userCreate:
+    sidecars: []
 
 system:
   ## be sure to include the scheme on the url, for example: "https://sentry.example.com"


### PR DESCRIPTION
Support for sidecars in jobs is only available for sentry-db-init job. Its missing on others.

Added sidecar support for the following jobs in hooks

*  snuba-db-init-job
*  snuba-migrate-job
*  user-create