### PR TITLE
Configurable Security Context for CronJobs

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 16.0.4
+version: 16.0.5
 appVersion: 22.9.0
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -58,6 +58,10 @@ spec:
           imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 12 }}
             {{- end }}
+            {{- if .Values.sentry.cleanup.securityContext }}
+          securityContext:
+{{ toYaml .Values.sentry.cleanup.securityContext | indent 12 }}
+      {{- end }}
           containers:
           - name: {{ .Chart.Name }}-sentry-cleanup
             image: "{{ template "sentry.image" . }}"

--- a/sentry/templates/cronjob-snuba-cleanup-errors.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-errors.yaml
@@ -57,6 +57,10 @@ spec:
           imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 12 }}
             {{- end }}
+            {{- if .Values.snuba.cleanupErrors.securityContext }}
+          securityContext:
+{{ toYaml .Values.snuba.cleanupErrors.securityContext | indent 12 }}
+      {{- end }}
           containers:
           - name: {{ .Chart.Name }}-snuba-cleanup-errors
             image: "{{ template "snuba.image" . }}"

--- a/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
+++ b/sentry/templates/cronjob-snuba-cleanup-transactions.yaml
@@ -57,6 +57,10 @@ spec:
           imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 12 }}
             {{- end }}
+            {{- if .Values.snuba.cleanupTransactions.securityContext }}
+          securityContext:
+{{ toYaml .Values.snuba.cleanupTransactions.securityContext | indent 12 }}
+      {{- end }}
           containers:
           - name: {{ .Chart.Name }}-snuba-cleanup-errors
             image: "{{ template "snuba.image" . }}"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -424,6 +424,7 @@ snuba:
     schedule: "0 * * * *"
     sidecars: []
     volumes: []
+    # securityContext: {}
     serviceAccount: {}
 
   cleanupTransactions:
@@ -435,6 +436,7 @@ snuba:
     schedule: "0 * * * *"
     sidecars: []
     volumes: []
+    # securityContext: {}
     serviceAccount: {}
 
 hooks:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -230,6 +230,7 @@ sentry:
     enabled: true
     schedule: "0 0 * * *"
     days: 90
+    # securityContext: {}
     sidecars: []
     volumes: []
     serviceAccount: {}


### PR DESCRIPTION
Configurable Security Context is missing from both Snuba cleanup jobs
(cleanup transactions and cleanup errors). It makes it impossible to run
those jobs with `runAsNonRoot` - k8s cannot verify id of a named user.