### PR TITLE
Update `apiVersion` by comparing kubernetes version

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.2.0
+version: 3.2.1
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/ingress-clickhouse.yaml
+++ b/clickhouse/templates/ingress-clickhouse.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.clickhouse.ingress.enabled}}
-apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "clickhouse.fullname" . }}

--- a/clickhouse/templates/ingress-tabix.yaml
+++ b/clickhouse/templates/ingress-tabix.yaml
@@ -1,6 +1,12 @@
 {{- if .Values.tabix.enabled }}
 {{- if .Values.tabix.ingress.enabled}}
-apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "clickhouse.fullname" . }}-tabix


### PR DESCRIPTION
Latest Kubernetes ingress no longer add `beta1` after apiVersion. This fix apply to enable installation of helm chart on kubernetes (+1.19). 