### PR TITLE
Add security context to clickhouse init container

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.3.0
+version: 3.4.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -78,6 +78,10 @@ spec:
         resources:
 {{ toYaml .Values.clickhouse.init.resources | indent 10 }}
         {{- end }}
+        {{- with .Values.clickhouse.init.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}-replica
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -77,6 +77,10 @@ spec:
         resources:
 {{ toYaml .Values.clickhouse.init.resources | indent 10 }}
         {{- end }}
+        {{- with .Values.clickhouse.init.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -145,6 +145,8 @@ clickhouse:
   ## Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated.
   ## More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
     resources: {}
+    # Security Context
+    securityContext: {}
   livenessProbe:
     enabled: true
     initialDelaySeconds: "30"


### PR DESCRIPTION
in addition to [MR904](https://github.com/sentry-kubernetes/charts/pull/904) I also added an option to add the security context to the clickhouse init container