### PR TITLE
add option to disable init container

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.3.0
+version: 3.5.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -64,6 +64,7 @@ spec:
       - name: {{ . | quote }}
     {{- end }}
     {{- end }}
+      {{- if .Values.clickhouse.init.enabled }}
       initContainers:
       - name: init
         image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
@@ -77,6 +78,7 @@ spec:
         resources:
 {{ toYaml .Values.clickhouse.init.resources | indent 10 }}
         {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -138,6 +138,7 @@ clickhouse:
   resources: {}
 
   init:
+    enabled: true
     image: "busybox"
     imageVersion: "1.31.0"
     imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
I added an option to disable the init container as on my environment the container cannot be modified as the containers have to be running without root rights. Currently the used base image already has that directory configured, so we also don't need it. (Nevertheless leaving the default to enabled)