### PR TITLE
feat: Allow to pass missing env vars

### DIFF
--- a/sentry-kubernetes/Chart.yaml
+++ b/sentry-kubernetes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry-kubernetes
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 type: application
-version: 0.3.2
+version: 0.4.0
 appVersion: latest
 home: https://github.com/getsentry/sentry-kubernetes
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png

--- a/sentry-kubernetes/templates/deployment.yaml
+++ b/sentry-kubernetes/templates/deployment.yaml
@@ -35,18 +35,38 @@ spec:
               secretKeyRef:
                 name: {{ template "sentry-kubernetes.secretName" . }}
                 key: sentry.dsn
-          {{ if .Values.sentry.environment }}
+          {{ if .Values.sentry.environment -}}
           - name: ENVIRONMENT
             value: {{ .Values.sentry.environment }}
           {{ end }}
-          {{ if .Values.sentry.release }}
+          {{- if .Values.sentry.release -}}
           - name: RELEASE
             value: {{ .Values.sentry.release }}
           {{ end }}
-          {{ if .Values.sentry.logLevel }}
+          {{- if .Values.sentry.logLevel -}}
           - name: LOG_LEVEL
             value: {{ .Values.sentry.logLevel }}
           {{ end }}
+          {{- if .Values.sentry.eventNamespaces -}}
+          - name: EVENT_NAMESPACES
+            value: {{ .Values.sentry.eventNamespaces }}
+          {{ end }}
+          {{- if .Values.sentry.eventNamespacesExcluded -}}
+          - name: EVENT_NAMESPACES_EXCLUDED
+            value: {{ .Values.sentry.eventNamespacesExcluded }}
+          {{ end }}
+          {{- if .Values.sentry.componentFilter -}}
+          - name: COMPONENT_FILTER
+            value: {{ .Values.sentry.componentFilter }}
+          {{ end }}
+          {{- if .Values.sentry.eventLevels -}}
+          - name: EVENT_LEVELS
+            value: {{ .Values.sentry.eventLevels }}
+          {{ end }}
+          {{- if .Values.sentry.mangleNames -}}
+          - name: MANGLE_NAMES
+            value: {{ .Values.sentry.mangleNames }}
+          {{ end }}          
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}


### PR DESCRIPTION
[sentry-kubernetes ](https://github.com/getsentry/sentry-kubernetes) allows to specify multiple environ variables, but helm chart allows to specify only few of them. 

So I decided to add missing env vars to deployment spec. 