### PR TITLE
Configurable resources and env for relay init container

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.2.1
+version: 15.2.2
 appVersion: 22.8.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -69,9 +69,14 @@ spec:
           args:
             - "credentials"
             - "generate"
+          resources:
+{{ toYaml .Values.relay.init.resources | indent 12 }}
           env:
             - name: RELAY_PORT
               value: '{{ template "relay.port" }}'
+{{- if .Values.relay.init.env }}
+{{ toYaml .Values.relay.init.env | indent 12 }}
+{{- end }}
           volumeMounts:
             - name: credentials
               mountPath: /work/.relay

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -74,6 +74,9 @@ relay:
     targetCPUUtilizationPercentage: 50
   sidecars: []
   volumes: []
+  init:
+    resources: {}
+    # env: []
 
 geodata:
   path: ""


### PR DESCRIPTION
Relay init container is missing option to configure resources. It makes it unusable with strict policies where resources are obligatory.

Additionally added option to configure env vars - don't know relay enough to say how useful it is in this context (config generation) but relay itself supports env variables.