### PR TITLE
Upgrade clickhouse

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.3.0
+version: 3.4.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/configmap-config.yaml
+++ b/clickhouse/templates/configmap-config.yaml
@@ -33,7 +33,51 @@ data:
         <timezone>{{ .Values.timezone | default "Asia/Shanghai" }}</timezone>
         <umask>{{ .Values.clickhouse.configmap.umask | default "027" }}</umask>
         <mlock_executable>{{ .Values.clickhouse.configmap.mlock_executable | default "false" }}</mlock_executable>
-        <remote_servers incl="clickhouse_remote_servers" optional="true" />
+        {{- if .Values.clickhouse.configmap.remote_servers.enabled }}
+        <remote_servers>
+            <{{ include "clickhouse.fullname" . }}>
+            {{- range untilStep 0 (int .Values.clickhouse.replicas) 1 }}
+                <shard>
+                    <replica>
+                        <internal_replication>{{ $.Values.clickhouse.configmap.remote_servers.internal_replication | default "false" }}</internal_replication>
+                        <host>{{ include "clickhouse.fullname" $ }}-{{ . }}.{{ include "clickhouse.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}</host>
+                        <port>{{ $.Values.clickhouse.tcp_port}}</port>
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.user }}
+                        <user>{{ $.Values.clickhouse.configmap.remote_servers.replica.user }}</user>
+                      {{- end }}
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.password }}
+                        <password>{{ $.Values.clickhouse.configmap.remote_servers.replica.password }}</password>
+                      {{- end }}
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.secure }}
+                        <secure>{{ $.Values.clickhouse.configmap.remote_servers.replica.secure }}</secure>
+                      {{- end }}
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.compression }}
+                        <compression>{{ $.Values.clickhouse.configmap.remote_servers.replica.compression }}</compression>
+                      {{- end }}
+                    </replica>
+                    {{- if $.Values.clickhouse.configmap.remote_servers.replica.backup.enabled }}
+                    <replica>
+                        <host>{{ include "clickhouse.fullname" $ }}-replica-{{ . }}.{{ include "clickhouse.fullname" $ }}-replica-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}</host>
+                        <port>{{ $.Values.clickhouse.tcp_port}}</port>
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.user }}
+                        <user>{{ $.Values.clickhouse.configmap.remote_servers.replica.user }}</user>
+                      {{- end }}
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.password }}
+                        <password>{{ $.Values.clickhouse.configmap.remote_servers.replica.password }}</password>
+                      {{- end }}
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.secure }}
+                        <secure>{{ $.Values.clickhouse.configmap.remote_servers.replica.secure }}</secure>
+                      {{- end }}
+                      {{- if $.Values.clickhouse.configmap.remote_servers.replica.compression }}
+                        <compression>{{ $.Values.clickhouse.configmap.remote_servers.replica.compression }}</compression>
+                      {{- end }}
+                    </replica>
+                    {{- end }}
+                </shard>   
+            {{- end }}
+            </{{ include "clickhouse.fullname" . }}>
+        </remote_servers>
+        {{- end }}
         <zookeeper incl="zookeeper-servers" optional="true" />
         <macros incl="macros" optional="true" />
         <builtin_dictionaries_reload_interval>{{ .Values.clickhouse.configmap.builtin_dictionaries_reload_interval | default "3600" }}</builtin_dictionaries_reload_interval>

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 19.4.0
+version: 19.5.0
 appVersion: 23.6.1
 dependencies:
   - name: memcached

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -956,7 +956,7 @@ config:
 clickhouse:
   enabled: true
   clickhouse:
-    imageVersion: "20.12.8.5"
+    imageVersion: "21.8.13.6"
     configmap:
       remote_servers:
         internal_replication: true
@@ -1045,6 +1045,8 @@ kafka:
       - name: ingest-transactions
       - name: ingest-events
       - name: ingest-replay-recordings
+      - name: ingest-metrics
+      - name: ingest-performance-metrics
       - name: profiles
 
   service:


### PR DESCRIPTION
I took a deeper look at the upgrade problem of clickhouse, as the old clickhouse version doesn't run as non-root in my environment. The trick was to configure the `sentry-clickhouse` cluster correct. After that the migration scripts will find the cluster and it's running