### PR TITLE
Fix Clickhouse servicemonitor

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.1.2
+version: 3.1.3
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/servicemonitor-clickhouse-replica.yaml
+++ b/clickhouse/templates/servicemonitor-clickhouse-replica.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
 {{- if .Values.clickhouse.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -14,13 +15,26 @@ metadata:
     {{- toYaml .Values.clickhouse.metrics.serviceMonitor.selector | nindent 4 }}
     {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "clickhouse.name" . }}-replica-metrics
   endpoints:
     - port: metrics
+      path: /metrics
       {{- if .Values.clickhouse.metrics.serviceMonitor.interval }}
       interval: {{ .Values.clickhouse.metrics.serviceMonitor.interval }}
       {{- end }}
+{{- if .Values.clickhouse.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ toYaml .Values.clickhouse.metrics.serviceMonitor.metricRelabelings | indent 6 }}
+{{- end }}
+{{- if .Values.clickhouse.metrics.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.clickhouse.metrics.serviceMonitor.relabelings | nindent 6 }}
+{{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/clickhouse/templates/servicemonitor-clickhouse.yaml
+++ b/clickhouse/templates/servicemonitor-clickhouse.yaml
@@ -14,13 +14,25 @@ metadata:
     {{- toYaml .Values.clickhouse.metrics.serviceMonitor.selector | nindent 4 }}
     {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "clickhouse.name" . }}-metrics
   endpoints:
     - port: metrics
+      path: /metrics
       {{- if .Values.clickhouse.metrics.serviceMonitor.interval }}
       interval: {{ .Values.clickhouse.metrics.serviceMonitor.interval }}
-  {{- end }}
+      {{- end }}
+{{- if .Values.clickhouse.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ toYaml .Values.clickhouse.metrics.serviceMonitor.metricRelabelings | indent 6 }}
+{{- end }}
+{{- if .Values.clickhouse.metrics.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.clickhouse.metrics.serviceMonitor.relabelings | nindent 6 }}
+{{- end }}
 ---
 {{- end}}


### PR DESCRIPTION
1. Add missing `namespaceSelector` and endpoint `path`
2. Only enable replica servicemonitor when replica is enabled