### PR TITLE
Update to sentry 22.8.0

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.1.0
+version: 15.2.0
 appVersion: 22.8.0
 dependencies:
   - name: memcached

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry
 description: A Helm chart for Kubernetes
 type: application
 version: 15.1.0
-appVersion: 22.7.0
+appVersion: 22.8.0
 dependencies:
   - name: memcached
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Update sentry version as https://github.com/getsentry/sentry/releases/tag/22.8.0 is now available