### PR TITLE
remove POSTGRES_PASSWORD env var from external pg in cleanup cronjob

### DIFF
--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -78,9 +78,6 @@ spec:
                 secretKeyRef:
                   name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
                   key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
-            {{- else if .Values.externalPostgresql.password }}
-            - name: POSTGRES_PASSWORD
-              value: {{ include "sentry.postgresql.password" . | quote }}
             {{- end }}
             {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
I'm added custom env var which inject `POSTGRES_PASSWORD` from k8s secret
```yaml
    - name: POSTGRES_PASSWORD
      valueFrom:
        secretKeyRef:
          name: sentry-postgres-password
          key: password
```

but this made duplication error, so I removed this.