### PR TITLE
feat: Allow to set specified merge_tree settings in config.xml

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.2.1
+version: 3.3.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/configmap-config.yaml
+++ b/clickhouse/templates/configmap-config.yaml
@@ -115,5 +115,13 @@ data:
         {{- if .Values.clickhouse.configmap.interserver_http_host }}
         <interserver_http_host>{{ .Values.clickhouse.configmap.interserver_http_host }}</interserver_http_host>
         {{- end }}
+
+        {{- if .Values.clickhouse.configmap.merge_tree.enabled }}
+        <merge_tree>
+            <parts_to_delay_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_delay_insert }}</parts_to_delay_insert> 
+            <parts_to_throw_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_throw_insert }}</parts_to_throw_insert> 
+            <max_part_loading_threads>{{ .Values.clickhouse.configmap.merge_tree.max_part_loading_threads }}</max_part_loading_threads> 
+        </merge_tree>
+        {{- end }}
     </yandex>
 {{- end }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -369,6 +369,16 @@ clickhouse:
           result_rows: "0"
           read_rows: "0"
           execution_time: "0"
+    ## Allows to configure specified MergeTree tables settings in config.xml
+    ## More info: https://clickhouse.com/docs/en/operations/settings/merge-tree-settings
+    merge_tree:
+      enabled: false
+      # If the number of active parts in a single partition exceeds the parts_to_delay_insert value, an INSERT artificially slows down.
+      parts_to_delay_insert: 150
+      # If the number of inactive parts in a single partition more than the inactive_parts_to_throw_insert value, INSERT is interrupted with the "Too many inactive parts (N). Parts cleaning are processing significantly slower than inserts" exception.
+      parts_to_throw_insert: 300
+      # The maximum number of threads that read parts when ClickHouse starts.
+      max_part_loading_threads: auto
 
 ##
 ## Web interface for ClickHouse in the Tabix project.


### PR DESCRIPTION
A few weeks ago I faced a problem with [clickhouse](https://github.com/sentry-kubernetes/charts/issues/743).
The solution was to add [merge_tree setting](https://github.com/sentry-kubernetes/charts/issues/743#issuecomment-1312918533) to Clickhouse `config.xml`.

Unfortunately, it is not possible to set above settings via chart values so I decided to add handling these specific params.
