### PR TITLE
Fixing indent in user-create.yaml

### DIFF
--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -92,7 +92,7 @@ spec:
               key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
         {{- end }}
         {{- if .Values.hooks.dbInit.env }}
-{{ toYaml .Values.hooks.dbInit.env | indent 10 }}
+{{ toYaml .Values.hooks.dbInit.env | indent 8 }}
         {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry


### PR DESCRIPTION
the yaml could not be parsed into a json . no Value could be found due to false indentation