### PR TITLE
fix relay upstream issues by setting http-keepalive to 15 (#671)

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 16.0.5
+version: 16.0.6
 appVersion: 22.9.0
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -291,11 +291,8 @@ data:
         "protocol": "uwsgi",
         # This is needed to prevent https://git.io/fj7Lw
         "uwsgi-socket": None,
-
-        # These ase for proper HTTP/1.1 support from uWSGI
-        # Without these it doesn't do keep-alives causing
-        # issues with Relay's direct requests.
-        "http-keepalive": True,
+        # Keep this between 15s-75s as that's what Relay supports
+        "http-keepalive": {{ .Values.config.web.httpKeepalive }},
         "http-chunked-input": True,
         # the number of web workers
         'workers': 3,

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -698,6 +698,8 @@ config:
     # No Python Extension Config Given
   relay: |
     # No YAML relay config given
+  web:
+    httpKeepalive: 15
 
 clickhouse:
   enabled: true


### PR DESCRIPTION
The http-keepalive option was changed from 'True' to '15' in the [getsentry/self-hosted](https://github.com/getsentry/self-hosted/blob/master/sentry/sentry.conf.example.py#L194) repo. The current setting causes connection/authentication issues between relay and web containers.

see https://github.com/sentry-kubernetes/charts/issues/671

thanks to @junowong0114 for pointing out the solution