### PR TITLE
fix: Apply appropriate batch apiVersion based on kubernetes version

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.8
+version: 15.0.9
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -99,6 +99,26 @@ Return if ingress is stable.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for batch (cronjobs and jobs).
+batch/v1beta1 will no longer be served in v1.25
+See more at https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125
+*/}}
+{{- define "sentry.batch.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "batch/v1") (semverCompare ">= 1.21.x" (include "sentry.kubeVersion" .)) -}}
+      {{- print "batch/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "batch/v1beta1" -}}
+    {{- print "batch/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if batch is stable.
+*/}}
+{{- define "sentry.batch.isStable" -}}
+  {{- eq (include "sentry.batch.apiVersion" .) "batch/v1" -}}
+{{- end -}}
+
+{{/*
 Return if ingress supports ingressClassName.
 */}}
 {{- define "sentry.ingress.supportsIngressClassName" -}}

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.sentry.cleanup.enabled }}
-apiVersion: batch/v1beta1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry-cleanup

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.snuba.cleanupErrors.enabled }}
-apiVersion: batch/v1beta1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba-cleanup-errors

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.snuba.cleanupTransactions.enabled }}
-apiVersion: batch/v1beta1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba-cleanup-transactions

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -3,7 +3,8 @@
 {{- $clickhousePort := include "sentry.clickhouse.port" . -}}
 {{- $kafkaHost := include "sentry.kafka.host" . -}}
 {{- $kafkaPort := include "sentry.kafka.port" . -}}
-apiVersion: batch/v1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ template "sentry.fullname" . }}-db-check

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.hooks.enabled -}}
-apiVersion: batch/v1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ template "sentry.fullname" . }}-db-init

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.hooks.enabled -}}
 {{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
-apiVersion: batch/v1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba-db-init

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.hooks.enabled -}}
 {{- $clickhouseHost := include "sentry.clickhouse.host" . -}}
-apiVersion: batch/v1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba-migrate

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.user.create .Values.hooks.enabled -}}
-apiVersion: batch/v1
+{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
+apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ template "sentry.fullname" . }}-user-create


### PR DESCRIPTION
As stated in the [deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/\#cronjob-v125), batch/v1beta1 will no longer be served in v1.25
Migrate manifests and API clients to use the batch/v1 API version, available since v1.21 

This commit allows to set the appropriate batch apiVersion based on sentry.kubeVersion

For example if you use : 
*  a  kubernetes version under ```1.21``` it will use ```batch/v1beta1```
*  a kubernetes version  ```>= 1.21``` of kubernetes it will use ```batch/v1```


Signed-off-by: Yann Toqué <toqueyann@gmail.com>