### PR TITLE
(super tiny change) remove sentry "10" from title to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Sentry 10 helm charts
+# Sentry helm charts
 
 Sentry is a cross-platform crash reporting and aggregation platform.
 
-This repository aims to support Sentry 10 and move out from the deprecated Helm charts official repo.
+This repository aims to support Sentry >=10 and move out from the deprecated Helm charts official repo.
 
 Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/charts/tree/master/stable/sentry). This work has been partly inspired by it.
 


### PR DESCRIPTION
Thanks for the package! To be honest, when I firstly read this, I thought it was for sentry 10, not for the latest sentry 23. So hopefully this super tiny PR can avoid future confusions :)