### PR TITLE
Always create clickhouse config volumes just like volumeMounts

### DIFF
--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -163,7 +163,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
-      {{- if .Values.clickhouse.configmap.enabled }}
       - name: {{ include "clickhouse.fullname" . }}-config
         configMap:
           name: {{ include "clickhouse.fullname" . }}-config
@@ -182,7 +181,6 @@ spec:
           items:
           - key: users.xml
             path: users.xml
-      {{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-replica
       {{- end }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -162,7 +162,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
-      {{- if .Values.clickhouse.configmap.enabled }}
       - name: {{ include "clickhouse.fullname" . }}-config
         configMap:
           name: {{ include "clickhouse.fullname" . }}-config
@@ -181,7 +180,6 @@ spec:
           items:
           - key: users.xml
             path: users.xml
-      {{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}


### PR DESCRIPTION
The volumes should always be created because the config maps are always there (default or custom)
Currently volumeMounts are always created which works fine also with custom configmaps, but the volumes aren't created because of the mentioned if condition