### PR TITLE
Adding secrets for filestore s3 secret key

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.6.0
+version: 17.7.2
 appVersion: 22.10.0
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -494,4 +494,11 @@ Common Sentry environment variables
       name: {{ .Values.mail.existingSecret }}
       key: {{ default "mail-password" .Values.mail.existingSecretKey }}
 {{- end }}
+{{- if and (eq .Values.filestore.backend "s3") .Values.filestore.s3.existingSecret }}
+- name: S3_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.s3.existingSecret }}
+      key: {{ default "s3-secret-key" .Values.filestore.s3.existingSecretKey }}
+{{- end }}
 {{- end -}}

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -95,7 +95,7 @@ data:
     filestore.options:
       bucket_name: {{ .Values.filestore.gcs.bucketName | quote }}
     {{ end }}
-    {{- if eq .Values.filestore.backend "s3" }}
+    {{- if not .Values.filestore.s3.existingSecretKey }}
     filestore.options:
       {{- if .Values.filestore.s3.accessKey }}
       access_key: {{ .Values.filestore.s3.accessKey | quote }}
@@ -439,6 +439,7 @@ data:
         }
     )
 
+
     #######################
     # Email Configuration #
     #######################
@@ -450,6 +451,21 @@ data:
     SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port | quote }}))
     SENTRY_OPTIONS['mail.host'] = os.getenv("SENTRY_EMAIL_HOST", {{ .Values.mail.host | quote }})
     SENTRY_OPTIONS['mail.from'] = os.getenv("SENTRY_EMAIL_FROM", {{ .Values.mail.from | quote }})
+
+
+    #######################
+    # Filestore S3 Configuration #
+    #######################
+    {{- if .Values.filestore.s3.existingSecret }}
+    SENTRY_OPTIONS['filestore.backend'] = 's3'
+    SENTRY_OPTIONS['filestore.options'] = {
+      'access_key': os.getenv("S3_ACCESS_KEY", {{ .Values.filestore.s3.accessKey | quote }}),
+      'secret_key': os.getenv("S3_SECRET_KEY", ""),
+      'bucket_name': {{ .Values.filestore.s3.bucketName | quote }},
+      'region_name': {{ .Values.filestore.s3.region_name | quote }},
+    }
+    {{- end }}
+
 
     #########################
     # Bitbucket Integration #


### PR DESCRIPTION
If an existingSecret is specified, S3 Filestore options are configured in sentry.conf.py and a a secret is created in _helper.tpl