### PR TITLE
Drop useless clickhouse init container

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.4.0
+version: 3.5.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -65,19 +65,6 @@ spec:
       - name: {{ . | quote }}
     {{- end }}
     {{- end }}
-      initContainers:
-      - name: init
-        image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
-        imagePullPolicy: {{ .Values.clickhouse.init.imagePullPolicy }}
-        args:
-        - /bin/sh
-        - -c
-        - |
-          mkdir -p /etc/clickhouse-server/metrica.d
-        {{- if .Values.clickhouse.init.resources }}
-        resources:
-{{ toYaml .Values.clickhouse.init.resources | indent 10 }}
-        {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}-replica
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -64,19 +64,6 @@ spec:
       - name: {{ . | quote }}
     {{- end }}
     {{- end }}
-      initContainers:
-      - name: init
-        image: {{ .Values.clickhouse.init.image }}:{{ .Values.clickhouse.init.imageVersion }}
-        imagePullPolicy: {{ .Values.clickhouse.init.imagePullPolicy }}
-        args:
-        - /bin/sh
-        - -c
-        - |
-          mkdir -p /etc/clickhouse-server/metrica.d
-        {{- if .Values.clickhouse.init.resources }}
-        resources:
-{{ toYaml .Values.clickhouse.init.resources | indent 10 }}
-        {{- end }}
       containers:
       - name: {{ include "clickhouse.fullname" . }}
         image: {{ .Values.clickhouse.image }}:{{ .Values.clickhouse.imageVersion }}

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -137,14 +137,6 @@ clickhouse:
   ## The resource limits and requests used by clickhouse
   resources: {}
 
-  init:
-    image: "busybox"
-    imageVersion: "1.31.0"
-    imagePullPolicy: "IfNotPresent"
-  # imagePullSecrets:
-  ## Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated.
-  ## More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-    resources: {}
   livenessProbe:
     enabled: true
     initialDelaySeconds: "30"


### PR DESCRIPTION
So after a roundtrip I think we should drop the init container as the only thing it does is:
`mkdir -p /etc/clickhouse-server/metrica.d`

As the directory already exists in the base image, we don't need the mkdir.

So we also don't need to merge #928 #929 and can close them