### PR TITLE
Add conditional server block to nginx configmap to enable metric scraping

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.6.0
+version: 17.7.0
 appVersion: 22.10.0
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -27,6 +27,13 @@ data:
         proxy_pass http://relay;
       }
 
+      {{ if and .Values.nginx.metrics.enabled .Values.nginx.metrics.serviceMonitor.enabled -}}
+      location = /status/ {
+        stub_status;
+      }
+
+      {{ end -}}
+
       location / {
         proxy_pass http://sentry;
       }


### PR DESCRIPTION
This change exposes an endpoint `/status` in the Nginx config, which can then used by https://github.com/bitnami/containers/tree/main/bitnami/nginx-exporter (really just https://github.com/nginxinc/nginx-prometheus-exporter in a Bitnami trench coat) to expose metrics to Prometheus. It is only added if both `metrics` and `metrics.serviceMonitor` are enabled for `nginx`. I am not sure why Bitnami makes the exporter hit `/status` instead of the default `/stub_status` in the original exporter.

This should resolve https://github.com/sentry-kubernetes/charts/issues/711