### PR TITLE
Added ConfigMap annotations

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.9.0
+version: 17.9.1
 appVersion: 22.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-memcached.yaml
+++ b/sentry/templates/configmap-memcached.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "sentry.fullname" . }}-memcached
+  annotations:
+   {{- range $key, $value := .Values.memcached.config.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
 data:
   MEMCACHED_MEMORY_LIMIT: "{{ .Values.memcached.memoryLimit }}"
   MEMCACHED_MAX_ITEM_SIZE: "{{ .Values.memcached.maxItemSize }}"

--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+   {{- range $key, $value := .Values.nginx.config.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   name: {{ template "sentry.fullname" . }}-nginx
 data:
   server-block.conf: |

--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -45,4 +45,4 @@ data:
         metrics_transactions: ingest-performance-metrics
         metrics_sessions: ingest-metrics
 
-{{ .Values.relayConf | indent 4 }}
+{{ .Values.config.relayConf | indent 4 }}

--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "sentry.fullname" . }}-relay
+  annotations:
+   {{- range $key, $value := .Values.config.relay.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -41,4 +45,4 @@ data:
         metrics_transactions: ingest-performance-metrics
         metrics_sessions: ingest-metrics
 
-{{ .Values.config.relay | indent 4 }}
+{{ .Values.relayConf | indent 4 }}

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry
+  annotations:
+   {{- range $key, $value := .Values.config.web.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "sentry.fullname" . }}-snuba
+  annotations:
+   {{- range $key, $value := .Values.config.relay.annotations }}
+     {{ $key }}: {{ $value | quote }}
+   {{- end }}
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/relay: {{ .Values.config.relay | sha256sum }}
+        checksum/relay: {{ .Values.config.relayConf | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-relay.yaml") . | sha256sum }}
         {{- if .Values.relay.annotations }}
 {{ toYaml .Values.relay.annotations | indent 8 }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -374,6 +374,8 @@ snuba:
     sidecars: []
     volumes: []
     # volumeMounts: []
+  config:
+    annotations: {}
 
   consumer:
     replicas: 1
@@ -739,6 +741,8 @@ nginx:
   existingServerBlockConfigmap: '{{ template "sentry.fullname" . }}'
   resources: {}
   replicaCount: 1
+  config:
+    annotations: {}
   service:
     type: ClusterIP
     ports:
@@ -830,10 +834,13 @@ config:
     # No Python Extension Config Given
   snubaSettingsPy: |
     # No Python Extension Config Given
-  relay: |
+  relayConf: |
     # No YAML relay config given
+  relay:
+    annotations: {}
   web:
     httpKeepalive: 15
+    annotations: {}
 
 clickhouse:
   enabled: true
@@ -1084,6 +1091,8 @@ memcached:
     - "-m $(MEMCACHED_MEMORY_LIMIT)"
     - "-I $(MEMCACHED_MAX_ITEM_SIZE)"
   extraEnvVarsCM: "sentry-memcached"
+  config:
+    annotations: {}
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
The initial task was to pass secrets to the ConfigMap through Vault Secret Webhook to secretly pass Slack/Google/Github tokens. To do this I need to add vault annotations to ConfigMap.

Lint test fails because kafka 16.3.2, zookeeper 9.0.0 are no longer available in the bitnami repo.