### PR TITLE
split post-process-forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/
 
 For now the full list of values is not documented but you can get inspired by the values.yaml specific to each directory.
 
+## Upgrading from 16.x.x version of this Chart to 17.x.x
+
+Sentry version from 22.10.0 onwards should be using chart 17.x.x
+
+- post process forwarder events and transactions topics are splitted in Sentry 22.10.0
+
+You can delete the deployment "sentry-post-process-forward" as it's no longer needed.
+
+
+
 ## Upgrading from 15.x.x version of this Chart to 16.x.x
 
 system.secret-key is removed

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 16.0.6
-appVersion: 22.9.0
+version: 17.0.0
+appVersion: 22.10.0
 dependencies:
   - name: memcached
     repository: https://charts.bitnami.com/bitnami

--- a/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
@@ -1,0 +1,166 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-post-process-forward-errors
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+        role: sentry-post-process-forward-errors
+  replicas: {{ .Values.sentry.postProcessForwardErrors.replicas }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
+        {{- if .Values.sentry.postProcessForwardErrors.annotations }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+        role: sentry-post-process-forward-errors
+        {{- if .Values.sentry.postProcessForwardErrors.podLabels }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.postProcessForwardErrors.affinity }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.postProcessForwardErrors.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.postProcessForwardErrors.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.postProcessForwardErrors.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.postProcessForwardErrors.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.postProcessForwardErrors.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.postProcessForwardErrors.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-post-process-forward-errors
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "post-process-forwarder"
+          - "--commit-batch-size"
+          - "{{ default "1" .Values.sentry.postProcessForwardErrors.commitBatchSize }}"
+          - "--entity"
+          - "errors"
+        env:
+        - name: SNUBA
+          value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
+        {{- if .Values.sentry.existingSecret }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sentry.existingSecret }}
+              key: {{ default "key" .Values.sentry.existingSecretKey }}
+        {{- else }}
+        - name: SENTRY_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sentry.fullname" . }}-sentry-secret
+              key: "key"
+        {{- end }}
+        {{- if .Values.postgresql.enabled }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.existingSecret }}
+              key: {{ default "postgresql-password" .Values.postgresql.existingSecretKey }}
+        {{- else if .Values.externalPostgresql.password }}
+        - name: POSTGRES_PASSWORD
+          value: {{ .Values.externalPostgresql.password | quote }}
+        {{- else if .Values.externalPostgresql.existingSecret }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalPostgresql.existingSecret }}
+              key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKey }}
+        {{- end }}
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        {{ end }}
+{{- if .Values.sentry.postProcessForwardErrors.env }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+        resources:
+{{ toYaml .Values.sentry.postProcessForwardErrors.resources | indent 12 }}
+{{- if .Values.sentry.postProcessForwardErrors.sidecars }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-errors
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+{{- if .Values.sentry.postProcessForwardErrors.volumes }}
+{{ toYaml .Values.sentry.postProcessForwardErrors.volumes | indent 6 }}
+{{- end }}
+      {{- if .Values.sentry.postProcessForwardErrors.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.postProcessForwardErrors.priorityClassName }}"
+      {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "sentry.fullname" . }}-post-process-forward
+  name: {{ template "sentry.fullname" . }}-post-process-forward-transactions
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -22,36 +22,36 @@ spec:
     matchLabels:
         app: sentry
         release: "{{ .Release.Name }}"
-        role: sentry-post-process-forward
-  replicas: {{ .Values.sentry.postProcessForward.replicas }}
+        role: sentry-post-process-forward-transactions
+  replicas: {{ .Values.sentry.postProcessForwardTransactions.replicas }}
   template:
     metadata:
       annotations:
         checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
         checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
-        {{- if .Values.sentry.postProcessForward.annotations }}
-{{ toYaml .Values.sentry.postProcessForward.annotations | indent 8 }}
+        {{- if .Values.sentry.postProcessForwardTransactions.annotations }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        role: sentry-post-process-forward
-        {{- if .Values.sentry.postProcessForward.podLabels }}
-{{ toYaml .Values.sentry.postProcessForward.podLabels | indent 8 }}
+        role: sentry-post-process-forward-transactions
+        {{- if .Values.sentry.postProcessForwardTransactions.podLabels }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.podLabels | indent 8 }}
         {{- end }}
     spec:
       affinity:
-      {{- if .Values.sentry.postProcessForward.affinity }}
-{{ toYaml .Values.sentry.postProcessForward.affinity | indent 8 }}
+      {{- if .Values.sentry.postProcessForwardTransactions.affinity }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.postProcessForward.nodeSelector }}
+      {{- if .Values.sentry.postProcessForwardTransactions.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.sentry.postProcessForward.nodeSelector | indent 8 }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.postProcessForward.tolerations }}
+      {{- if .Values.sentry.postProcessForwardTransactions.tolerations }}
       tolerations:
