### PR TITLE
add container security context

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 19.3.0
+version: 19.4.0
 appVersion: 23.6.1
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -95,6 +95,10 @@ spec:
 {{- end }}
             resources:
 {{ toYaml .Values.sentry.cleanup.resources | indent 14 }}
+{{- if .Values.sentry.cleanup.containerSecurityContext }}
+            securityContext:
+{{ toYaml .Values.sentry.cleanup.containerSecurityContext | indent 14 }}
+{{- end }}
 {{- if .Values.sentry.cleanup.sidecars }}
 {{ toYaml .Values.sentry.cleanup.sidecars | indent 10 }}
 {{- end }}

--- a/sentry/templates/deployment-metrics.yaml
+++ b/sentry/templates/deployment-metrics.yaml
@@ -98,6 +98,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
+{{- if .Values.metrics.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.metrics.containerSecurityContext | indent 10 }}
+{{- end }}
 {{- if .Values.metrics.volumes }}
       volumes:
 {{ toYaml .Values.metrics.volumes | indent 6 }}

--- a/sentry/templates/deployment-relay.yaml
+++ b/sentry/templates/deployment-relay.yaml
@@ -74,6 +74,10 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.relay.init.resources | indent 12 }}
+{{- if .Values.relay.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.relay.containerSecurityContext | indent 12 }}
+{{- end }}
           env:
             - name: RELAY_PORT
               value: '{{ template "relay.port" }}'
@@ -149,6 +153,10 @@ spec:
           timeoutSeconds: {{ .Values.relay.probeTimeoutSeconds }}
         resources:
 {{ toYaml .Values.relay.resources | indent 12 }}
+{{- if .Values.relay.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.relay.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.relay.sidecars }}
 {{ toYaml .Values.relay.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-billing-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-billing-metrics-consumer.yaml
@@ -104,6 +104,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.billingMetricsConsumer.resources | indent 12 }}
+{{- if .Values.sentry.billingMetricsConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.billingMetricsConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.billingMetricsConsumer.sidecars }}
 {{ toYaml .Values.sentry.billingMetricsConsumer.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -89,6 +89,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.cron.resources | indent 12 }}
+{{- if .Values.sentry.cron.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.cron.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.cron.sidecars }}
 {{ toYaml .Values.sentry.cron.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
@@ -109,6 +109,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumer.resources | indent 12 }}
+{{- if .Values.sentry.ingestConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestConsumer.sidecars }}
 {{ toYaml .Values.sentry.ingestConsumer.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
@@ -109,6 +109,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumer.resources | indent 12 }}
+{{- if .Values.sentry.ingestConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestConsumer.sidecars }}
 {{ toYaml .Values.sentry.ingestConsumer.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -109,6 +109,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumer.resources | indent 12 }}
+{{- if .Values.sentry.ingestConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestConsumer.sidecars }}
 {{ toYaml .Values.sentry.ingestConsumer.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-metrics-consumer-perf.yaml
+++ b/sentry/templates/deployment-sentry-ingest-metrics-consumer-perf.yaml
@@ -106,6 +106,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestMetricsConsumerPerf.resources | indent 12 }}
+{{- if .Values.sentry.ingestMetricsConsumerPerf.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestMetricsConsumerPerf.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestMetricsConsumerPerf.sidecars }}
 {{ toYaml .Values.sentry.ingestMetricsConsumerPerf.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-metrics-consumer-rh.yaml
+++ b/sentry/templates/deployment-sentry-ingest-metrics-consumer-rh.yaml
@@ -106,6 +106,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestMetricsConsumerRh.resources | indent 12 }}
+{{- if .Values.sentry.ingestMetricsConsumerRh.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestMetricsConsumerRh.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestMetricsConsumerRh.sidecars }}
 {{ toYaml .Values.sentry.ingestMetricsConsumerRh.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-monitors.yaml
+++ b/sentry/templates/deployment-sentry-ingest-monitors.yaml
@@ -100,6 +100,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestMonitors.resources | indent 12 }}
+{{- if .Values.sentry.ingestMonitors.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestMonitors.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestMonitors.sidecars }}
 {{ toYaml .Values.sentry.ingestMonitors.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-replay-recordings.yaml
+++ b/sentry/templates/deployment-sentry-ingest-replay-recordings.yaml
@@ -100,6 +100,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestReplayRecordings.resources | indent 12 }}
+{{- if .Values.sentry.ingestReplayRecordings.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.ingestReplayRecordings.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.ingestReplayRecordings.sidecars }}
 {{ toYaml .Values.sentry.ingestReplayRecordings.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
@@ -98,6 +98,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForwardErrors.resources | indent 12 }}
+{{- if .Values.sentry.postProcessForwardErrors.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.postProcessForwardErrors.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.postProcessForwardErrors.sidecars }}
 {{ toYaml .Values.sentry.postProcessForwardErrors.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -101,6 +101,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForwardTransactions.resources | indent 12 }}
