### PR TITLE
Add missing annotations for relay hpa

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 17.11.1
+version: 17.11.2
 appVersion: 22.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/hpa-relay.yaml
+++ b/sentry/templates/hpa-relay.yaml
@@ -3,6 +3,11 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sentry.fullname" . }}-relay
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "25"
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
In some cases (for example, when using ArgoCD), the first installation of sentry fails, since an hpa is created for relay with a ref to a deployment that does not yet exist. The system waits for the "resource too healthy" and does not proceed to the post-install hook step, which is why the entire installation fails by timeout.

I think it would be more correct to apply the hpa manifest at the same time when the deployment is applied.