### PR TITLE
Add support for injecting Slack integration secrets via K8s secrets, and fix paths to Bitnami charts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
           ct lint \
             --target-branch=develop \
             --chart-dirs=. \
-            --chart-repos=bitnami=https://charts.bitnami.com/bitnami,sentry-kubernetes=https://sentry-kubernetes.github.io/charts
+            --chart-repos=bitnami=https://charts.bitnami.com/bitnami,bitnami-old=https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami,sentry-kubernetes=https://sentry-kubernetes.github.io/charts
      # It would be nice to turn on this testing, but it is hard to get right and
      # rather complex (as well as expensive in terms of runner compute time).
      # Additionally, this is out of scope of fixing the issue brought up in #456

--- a/sentry/Chart.lock
+++ b/sentry/Chart.lock
@@ -6,22 +6,22 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 16.12.1
 - name: kafka
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 16.3.2
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
   version: 3.2.0
 - name: zookeeper
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 9.0.0
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 8.32.2
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 10.16.2
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
   version: 12.0.4
-digest: sha256:89370355980c21097da681e8803e3b2911b27645b84d8f7865769282420ad68d
-generated: "2022-11-04T13:10:26.422245+01:00"
+digest: sha256:100e52b213962d99739dadb3d01800b811ef08340f23fd57ec7c0d2c71547f91
+generated: "2023-03-09T10:48:18.306934+11:00"

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 16.12.1
     condition: redis.enabled
   - name: kafka
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     version: 16.3.2
     condition: kafka.enabled
   - name: clickhouse
@@ -22,16 +22,16 @@ dependencies:
     version: 3.2.0
     condition: clickhouse.enabled
   - name: zookeeper
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     version: 9.0.0
     condition: zookeeper.enabled
   - name: rabbitmq
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     version: 8.32.2
     alias: rabbitmq
     condition: rabbitmq.enabled
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     version: 10.16.2
     condition: postgresql.enabled
   - name: nginx

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.9.1
+version: 17.10.1
 appVersion: 22.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -494,4 +494,21 @@ Common Sentry environment variables
       name: {{ .Values.mail.existingSecret }}
       key: {{ default "mail-password" .Values.mail.existingSecretKey }}
 {{- end }}
+{{- if .Values.slack.existingSecret }}
+- name: SLACK_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.slack.existingSecret }}
+      key: "client-id"
+- name: SLACK_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.slack.existingSecret }}
+      key: "client-secret"
+- name: SLACK_SIGNING_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.slack.existingSecret }}
+      key: "signing-secret"
+{{- end }}
 {{- end -}}

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -62,7 +62,7 @@ data:
     #########
     # Slack #
     #########
-    {{- if .Values.slack.clientId }}
+    {{- if and (.Values.slack.clientId) (.Values.slack.clientSecret) (.Values.slack.signingSecret) (not .Values.slack.existingSecret) }}
     slack.client-id: {{ .Values.slack.clientId | quote }}
     slack.client-secret: {{ .Values.slack.clientSecret | quote }}
     slack.signing-secret: {{ .Values.slack.signingSecret | quote }}
@@ -475,4 +475,12 @@ data:
     }
 {{- end }}
 
+{{- if .Values.slack.existingSecret }}
+    #########
+    # SLACK #
+    #########
+    SENTRY_OPTIONS['slack.client-id'] = os.environ.get("SLACK_CLIENT_ID")
+    SENTRY_OPTIONS['slack.client-secret'] = os.environ.get("SLACK_CLIENT_SECRET")
+    SENTRY_OPTIONS['slack.signing-secret'] = os.environ.get("SLACK_SIGNING_SECRET")
+{{- end }}
 {{ .Values.config.sentryConfPy | indent 4 }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -731,6 +731,7 @@ slack: {}
 #   clientId:
 #   clientSecret:
 #   signingSecret:
+#   existingSecret:
 #   Reference -> https://develop.sentry.dev/integrations/slack/
 
 nginx:


### PR DESCRIPTION
- Adds the ability to specify an existing K8s secret containing the parameters for the Slack integration, adds them as environment variables and configures Sentry to use them. Disclaimer: I have not tested this on my installation but the templates turn out alright. This should help resolve https://github.com/sentry-kubernetes/charts/issues/829
- Also, changed the repo URLs for some Bitnami charts that are more than 6 months old. See this issue: https://github.com/bitnami/charts/issues/10545