### PR TITLE
Add ingest consumers HPA templates

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.0.0
+version: 20.0.1
 appVersion: 23.6.1
 dependencies:
   - name: memcached

--- a/sentry/templates/hpa-billingMetricsConsumer.yaml
+++ b/sentry/templates/hpa-billingMetricsConsumer.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-billing-metrics-consumer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-billing-metrics-consumer
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/sentry/templates/hpa-ingestMetricsConsumerPerf.yaml
+++ b/sentry/templates/hpa-ingestMetricsConsumerPerf.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-metrics-consumer-perf
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-metrics-consumer-perf
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/sentry/templates/hpa-ingestMetricsConsumerRh.yaml
+++ b/sentry/templates/hpa-ingestMetricsConsumerRh.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-metrics-consumer-rh
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-metrics-consumer-rh
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/sentry/templates/hpa-ingestMonitors.yaml
+++ b/sentry/templates/hpa-ingestMonitors.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-monitors
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-monitors
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/sentry/templates/hpa-ingestReplayRecordings.yaml
+++ b/sentry/templates/hpa-ingestReplayRecordings.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-replay-recordings
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-replay-recordings
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}


### PR DESCRIPTION
Autoscaling for ingest consumers is mentioned in [values.yaml](https://github.com/sentry-kubernetes/charts/blob/develop/sentry/values.yaml#L174) but HPA's are not created.