### PR TITLE
Allow for v0 API endpoints

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 16.0.2
+version: 16.0.3
 appVersion: 22.9.0
 dependencies:
   - name: memcached

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -139,9 +139,9 @@ spec:
               servicePort: {{ template "relay.port" . }}
               {{- end }}
         {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "traefik" }}
-          - path: {{ default "/" .Values.ingress.path }}api/{[1-9][0-9]*}/{(.*)}
+          - path: {{ default "/" .Values.ingress.path }}api/{[0-9][0-9]*}/{(.*)}
         {{- else }}
-          - path: {{ default "/" .Values.ingress.path }}api/[1-9][0-9]*/(.*)
+          - path: {{ default "/" .Values.ingress.path }}api/[0-9][0-9]*/(.*)
         {{- end }}
             {{- if $ingressSupportsPathType }}
             pathType: {{ $ingressPathType }}


### PR DESCRIPTION
Support the V0 api endpoints.
In the newest release of this chart, sentry 22.9.0. This does API calls to the uri: `example.com/api/0/organizations/[org-name]/eventsv2/?data=here`

With the current set-up this will always result in a 404.