### PR TITLE
Add noStrictOffsetReset to consumers

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.2.0
+version: 15.2.1
 appVersion: 22.8.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -108,6 +108,9 @@ spec:
           - "--queued-min-messages"
           - "{{ .Values.snuba.consumer.queuedMinMessages }}"
           {{- end }}
+          {{- if .Values.snuba.consumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -104,6 +104,9 @@ spec:
           - "--queued-min-messages"
           - "{{ .Values.snuba.outcomesConsumer.queuedMinMessages }}"
           {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -108,6 +108,9 @@ spec:
           - "--queued-min-messages"
           - "{{ .Values.snuba.sessionsConsumer.queuedMinMessages }}"
           {{- end }}
+          {{- if .Values.snuba.sessionsConsumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -70,7 +70,9 @@ spec:
           - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
           - "--dataset=events"
           - "--entity=events"
+          {{- if .Values.snuba.subscriptionConsumerEvents.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
+          {{- end }}
           - "--consumer-group=snuba-events-subscriptions-consumers"
           - "--followed-consumer-group=snuba-consumers"
           - "--delay-seconds=60"

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -70,7 +70,9 @@ spec:
           - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
           - "--dataset=transactions"
           - "--entity=transactions"
+          {{- if .Values.snuba.subscriptionConsumerTransactions.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
+          {{- end }}
           - "--consumer-group=snuba-transactions-subscriptions-consumers"
           - "--followed-consumer-group=transactions_group"
           - "--delay-seconds=60"

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -110,6 +110,9 @@ spec:
           - "--queued-min-messages"
           - "{{ .Values.snuba.transactionsConsumer.queuedMinMessages }}"
           {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -190,6 +190,7 @@ sentry:
     # commitBatchSize: 1
     sidecars: []
     volumes: []
+    # noStrictOffsetReset: false
   subscriptionConsumerTransactions:
     replicas: 1
     env: []
@@ -202,6 +203,7 @@ sentry:
     # commitBatchSize: 1
     sidecars: []
     volumes: []
+    # noStrictOffsetReset: false
   postProcessForward:
     replicas: 1
     env: []
@@ -267,6 +269,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -293,6 +296,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
     maxBatchSize: "3"
     # processes: ""
     # inputBlockSize: ""
@@ -356,6 +360,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -382,6 +387,7 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""


### PR DESCRIPTION
We frequently have to reset Kafka's log offset in order for Snuba to consume again.
Add a parameter to commands that handle `--no-strict-offset-reset` option.