### PR TITLE
fix snuba storagesets for 22.9.0

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 15.2.1
-appVersion: 22.8.0
+version: 15.3.0
+appVersion: 22.9.0
 dependencies:
   - name: memcached
     repository: https://charts.bitnami.com/bitnami

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -43,6 +43,7 @@ data:
             "errors_v2",
             "errors_v2_ro",
             "profiles",
+            "functions",
             "replays",
             "generic_metrics_sets",
             "generic_metrics_distributions",


### PR DESCRIPTION
According to new snuba storage set, add key to config
https://github.com/getsentry/snuba/blob/master/snuba/clusters/storage_sets.py#L20