### PR TITLE
fix: snuba migrate takes longer than default active deadline (#712)

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -428,7 +428,7 @@ snuba:
 hooks:
   enabled: true
   removeOnSuccess: true
-  activeDeadlineSeconds: 100
+  activeDeadlineSeconds: 300
   shareProcessNamespace: false
   dbCheck:
     image:


### PR DESCRIPTION
fix #712 by increasing default hooks active deadline.