### PR TITLE
Custom relay args

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.2.0
+version: 17.3.0
 appVersion: 22.10.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -69,6 +69,9 @@ spec:
           args:
             - "credentials"
             - "generate"
+{{- if .Values.relay.init.additionalArgs }}
+{{ toYaml .Values.relay.init.additionalArgs | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.relay.init.resources | indent 12 }}
           env:
@@ -93,6 +96,10 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-relay
+{{- if .Values.relay.args }}
+        args:
+{{ toYaml .Values.relay.args | indent 10 }}
+{{- end }}
         image: "{{ template "relay.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
         ports:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -51,6 +51,7 @@ serviceAccount:
 
 relay:
   replicas: 1
+  # args: []
   mode: managed
   env: []
   probeFailureThreshold: 5
@@ -76,6 +77,7 @@ relay:
   volumes: []
   init:
     resources: {}
+    # additionalArgs: []
     # env: []
 
 geodata:


### PR DESCRIPTION
Allow custom args in both relay and its init container to enable changing config file used.

Together with #702 it enables full overwrite of the configuration. Why would you want to do that?

* Current one is stored as a configmap instead of a secret while there are redis (and possibly kafka?) credentials included.
* There are at least two formats of the redis configuration block, one for single instance (string) and another (map) for Redis Cluster. Without native support for Redis Cluster throughout the chart it would be quite cumbersome to support it in the template - unless you have a good idea how that could be done cleanly?
* There may be possible other options in existing config blocks that user might want to overwrite / extend. I've tried to verify how does Relay handle repeated keys and to my understanding latest one overwrites the older ones but that's not an intuitive behaviour.