### PR TITLE
Ability to specify customCA for worker deployment

### DIFF
--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -106,6 +106,10 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+        {{- if .Values.sentry.worker.customCA }}
+        - name: custom-ca
+          mountPath: /etc/pki/ca-trust/custom
+        {{ end }}
   {{- if .Values.sentry.worker.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.worker.livenessProbe.periodSeconds }}
@@ -151,6 +155,11 @@ spec:
       {{- if .Values.sentry.worker.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.worker.priorityClassName }}"
       {{- end }}
+      {{- if .Values.sentry.web.customCA }}
+      - name: custom-ca
+        secret:
+{{ toYaml .Values.sentry.web.customCA | indent 10 }}
+      {{ end }}
 {{- if .Values.sentry.worker.volumes }}
 {{ toYaml .Values.sentry.worker.volumes | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -152,14 +152,14 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
-      {{- if .Values.sentry.worker.priorityClassName }}
-      priorityClassName: "{{ .Values.sentry.worker.priorityClassName }}"
-      {{- end }}
       {{- if .Values.sentry.web.customCA }}
       - name: custom-ca
         secret:
 {{ toYaml .Values.sentry.web.customCA | indent 10 }}
       {{ end }}
+      {{- if .Values.sentry.worker.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.worker.priorityClassName }}"
+      {{- end }}
 {{- if .Values.sentry.worker.volumes }}
 {{ toYaml .Values.sentry.worker.volumes | indent 6 }}
 {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -141,6 +141,8 @@ sentry:
       failureThreshold: 3
     sidecars: []
     volumes: []
+    # customCA:
+    #   secretName: custom-ca
 
   ingestConsumer:
     replicas: 1


### PR DESCRIPTION
Add ability to add customCA to celery worker deployment like for web deployment.
According to this comment:
https://github.com/sentry-kubernetes/charts/issues/371#issuecomment-1193864927