### PR TITLE
Feat/add serviceaccount names for jobs

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.1
+version: 15.0.6
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -140,4 +140,7 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.dbCheck.resources | indent 10 }}
+      {{- if .Values.hooks.dbCheck.serviceAccount }}
+      serviceAccountName: {{ .Values.hooks.dbCheck.serviceAccount.name }}
+      {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -96,4 +96,7 @@ spec:
 {{- if .Values.hooks.dbInit.volumes }}
 {{ toYaml .Values.hooks.dbInit.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.hooks.dbInit.serviceAccount }}
+      serviceAccountName: {{ .Values.hooks.dbInit.serviceAccount.name }}
+      {{- end }}
 {{- end -}}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -90,4 +90,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+      {{- if .Values.hooks.snubaInit.serviceAccount }}
+      serviceAccountName: {{ .Values.hooks.snubaInit.serviceAccount.name }}
+      {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -90,4 +90,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "sentry.fullname" . }}-snuba
+      {{- if .Values.hooks.snubaMigrate.serviceAccount }}
+      serviceAccountName: {{ .Values.hooks.snubaMigrate.serviceAccount.name }}
+      {{- end }}
 {{- end }}

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -104,4 +104,7 @@ spec:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-sentry
+      {{- if .Values.hooks.userCreate.serviceAccount }}
+      serviceAccountName: {{ .Values.hooks.userCreate.serviceAccount.name }}
+      {{- end }}
 {{- end -}}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -439,6 +439,7 @@ hooks:
     nodeSelector: {}
     securityContext: {}
     # tolerations: []
+    serviceAccount: {}
   dbInit:
     env: []
     podAnnotations: {}
@@ -453,6 +454,7 @@ hooks:
     affinity: {}
     nodeSelector: {}
     # tolerations: []
+    serviceAccount: {}
   snubaInit:
     podAnnotations: {}
     resources:
@@ -465,6 +467,11 @@ hooks:
     affinity: {}
     nodeSelector: {}
     # tolerations: []
+    serviceAccount: {}
+  snubaMigrate:
+    serviceAccount: {}
+  userCreate:
+    serviceAccount: {}
 
 system:
   ## be sure to include the scheme on the url, for example: "https://sentry.example.com"


### PR DESCRIPTION
Adding an option to provide service account name to hook jobs allows for more customizability.
This option is completely missing in hook jobs

The current use case is to allow these jobs to register in consul mesh, so that they can access external resources in the mesh like redis, kafka etc...