### PR TITLE
Support custom volume mounts everywhere

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.1.3
+version: 3.2.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/deployment-tabix.yaml
+++ b/clickhouse/templates/deployment-tabix.yaml
@@ -58,6 +58,10 @@ spec:
         ports:
         - name: http
           containerPort: 80
+{{- if .Values.tabix.volumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.tabix.volumeMounts | indent 8 }}
+{{- end }}
         env:
         {{- if .Values.tabix.security }}
         - name: USER
@@ -101,6 +105,10 @@ spec:
         resources:
 {{ toYaml .Values.tabix.resources | indent 10 }}
       {{- end }}
+{{- if .Values.tabix.volumes }}
+      volumes:
+{{ toYaml .Values.tabix.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-tabix
       {{- end }}

--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -128,6 +128,9 @@ spec:
           mountPath: /etc/clickhouse-server/metrica.d
         - name: {{ include "clickhouse.fullname" . }}-users
           mountPath: /etc/clickhouse-server/users.d
+{{- if .Values.clickhouse.volumeMounts }}
+{{ toYaml .Values.clickhouse.volumeMounts | indent 8 }}
+{{- end }}
       {{- with .Values.clickhouse.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -141,6 +144,10 @@ spec:
             containerPort: {{ .Values.clickhouse.metrics.image.port }}
             protocol: TCP
         {{- if .Values.clickhouse.metrics.resources }}
+{{- if .Values.clickhouse.metrics.volumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.clickhouse.metrics.volumeMounts | indent 8 }}
+{{- end }}
         resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 8 }}
         {{- end }}
       {{- end }}
@@ -183,6 +190,9 @@ spec:
           - key: users.xml
             path: users.xml
       {{- end }}
+{{- if .Values.clickhouse.volumes }}
+{{ toYaml .Values.clickhouse.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-replica
       {{- end }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -147,7 +147,7 @@ spec:
 {{ toYaml .Values.clickhouse.metrics.volumeMounts | indent 8 }}
 {{- end }}
         {{- if .Values.clickhouse.metrics.resources }}
-        resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 8 }}
+        resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 10 }}
       {{- end }}
       {{- end }}
     {{- if .Values.clickhouse.nodeSelector }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -127,6 +127,9 @@ spec:
           mountPath: /etc/clickhouse-server/metrica.d
         - name: {{ include "clickhouse.fullname" . }}-users
           mountPath: /etc/clickhouse-server/users.d
+{{- if .Values.clickhouse.volumeMounts }}
+{{ toYaml .Values.clickhouse.volumeMounts | indent 8 }}
+{{- end }}
       {{- with .Values.clickhouse.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -139,6 +142,10 @@ spec:
           - name: metrics
             containerPort: {{ .Values.clickhouse.metrics.image.port }}
             protocol: TCP
+{{- if .Values.clickhouse.metrics.volumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.clickhouse.metrics.volumeMounts | indent 8 }}
+{{- end }}
         {{- if .Values.clickhouse.metrics.resources }}
         resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 8 }}
       {{- end }}
@@ -182,6 +189,9 @@ spec:
           - key: users.xml
             path: users.xml
       {{- end }}
+{{- if .Values.clickhouse.volumes }}
+{{ toYaml .Values.clickhouse.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -56,6 +56,10 @@ clickhouse:
   # Security Context
   securityContext: {}
 
+  ## Additional Volumes
+  # volumes: []
+  # volumeMounts: []
+
   ## Prometheus Exporter / Metrics
   ##
   metrics:
@@ -69,6 +73,10 @@ clickhouse:
 
     ## Metrics exporter resource requests and limits
     # resources: {}
+
+    ## Additional Volumes
+    # volumes: []
+    # volumeMounts: []
 
     ## Metrics exporter pod Annotation and Labels
     podAnnotations:
@@ -460,3 +468,7 @@ tabix:
 
   ## Additional Labels
   podLabels:
+
+  ## Additional Volumes
+  # volumes: []
+  # volumeMounts: []

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.4.0
+version: 17.5.0
 appVersion: 22.10.0
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -88,6 +88,9 @@ spec:
             - name: sentry-google-cloud-key
               mountPath: /var/run/secrets/google
             {{ end }}
+{{- if .Values.sentry.cleanup.volumeMounts }}
+{{ toYaml .Values.sentry.cleanup.volumeMounts | indent 12 }}
+{{- end }}
             resources:
 {{ toYaml .Values.sentry.cleanup.resources | indent 14 }}
 {{- if .Values.sentry.cleanup.sidecars }}

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -85,9 +85,12 @@ spec:
                 - secretRef:
                       name: {{ template "sentry.fullname" . }}-snuba-env
             volumeMounts:
-                - mountPath: /etc/snuba
-                  name: config
-                  readOnly: true
+              - mountPath: /etc/snuba
+                name: config
+                readOnly: true
+{{- if .Values.snuba.cleanupErrors.volumeMounts }}
+{{ toYaml .Values.snuba.cleanupErrors.volumeMounts | indent 14 }}
+{{- end }}
             resources:
 {{ toYaml .Values.snuba.cleanupErrors.resources | indent 14 }}
 {{- if .Values.snuba.cleanupErrors.sidecars }}
@@ -99,7 +102,7 @@ spec:
               configMap:
                 name: {{ template "sentry.fullname" . }}-snuba
 {{- if .Values.snuba.cleanupErrors.volumes }}
-{{ toYaml .Values.snuba.cleanupErrors.volumes | indent 10 }}
+{{ toYaml .Values.snuba.cleanupErrors.volumes | indent 12 }}
 {{- end }}
           {{- if .Values.snuba.cleanupErrors.priorityClassName }}
           priorityClassName: "{{ .Values.snuba.cleanupErrors.priorityClassName }}"

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -85,9 +85,12 @@ spec:
                 - secretRef:
                       name: {{ template "sentry.fullname" . }}-snuba-env
             volumeMounts:
-                - mountPath: /etc/snuba
-                  name: config
-                  readOnly: true
+              - mountPath: /etc/snuba
+                name: config
+                readOnly: true
+{{- if .Values.snuba.cleanupTransactions.volumeMounts }}
+{{ toYaml .Values.snuba.cleanupTransactions.volumeMounts | indent 14 }}
+{{- end }}
             resources:
 {{ toYaml .Values.snuba.cleanupTransactions.resources | indent 14 }}
 {{- if .Values.snuba.cleanupTransactions.sidecars }}
@@ -99,7 +102,7 @@ spec:
               configMap:
                 name: {{ template "sentry.fullname" . }}-snuba
 {{- if .Values.snuba.cleanupTransactions.volumes }}
-{{ toYaml .Values.snuba.cleanupTransactions.volumes | indent 10 }}
+{{ toYaml .Values.snuba.cleanupTransactions.volumes | indent 12 }}
 {{- end }}
           {{- if .Values.snuba.cleanupTransactions.priorityClassName }}
           priorityClassName: "{{ .Values.snuba.cleanupTransactions.priorityClassName }}"

--- a/sentry/templates/deployment-metrics.yaml
+++ b/sentry/templates/deployment-metrics.yaml
@@ -68,6 +68,10 @@ spec:
           containerPort: 9125
         - name: metrics
           containerPort: 9102
+{{- if .Values.metrics.volumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.metrics.volumeMounts | indent 8 }}
+{{- end }}
 {{- if .Values.metrics.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
@@ -94,6 +98,11 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
+{{- if .Values.metrics.volumes }}
+      volumes:
+{{ toYaml .Values.metrics.volumes | indent 6 }}
+{{- end }}
+
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-metrics
       {{- end }}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -87,6 +87,9 @@ spec:
               mountPath: /work/.relay/config.yml
               subPath: config.yml
               readOnly: true
+{{- if .Values.relay.init.volumeMounts }}
+{{ toYaml .Values.relay.volumeMounts | indent 12 }}
+{{- end }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | quote }}
       {{- end }}
@@ -121,6 +124,9 @@ spec:
           - name: {{ .Values.geodata.volumeName }}
             mountPath: {{ .Values.geodata.mountPath }}
           {{- end }}
+{{- if .Values.relay.volumeMounts }}
+{{ toYaml .Values.relay.volumeMounts | indent 10 }}
+{{- end }}
         livenessProbe:
           failureThreshold: {{ .Values.relay.probeFailureThreshold }}
           httpGet:

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -84,6 +84,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.cron.volumeMounts }}
+{{ toYaml .Values.sentry.cron.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.cron.resources | indent 12 }}
 {{- if .Values.sentry.cron.sidecars }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
@@ -95,6 +95,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.postProcessForwardErrors.volumeMounts }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForwardErrors.resources | indent 12 }}
 {{- if .Values.sentry.postProcessForwardErrors.sidecars }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -98,6 +98,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.postProcessForwardTransactions.volumeMounts }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForwardTransactions.resources | indent 12 }}
 {{- if .Values.sentry.postProcessForwardTransactions.sidecars }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
@@ -88,6 +88,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.subscriptionConsumerEvents.volumeMounts }}
+{{ toYaml .Values.sentry.subscriptionConsumerEvents.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerEvents.sidecars }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
@@ -88,6 +88,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.subscriptionConsumerTransactions.volumeMounts }}
+{{ toYaml .Values.sentry.subscriptionConsumerTransactions.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerTransactions.sidecars }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -97,6 +97,9 @@ spec:
         - name: custom-ca
           mountPath: /etc/pki/ca-trust/custom
         {{ end }}
+{{- if .Values.sentry.web.volumeMounts }}
+{{ toYaml .Values.sentry.web.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: {{ .Values.sentry.web.probeFailureThreshold }}
           httpGet:

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -94,6 +94,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.sentry.worker.volumeMounts }}
+{{ toYaml .Values.sentry.worker.volumeMounts | indent 8 }}
+{{- end }}
   {{- if .Values.sentry.worker.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.worker.livenessProbe.periodSeconds }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -82,6 +82,9 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.api.volumeMounts }}
