### PR TITLE
Implement concurrency

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.10.1
+version: 17.10.2
 appVersion: 22.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -71,6 +71,8 @@ spec:
               - "cleanup"
               - "--days"
               - "{{ .Values.sentry.cleanup.days }}"
+              - "--concurrency"
+              - "{{ .Values.sentry.cleanup.concurrency }}"
             env:
             - name: C_FORCE_ROOT
               value: "true"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -337,6 +337,7 @@ sentry:
     enabled: true
     schedule: "0 0 * * *"
     days: 90
+    concurrency: 1
     # securityContext: {}
     sidecars: []
     volumes: []


### PR DESCRIPTION
We always have a _very_ big nodestore_node table, and our clean-up cron takes a while. I discovered there is a concurrency option which removes the old NodeStore values a bit faster. 


When not providing the `--concurrency` option, the default used is `1`, so added this is the default in the values. One can override if they need more concurrency