### PR TITLE
Added missing Storage_Set expected to be in 22.7.0 migrations

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.0.9
+version: 15.0.10
 appVersion: 22.6.0
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -45,6 +45,7 @@ data:
             "profiles",
             "replays",
             "generic_metrics_sets",
+            "generic_metrics_distributions",
         },
         {{- /*
           The default clickhouse installation runs in distributed mode, while the external


### PR DESCRIPTION
After upgrading Helm Chart to latest version (15.0.8) and overriding image tags to use latest stable Sentry version (22.7.0) it appears that snuba-api tries to run a migration for a non-defined storage_set and gets stuck "in progress" till the missing set is manually added to the deployed configmap and migrations are re-run following very similar steps as described in https://forum.sentry.io/t/migration-error/11882/2

```
sessions
[X]  0001_sessions
[X]  0002_sessions_aggregates
[X]  0003_sessions_matview

generic_metrics
[X]  0001_sets_aggregate_table
[X]  0002_sets_raw_table
[X]  0003_sets_mv
[X]  0004_sets_raw_add_granularities
[X]  0005_sets_replace_mv
[X]  0006_sets_raw_add_granularities_dist_table
[-]  0007_distributions_aggregate_table (IN PROGRESS)    <----- this
[ ]  0008_distributions_raw_table
[ ]  0009_distributions_mv
```

I'm not sure what is the best way to handle it but ideally we should be able to override default appVersion/image tag to the latest version if desired. 

Please feel free to reject this PR if you feel it's bad/breaking change that can add discrepancy between versions etc