+{{ toYaml .Values.snuba.api.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -106,12 +106,18 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.replacer.volumeMounts }}
+{{ toYaml .Values.snuba.replacer.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.replacer.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ template "sentry.fullname" . }}-snuba
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.replacer.volumes }}
+{{ toYaml .Values.snuba.replacer.volumes | indent 6 }}
+{{- end }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -92,12 +92,18 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.subscriptionConsumerEvents.volumeMounts }}
+{{ toYaml .Values.snuba.subscriptionConsumerEvents.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ template "sentry.fullname" . }}-snuba
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.subscriptionConsumerEvents.volumes }}
+{{ toYaml .Values.snuba.subscriptionConsumerEvents.volumes | indent 6 }}
+{{- end }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -92,12 +92,18 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.snuba.subscriptionConsumerTransactions.volumeMounts }}
+{{ toYaml .Values.snuba.subscriptionConsumerTransactions.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.resources | indent 12 }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ template "sentry.fullname" . }}-snuba
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.subscriptionConsumerTransactions.volumes }}
+{{ toYaml .Values.snuba.subscriptionConsumerTransactions.volumes | indent 6 }}
+{{- end }}

--- a/sentry/templates/deployment-symbolicator.yaml
+++ b/sentry/templates/deployment-symbolicator.yaml
@@ -85,6 +85,9 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.symbolicator.api.volumeMounts }}
+{{ toYaml .Values.symbolicator.api.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -121,6 +124,9 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
+{{- if .Values.sentry.ingestConsumer.volumes }}
+{{ toYaml .Values.symbolicator.api.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.symbolicator.api.priorityClassName }}
       priorityClassName: "{{ .Values.symbolicator.api.priorityClassName }}"
       {{- end }}

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -137,12 +137,20 @@ spec:
               fi
             done
             echo "Kafka is up"
+{{- if .Values.hooks.dbCheck.volumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.hooks.dbCheck.volumeMounts | indent 8 }}
+{{- end }}
         env:
 {{- if .Values.hooks.dbCheck.env }}
 {{ toYaml .Values.hooks.dbCheck.env | indent 8 }}
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.dbCheck.resources | indent 10 }}
+{{- if .Values.hooks.dbCheck.volumes }}
+      volumes:
+{{ toYaml .Values.hooks.dbCheck.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.hooks.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.hooks.shareProcessNamespace }}
       {{- end }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -81,6 +81,9 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+{{- if .Values.hooks.dbInit.volumeMounts }}
+{{ toYaml .Values.hooks.dbInit.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
 {{- if .Values.hooks.dbInit.sidecars }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -87,12 +87,18 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.hooks.snubaInit.volumeMounts }}
+{{ toYaml .Values.hooks.snubaInit.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ template "sentry.fullname" . }}-snuba
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.hooks.snubaInit.volumes }}
+{{ toYaml .Values.hooks.snubaInit.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.hooks.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.hooks.shareProcessNamespace }}
       {{- end }}

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -87,12 +87,18 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
+{{- if .Values.hooks.snubaInit.volumeMounts }}
+{{ toYaml .Values.hooks.snubaInit.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ template "sentry.fullname" . }}-snuba
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.hooks.snubaInit.volumes }}
+{{ toYaml .Values.hooks.snubaInit.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.hooks.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.hooks.shareProcessNamespace }}
       {{- end }}

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -92,12 +92,18 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+{{- if .Values.hooks.dbInit.volumeMounts }}
+{{ toYaml .Values.hooks.dbInit.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
       volumes:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-sentry
+{{- if .Values.hooks.dbInit.volumes }}
+{{ toYaml .Values.hooks.dbInit.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.hooks.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.hooks.shareProcessNamespace }}
       {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -75,10 +75,13 @@ relay:
     targetCPUUtilizationPercentage: 50
   sidecars: []
   volumes: []
+  volumeMounts: []
   init:
     resources: {}
     # additionalArgs: []
     # env: []
+    # volumes: []
+    # volumeMounts: []
 
 geodata:
   path: ""
@@ -120,6 +123,7 @@ sentry:
       targetCPUUtilizationPercentage: 50
     sidecars: []
     volumes: []
+    volumeMounts: []
 
   features:
     orgSubdomains: false
@@ -149,6 +153,7 @@ sentry:
       failureThreshold: 3
     sidecars: []
     volumes: []
+    volumeMounts: []
 
   ingestConsumer:
     replicas: 1
@@ -186,6 +191,8 @@ sentry:
     # podLabels: []
     sidecars: []
     volumes: []
+    # volumeMounts: []
+
   subscriptionConsumerEvents:
     replicas: 1
     env: []
@@ -199,6 +206,8 @@ sentry:
     sidecars: []
     volumes: []
     # noStrictOffsetReset: false
+    # volumeMounts: []
+
   subscriptionConsumerTransactions:
     replicas: 1
     env: []
@@ -212,6 +221,8 @@ sentry:
     sidecars: []
     volumes: []
     # noStrictOffsetReset: false
+    # volumeMounts: []
+
   postProcessForwardErrors:
     replicas: 1
     env: []
@@ -224,6 +235,8 @@ sentry:
     # commitBatchSize: 1
     sidecars: []
     volumes: []
+    # volumeMounts: []
+
   postProcessForwardTransactions:
     replicas: 1
     env: []
@@ -236,6 +249,8 @@ sentry:
     # commitBatchSize: 1
     sidecars: []
     volumes: []
+    # volumeMounts: []
+
   cleanup:
     successfulJobsHistoryLimit: 5
     failedJobsHistoryLimit: 5
@@ -247,6 +262,7 @@ sentry:
     # securityContext: {}
     sidecars: []
     volumes: []
+    # volumeMounts: []
     serviceAccount: {}
 
 snuba:
@@ -279,6 +295,7 @@ snuba:
       targetCPUUtilizationPercentage: 50
     sidecars: []
     volumes: []
+    # volumeMounts: []
 
   consumer:
     replicas: 1
@@ -348,6 +365,8 @@ snuba:
     # maxBatchTimeMs: ""
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # volumes: []
+    # volumeMounts: []
 
   subscriptionConsumerEvents:
     replicas: 1
@@ -359,6 +378,8 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    # volumes: []
+    # volumeMounts: []
 
   subscriptionConsumerTransactions:
     replicas: 1
@@ -370,6 +391,8 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    # volumes: []
+    # volumeMounts: []
 
   sessionsConsumer:
     replicas: 1
@@ -441,6 +464,8 @@ snuba:
     volumes: []
     # securityContext: {}
     serviceAccount: {}
+    # volumes: []
+    # volumeMounts: []
 
   cleanupTransactions:
     successfulJobsHistoryLimit: 5
@@ -453,6 +478,8 @@ snuba:
     volumes: []
     # securityContext: {}
     serviceAccount: {}
+    # volumes: []
+    # volumeMounts: []
 
 hooks:
   enabled: true
@@ -478,6 +505,8 @@ hooks:
     nodeSelector: {}
     securityContext: {}
     # tolerations: []
+    # volumes: []
+    # volumeMounts: []
   dbInit:
     env: []
     # podLabels: []
@@ -493,6 +522,8 @@ hooks:
     affinity: {}
     nodeSelector: {}
     # tolerations: []
+    # volumes: []
+    # volumeMounts: []
   snubaInit:
     # podLabels: []
     podAnnotations: {}
@@ -506,8 +537,12 @@ hooks:
     affinity: {}
     nodeSelector: {}
     # tolerations: []
+    # volumes: []
+    # volumeMounts: []
   snubaMigrate: {}
     # podLabels: []
+    # volumes: []
+    # volumeMounts: []
 
 system:
   ## be sure to include the scheme on the url, for example: "https://sentry.example.com"
@@ -574,6 +609,10 @@ symbolicator:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+
+    # volumes: []
+    # volumeMounts: []
+
   # TODO The cleanup cronjob is not yet implemented
   cleanup:
     enabled: false

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -270,7 +270,7 @@ snuba:
     replicas: 1
     # set command to ["snuba","api"] if securityContext.runAsUser > 0
     # see: https://github.com/getsentry/snuba/issues/956
-    command: {}
+    command: []
     #   - snuba
     #   - api
     env: []


### PR DESCRIPTION
Allow custom volume mounts for all deployments, stateful sets and cronjobs.

It makes it possible to run properly in restrictive environments with read-only filesystem (where without volume mounted as `/tmp` even logs cannot be read from many of those pods), allows for root ca addition to any pod and many other customizations/workaround (e.g. I'm using it to overwrite some config which contains plaintext credentials to instead take them from env vars - by mounting alternative config files).

Tried to keep indentation consistent where possible.

Also changed one default value -  `snuba.command` from `{}` to `[]` - it's a list so using `{}` generates warnings from helm or skaffold (not sure which one).