### PR TITLE
Extend Redis functionality

### DIFF
--- a/sentry/templates/configmap-relay.yaml
+++ b/sentry/templates/configmap-relay.yaml
@@ -1,6 +1,8 @@
-{{- $redisHost := include "sentry.redis.host" . -}}
-{{- $redisPort := include "sentry.redis.port" . -}}
-{{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisHost   := include "sentry.redis.host" . -}}
+{{- $redisPort   := include "sentry.redis.port" . -}}
+{{- $redisPass   := include "sentry.redis.password" . -}}
+{{- $redisDb     := include "sentry.redis.db" . -}}
+{{- $redisProto  := ternary "rediss" "redis" (eq (include "sentry.redis.ssl" .) "true")  -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,11 +34,12 @@ data:
         - name: "message.max.bytes"
           value: 50000000  # 50MB or bust
 
-      {{- if $redisPass }}
-      redis: "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
+      {{- if $redisPass }}    
+      redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
       {{- else }}
-      redis: "redis://{{ $redisHost }}:{{ $redisPort }}"
+      redis: "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
       {{- end }}
+
       topics:
         metrics_transactions: ingest-performance-metrics
         metrics_sessions: ingest-metrics

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -1,6 +1,8 @@
-{{- $redisHost := include "sentry.redis.host" . -}}
-{{- $redisPort := include "sentry.redis.port" . -}}
-{{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisHost   := include "sentry.redis.host" . -}}
+{{- $redisPort   := include "sentry.redis.port" . -}}
+{{- $redisPass   := include "sentry.redis.password" . -}}
+{{- $redisDb     := include "sentry.redis.db" . -}}
+{{- $redisProto  := ternary "rediss" "redis" (eq (include "sentry.redis.ssl" .) "true")  -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -72,15 +74,7 @@ data:
     #########
     # Redis #
     #########
-    redis.clusters:
-      default:
-        hosts:
-          0:
-            host: {{ $redisHost | quote }}
-            port: {{ $redisPort }}
-            {{- if $redisPass }}
-            password: {{ $redisPass | quote }}
-            {{- end }}
+    # This is configured in the sentry.conf.py as that has support for environment variables.
 
     ################
     # File storage #
@@ -201,6 +195,29 @@ data:
     SENTRY_OPTIONS["system.event-retention-days"] = int(env('SENTRY_EVENT_RETENTION_DAYS') or {{ .Values.sentry.cleanup.days | quote }})
 
     #########
+    # Redis #
+    #########
+
+    # Generic Redis configuration used as defaults for various things including:
+    # Buffers, Quotas, TSDB
+
+    SENTRY_OPTIONS["redis.clusters"] = {
+      "default": {
+        "hosts": {
+          0: {
+            "host": {{ $redisHost | quote }},
+            "password": os.environ.get("REDIS_PASSWORD", {{ $redisPass | quote }}),
+            "port": {{ $redisPort | quote }},
+            {{- if .Values.externalRedis.ssl }}
+            "ssl": {{ .Values.externalRedis.ssl | quote }},
+            {{- end }}
+            "db": {{ $redisDb | quote }}
+          }
+        }
+      }
+    }
+
+    #########
     # Queue #
     #########
 
@@ -210,10 +227,12 @@ data:
 
     {{- if or (.Values.rabbitmq.enabled) (.Values.rabbitmq.host) }}
     BROKER_URL = os.environ.get("BROKER_URL", "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ template "sentry.rabbitmq.host" . }}:5672/{{ .Values.rabbitmq.vhost }}")
-    {{- else if $redisPass }}
-    BROKER_URL = os.environ.get("BROKER_URL", "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/0")
     {{- else }}
-    BROKER_URL = os.environ.get("BROKER_URL", "redis://{{ $redisHost }}:{{ $redisPort }}/0")
+    {{- if $redisPass }}
+    BROKER_URL = os.environ.get("BROKER_URL", "{{ $redisProto }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}")
+    {{- else }}
+    BROKER_URL = os.environ.get("BROKER_URL", "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}")
+    {{- end }}
     {{- end }}
 
     #########

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -1,4 +1,6 @@
 {{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisDb   := include "sentry.redis.db" . -}}
+{{- $redisSsl  := include "sentry.redis.ssl" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -66,10 +68,17 @@ data:
     # Redis Options
     REDIS_HOST = {{ include "sentry.redis.host" . | quote }}
     REDIS_PORT = {{ include "sentry.redis.port" . }}
-    {{- if $redisPass }}
-    REDIS_PASSWORD = {{ $redisPass | quote }}
+    {{- if or ($redisPass) (.Values.externalRedis.existingSecret) }}
+    REDIS_PASSWORD = env("REDIS_PASSWORD")
     {{- end }}
+    {{- if $redisDb }}
+    REDIS_DB = {{ $redisDb }}
+    {{- else }}
     REDIS_DB = int(env("REDIS_DB", 1))
+    {{- end }}
+    {{- if $redisSsl  }}
+    REDIS_SSL = {{ $redisSsl | quote }}
+    {{- end }}
 
 {{- if .Values.metrics.enabled }}
     DOGSTATSD_HOST = "{{ template "sentry.fullname" . }}-metrics"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1073,6 +1073,19 @@ externalRedis:
   port: 6379
   ## Just omit the password field if your redis cluster doesn't use password
   # password: redis
+  # existingSecret: secret-name
+  ## set existingSecretKey if key name inside existingSecret is different from redis-password'
+  # existingSecretKey: secret-key-name
+  ## Integer database number to use for redis (This is an integer)
+  # db: 0
+  ## Use ssl for the connection to Redis (True/False)
+  # ssl: false
+  ## Use brokerUrl to configure a secret for the broker_url value
+  ## This allows to set a secure password for the broker.
+  #brokerUrl:
+  # existingSecret: secret-name
+  # existingSecretKey: sentry-key-name
+
 
 postgresql:
   enabled: true


### PR DESCRIPTION
- Adds support to set REDIS_PASSWORD as a kubernetes secret.
- Adds support to set externalredis.db too choose the db number
- Adds support to use externalredis.ssl for secure ssl
- Adds support to set externalredis.brokerUrl, this overrides the BROKER_URL environment variable that is used to set the broker with a secret.

The changes are backwards compatible/optional so they won't break existing setups.