### PR TITLE
Add support to specify credentials of clickhouse users with existing secrets

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.2.1
+version: 3.2.2
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/_helpers.tpl
+++ b/clickhouse/templates/_helpers.tpl
@@ -54,3 +54,64 @@ if .Values.clickhouse.configmap.logger.path is empty, default value "/var/log/cl
 {{- printf "%s" "/var/log/clickhouse-server" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Returns available value for certain key in an existing secret (if it exists).
+*/}}
+{{- define "getValueFromSecret" }}
+	{{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
+	{{- if and ($obj) (hasKey $obj .Key) }}
+		{{- index $obj .Key | b64dec -}}
+	{{- end -}}
+{{- end -}}
+
+{{/*
+Take list of users from .Values.clickhouse.configmap.users.user and replace/add username and password/password_sha256_hex from existingSecret (if specified)
+Save the result into to clickhouse.users (used in configmap-users.yaml)
+*/}}
+{{- define "clickhouse.users" -}}
+	{{ $result := list }}
+	{{ $namespace := .Release.Namespace }}
+	{{ range $user := .Values.clickhouse.configmap.users.user }}
+		{{ $modifiedUser := mustDeepCopy $user }}
+		{{ if hasKey $user "existingSecret" }}
+			{{ if hasKey $user "existingSecretNameKey" }}
+				{{ $username := (include "getValueFromSecret" (dict "Namespace" $namespace "Name" $user.existingSecret "Key" $user.existingSecretNameKey))  }}
+				{{- if $username }}
+					{{ $_ := set $modifiedUser "name" $username }}
+				{{- else -}}
+					{{- $errorMessage := printf "given existingSecret '%s' or its existingSecretNameKey '%s' cannot be loaded" $user.existingSecret $user.existingSecretNameKey }}
+					{{- fail $errorMessage -}}
+				{{- end -}}
+			{{- end -}}
+
+			{{ $usersConfig := mustDeepCopy (default (dict) ($user.config)) }}
+			{{ if hasKey $user "existingSecretPasswordSHA256Key" }}
+				{{ $passwordSHA256 := (include "getValueFromSecret" (dict "Namespace" $namespace "Name" $user.existingSecret "Key" $user.existingSecretPasswordSHA256Key))  }}
+				{{- if $passwordSHA256 }}
+					{{ $_ := set $usersConfig "password_sha256_hex" $passwordSHA256 }}
+					{{ $_ := unset $usersConfig "password"}}
+				{{- else -}}
+					{{- $errorMessage := printf "given existingSecret '%s' or its existingSecretPasswordSHA256Key '%s' cannot be loaded" $user.existingSecret $user.existingSecretPasswordSHA256Key }}
+					{{- fail $errorMessage -}}
+				{{- end -}}
+			{{- end -}}
+			{{ if hasKey $user "existingSecretPasswordKey" }}
+				{{ $password := (include "getValueFromSecret" (dict "Namespace" $namespace "Name" $user.existingSecret "Key" $user.existingSecretPasswordKey))  }}
+				{{- if $password }}
+					{{ $_ := set $usersConfig "password_sha256_hex" (sha256sum $password) }}
+					{{ $_ := unset $usersConfig "password"}}
+				{{- else -}}
+					{{- $errorMessage := printf "given existingSecret '%s' or its existingSecretPasswordKey '%s' cannot be loaded" $user.existingSecret $user.existingSecretPasswordKey }}
+					{{- fail $errorMessage -}}
+				{{- end -}}
+			{{- end -}}
+			{{- if gt (len $usersConfig) 0 -}}
+				{{ $_ := set $modifiedUser "config" $usersConfig }}
+			{{- end -}}
+		{{- end -}}
+		{{ $result = mustAppend $result $modifiedUser }}
+	{{- end }}
+	{{ toJson $result }}
+{{- end }}

--- a/clickhouse/templates/configmap-users.yaml
+++ b/clickhouse/templates/configmap-users.yaml
@@ -27,7 +27,7 @@ data:
 
     {{- if .Values.clickhouse.configmap.users.enabled }}
         <users>
-        {{- range $key, $value := .Values.clickhouse.configmap.users.user }}
+        {{- range $key, $value := include "clickhouse.users" . | fromJsonArray }}
         {{- with . }}
             <{{ .name }}>
             {{- range $k_1, $v_1 := .config }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -344,16 +344,26 @@ clickhouse:
     ##
     ## The users section of the user.xml configuration file contains user settings.
     ## More info: https://clickhouse.yandex/docs/en/operations/settings/settings_users/
+    ## Username and password for each user can be loaded from an existing secret.
+    ## To define user's name from an existing secret, both 'user[x].existingSecret' and 'user[x].existingSecretNameKey' must be set. In that case, 'user[x].name' value is ignored.
+    ## To define user's password from an existing secret, an 'user[x].existingSecret' and ('user[x].existingSecretPasswordKey' or 'user[x].existingSecretPasswordSHA256Key') must be set. 
+    ##    In that case, values 'user[x].password' and 'user[x].password_sha256_hex' are ignored.
+    ## When existingSecret is specified but the secret doesn't exist or it doesn't contain given keys (existingSecretNameKey or existingSecretPasswordKey or existingSecretPasswordSHA256Key), error is raised.
     users:
       enabled: false
       user:
-      - name: "default"
+      - # existingSecret: 
+        # existingSecretNameKey:
+        # existingSecretPasswordKey:   
+        # existingSecretPasswordSHA256Key: 
+        name: "default"
         config:
           # password: ""
           networks:
           - "::/0"
           profile: "default"
           quota: "default"
+
     ##
     ## Quotas allow you to limit resource usage over a period of time, or simply track the use of resources.
     ## Quotas are set up in the user config. This is usually 'users.xml'.

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -346,17 +346,17 @@ clickhouse:
     ## More info: https://clickhouse.yandex/docs/en/operations/settings/settings_users/
     ## Username and password for each user can be loaded from an existing secret.
     ## To define user's name from an existing secret, both 'user[x].existingSecret' and 'user[x].existingSecretNameKey' must be set. In that case, 'user[x].name' value is ignored.
-    ## To define user's password from an existing secret, an 'user[x].existingSecret' and ('user[x].existingSecretPasswordKey' or 'user[x].existingSecretPasswordSHA256Key') must be set. 
+    ## To define user's password from an existing secret, an 'user[x].existingSecret' and ('user[x].existingSecretPasswordKey' or 'user[x].existingSecretPasswordSHA256Key') must be set.
     ##    In that case, values 'user[x].password' and 'user[x].password_sha256_hex' are ignored.
     ## When existingSecret is specified but the secret doesn't exist or it doesn't contain given keys (existingSecretNameKey or existingSecretPasswordKey or existingSecretPasswordSHA256Key), error is raised.
     users:
       enabled: false
       user:
-      - # existingSecret: 
+      - name: "default"
+        # existingSecret:
         # existingSecretNameKey:
-        # existingSecretPasswordKey:   
-        # existingSecretPasswordSHA256Key: 
-        name: "default"
+        # existingSecretPasswordKey:
+        # existingSecretPasswordSHA256Key:
         config:
           # password: ""
           networks:


### PR DESCRIPTION
Currently, the usernames and passwords of clickhouse users are passed from values to a configmap. It is not possible to define these values using an existing secret. Password can be defined using SHA256 hash, but it can be hard to maintain. A better option is to have one existing secret with an unhashed password that will be passed to both sentry and clickhouse helm charts. Clickhouse helm chart will load this secret using `lookup` function (as commonly used by bitnami helm charts or recommended by [this guide](https://codersociety.com/blog/articles/helm-best-practices#11-use-the-lookup-function-to-avoid-secret-regeneration)), hash it and insert it to a configmap. That is implemented in this PR. Backward compatibility is preserved.

PR editing sentry chart to also load clickhouse credentials will be submitted separately.