-{{ toYaml .Values.sentry.postProcessForward.tolerations | indent 8 }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.images.sentry.imagePullSecrets }}
       imagePullSecrets:
@@ -64,15 +64,25 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.postProcessForward.securityContext }}
+      {{- if .Values.sentry.postProcessForwardTransactions.securityContext }}
       securityContext:
-{{ toYaml .Values.sentry.postProcessForward.securityContext | indent 8 }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.securityContext | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}-post-process-forward
+      - name: {{ .Chart.Name }}-post-process-forward-transactions
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry", "run", "post-process-forwarder", "--commit-batch-size", "{{ default "1" .Values.sentry.postProcessForward.commitBatchSize }}"]
+        command: ["sentry"]
+        args:
+          - "run"
+          - "post-process-forwarder"
+          - "--commit-batch-size"
+          - "{{ default "1" .Values.sentry.postProcessForwardTransactions.commitBatchSize }}"
+          - "--entity"
+          - "transactions"
+          - "--commit-log-topic=snuba-transactions-commit-log"
+          - "--synchronize-commit-group"
+          - "transactions_group"
         env:
         - name: SNUBA
           value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" }}
@@ -109,8 +119,8 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
-{{- if .Values.sentry.postProcessForward.env }}
-{{ toYaml .Values.sentry.postProcessForward.env | indent 8 }}
+{{- if .Values.sentry.postProcessForwardTransactions.env }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.env | indent 8 }}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
@@ -123,12 +133,12 @@ spec:
           mountPath: /var/run/secrets/google
         {{ end }}
         resources:
-{{ toYaml .Values.sentry.postProcessForward.resources | indent 12 }}
-{{- if .Values.sentry.postProcessForward.sidecars }}
-{{ toYaml .Values.sentry.postProcessForward.sidecars | indent 6 }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.resources | indent 12 }}
+{{- if .Values.sentry.postProcessForwardTransactions.sidecars }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder
+      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-transactions
       {{- end }}
       volumes:
       - name: config
@@ -151,9 +161,9 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
-{{- if .Values.sentry.postProcessForward.volumes }}
-{{ toYaml .Values.sentry.postProcessForward.volumes | indent 6 }}
+{{- if .Values.sentry.postProcessForwardTransactions.volumes }}
+{{ toYaml .Values.sentry.postProcessForwardTransactions.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.sentry.postProcessForward.priorityClassName }}
-      priorityClassName: "{{ .Values.sentry.postProcessForward.priorityClassName }}"
+      {{- if .Values.sentry.postProcessForwardTransactions.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.postProcessForwardTransactions.priorityClassName }}"
       {{- end }}

--- a/sentry/templates/serviceaccount-sentry-post-process-forwarder-errors.yaml
+++ b/sentry/templates/serviceaccount-sentry-post-process-forwarder-errors.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-post-process-forwarder-errors
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/sentry/templates/serviceaccount-sentry-post-process-forwarder-transactions.yaml
+++ b/sentry/templates/serviceaccount-sentry-post-process-forwarder-transactions.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}-post-process-forwarder
+  name: {{ .Values.serviceAccount.name }}-post-process-forwarder-transactions
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -210,7 +210,19 @@ sentry:
     sidecars: []
     volumes: []
     # noStrictOffsetReset: false
-  postProcessForward:
+  postProcessForwardErrors:
+    replicas: 1
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    # tolerations: []
+    # podLabels: []
+    # commitBatchSize: 1
+    sidecars: []
+    volumes: []
+  postProcessForwardTransactions:
     replicas: 1
     env: []
     resources: {}


### PR DESCRIPTION
Since https://github.com/getsentry/self-hosted/commit/4a02090030fdaaacbac521784919185afc47d88c, it's required to split post-process-forwarder into errors and transactions entity. This fixed post-process-forwarder deployment crash in the latest sentry (22.10.0)