+{{- if .Values.sentry.postProcessForwardTransactions.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.postProcessForwardTransactions.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.postProcessForwardTransactions.sidecars }}
 {{ toYaml .Values.sentry.postProcessForwardTransactions.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
@@ -91,6 +91,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.resources | indent 12 }}
+{{- if .Values.sentry.subscriptionConsumerEvents.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.subscriptionConsumerEvents.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.subscriptionConsumerEvents.sidecars }}
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
@@ -91,6 +91,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.resources | indent 12 }}
+{{- if .Values.sentry.subscriptionConsumerTransactions.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.subscriptionConsumerTransactions.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.subscriptionConsumerTransactions.sidecars }}
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -122,6 +122,10 @@ spec:
           timeoutSeconds: {{ .Values.sentry.web.probeTimeoutSeconds }}
         resources:
 {{ toYaml .Values.sentry.web.resources | indent 12 }}
+{{- if .Values.sentry.web.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.web.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.web.sidecars }}
 {{ toYaml .Values.sentry.web.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -112,6 +112,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.worker.resources | indent 12 }}
+{{- if .Values.sentry.worker.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.worker.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.sentry.worker.sidecars }}
 {{ toYaml .Values.sentry.worker.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-api.yaml
+++ b/sentry/templates/deployment-snuba-api.yaml
@@ -107,6 +107,10 @@ spec:
           timeoutSeconds: {{ .Values.snuba.api.readiness.timeoutSeconds }}
         resources:
 {{ toYaml .Values.snuba.api.resources | indent 12 }}
+{{- if .Values.snuba.api.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.api.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- if .Values.snuba.api.sidecars }}
 {{ toYaml .Values.snuba.api.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -130,6 +130,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.consumer.resources | indent 12 }}
+{{- if .Values.snuba.consumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.consumer.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -126,6 +126,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.outcomesConsumer.resources | indent 12 }}
+{{- if .Values.snuba.outcomesConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.outcomesConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -109,6 +109,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.replacer.resources | indent 12 }}
+{{- if .Values.snuba.replacer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.replacer.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-replays-consumer.yaml
+++ b/sentry/templates/deployment-snuba-replays-consumer.yaml
@@ -132,6 +132,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.replaysConsumer.resources | indent 12 }}
+{{- if .Values.snuba.replaysConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.replaysConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-sessions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-sessions-consumer.yaml
@@ -130,6 +130,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.sessionsConsumer.resources | indent 12 }}
+{{- if .Values.snuba.sessionsConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.sessionsConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -97,6 +97,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.resources | indent 12 }}
+{{- if .Values.snuba.subscriptionConsumerEvents.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.subscriptionConsumerEvents.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-sessions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-sessions.yaml
@@ -97,6 +97,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerSessions.resources | indent 12 }}
+{{- if .Values.snuba.subscriptionConsumerSessions.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.subscriptionConsumerSessions.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -97,6 +97,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.resources | indent 12 }}
+{{- if .Values.snuba.subscriptionConsumerTransactions.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.subscriptionConsumerTransactions.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -132,6 +132,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.snuba.transactionsConsumer.resources | indent 12 }}
+{{- if .Values.snuba.transactionsConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.transactionsConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
       {{- end }}

--- a/sentry/templates/deployment-symbolicator.yaml
+++ b/sentry/templates/deployment-symbolicator.yaml
@@ -110,6 +110,10 @@ spec:
           timeoutSeconds: 2
         resources:
 {{ toYaml .Values.symbolicator.api.resources | indent 12 }}
+{{- if .Values.symbolicator.api.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.symbolicator.api.containerSecurityContext | indent 12 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
       {{- end }}

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -59,9 +59,14 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.hooks.dbCheck.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.dbCheck.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.dbCheck.securityContext | indent 8 }}
+      {{- else }}
       {{- if .Values.hooks.securityContext }}
       securityContext:
 {{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: db-check
@@ -147,6 +152,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.dbCheck.resources | indent 10 }}
+{{- if .Values.hooks.dbCheck.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.dbCheck.containerSecurityContext | indent 10 }}
+{{- end }}
 {{- if .Values.hooks.dbCheck.volumes }}
       volumes:
 {{ toYaml .Values.hooks.dbCheck.volumes | indent 6 }}

--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -63,9 +63,14 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.dbInit.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.dbInit.securityContext | indent 8 }}
+      {{- else }}
       {{- if .Values.hooks.securityContext }}
       securityContext:
 {{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: db-init-job
@@ -86,6 +91,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
+{{- if .Values.hooks.dbInit.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.dbInit.containerSecurityContext | indent 10 }}
+{{- end }}
 {{- if .Values.hooks.dbInit.sidecars }}
 {{ toYaml .Values.hooks.dbInit.sidecars | indent 6 }}
 {{- end }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -65,9 +65,14 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.snubaInit.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.snubaInit.securityContext | indent 8 }}
+      {{- else }}
       {{- if .Values.hooks.securityContext }}
       securityContext:
 {{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: snuba-init
@@ -92,6 +97,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
+{{- if .Values.hooks.snubaInit.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.snubaInit.containerSecurityContext | indent 10 }}
+{{- end }}
       volumes:
       - name: config
         configMap:

--- a/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -65,9 +65,14 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.snubaMigrate.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.snubaMigrate.securityContext | indent 8 }}
+      {{- else }}
       {{- if .Values.hooks.securityContext }}
       securityContext:
 {{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: snuba-migrate
@@ -92,6 +97,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
+{{- if .Values.hooks.snubaMigrate.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.snubaMigrate.containerSecurityContext | indent 10 }}
+{{- end }}
       volumes:
       - name: config
         configMap:

--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -58,9 +58,14 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.dbInit.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.dbInit.securityContext | indent 8 }}
+      {{- else }}
       {{- if .Values.hooks.securityContext }}
       securityContext:
 {{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: user-create-job
@@ -105,6 +110,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
+{{- if .Values.hooks.dbInit.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.dbInit.containerSecurityContext | indent 10 }}
+{{- end }}
       volumes:
       - name: config
         configMap:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -63,6 +63,7 @@ relay:
   affinity: {}
   nodeSelector: {}
   securityContext: {}
+  containerSecurityContext: {}
   service:
     annotations: {}
   # tolerations: []
@@ -107,6 +108,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     service:
       annotations: {}
     # tolerations: []
@@ -163,6 +165,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
@@ -189,6 +192,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
@@ -215,6 +219,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
@@ -240,6 +245,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
 
@@ -264,6 +270,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
 
@@ -289,6 +296,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     # maxBatchSize: ""
@@ -326,6 +334,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     sidecars: []
@@ -340,6 +349,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     sidecars: []
@@ -354,6 +364,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     sidecars: []
@@ -368,6 +379,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     sidecars: []
@@ -381,6 +393,7 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     sidecars: []
@@ -397,6 +410,7 @@ sentry:
     schedule: "0 0 * * *"
     days: 90
     # securityContext: {}
+    # containerSecurityContext: {}
     sidecars: []
     volumes: []
     # volumeMounts: []
@@ -420,6 +434,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     service:
       annotations: {}
     # tolerations: []
@@ -441,6 +456,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -468,6 +484,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -495,6 +512,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -511,6 +529,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -524,6 +543,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -537,6 +557,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     # commitBatchSize: 1
@@ -553,6 +574,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -580,6 +602,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -607,6 +630,7 @@ snuba:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
@@ -656,6 +680,7 @@ hooks:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # volumes: []
     # volumeMounts: []
@@ -729,6 +754,7 @@ symbolicator:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
     # priorityClassName: "xxx"
@@ -1221,6 +1247,7 @@ metrics:
   tolerations: []
   affinity: {}
   securityContext: {}
+  containerSecurityContext: {}
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []


### PR DESCRIPTION
We are currently trying to deploy this chart to our very restrictive environment. This environment, requires to specify the `allowPrivilegeEscalation` which is only valid on container level security context. Currently the sentry and snuba charts only allow to specify the security context of the pod. With this MR I adapted the charts to specify the security context for the pod and container, like its also done in the bitnami charts.