### PR TITLE
Ingress Path Matching In Traefik

### DIFF
--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -139,7 +139,7 @@ spec:
               servicePort: {{ template "relay.port" . }}
               {{- end }}
         {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "traefik" }}
-          - path: {{ default "/" .Values.ingress.path }}api/{[1-9][0-9]*}/{(.*)}
+          - path: {{ default "/" .Values.ingress.path }}api/{id:[1-9][0-9]*}/{rest:(.*)}
         {{- else }}
           - path: {{ default "/" .Values.ingress.path }}api/[1-9][0-9]*/(.*)
         {{- end }}


### PR DESCRIPTION
Need to change path to another view, [as described in Github](https://github.com/traefik/traefik/issues/5606)

Example:
path: /api/{id:[1-9][0-9]*}/{rest:(.*)}

regex in Traefik works only when we named it as a variable.