### PR TITLE
Sentry 22.7.0

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.8
-appVersion: 22.6.0
+version: 15.1.0
+appVersion: 22.7.0
 dependencies:
   - name: memcached
     repository: https://charts.bitnami.com/bitnami

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -45,6 +45,7 @@ data:
             "profiles",
             "replays",
             "generic_metrics_sets",
+            "generic_metrics_distributions",
         },
         {{- /*
           The default clickhouse installation runs in distributed mode, while the external


### PR DESCRIPTION
https://github.com/getsentry/self-hosted/releases/tag/22.7.0

With this release sentry started to test ARM support and switched Clickhouse to version 21 on ARM. Worth checking out both options and plan clickhouse upgrade.