### PR TITLE
Update memcached service name in configmap-sentry

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -134,7 +134,7 @@ data:
         "default": {
             "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
             "LOCATION": [
-                "sentry-memcached:11211"
+                "{{ template "sentry.fullname" . }}-memcached:11211"
             ]
         }
     }


### PR DESCRIPTION
Reference the proper service name for memcached in sentry main configmap if sourcemaps are enabled