### PR TITLE
fix: Missing config for snuba migration

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.1.1
+version: 20.1.2
 appVersion: 23.7.1
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -46,6 +46,7 @@ data:
             "search_issues",
             "generic_metrics_counters",
             "spans",
+            "group_attributes",
         },
         {{- /*
           The default clickhouse installation runs in distributed mode, while the external


### PR DESCRIPTION
In the snuba [23.7.0 version](https://github.com/getsentry/snuba/releases/tag/23.7.0) they included a [snuba migration](https://github.com/getsentry/snuba/pull/4496/files) that needs a new key in the snuba settings config file to work properly.

If you try to upgrade the Helm chart to version 20.1.1 you should see this error in the sentry-snuba-migrations job:
```
Traceback (most recent call last):
  File "/usr/local/bin/snuba", line 33, in <module>
    sys.exit(load_entry_point('snuba', 'console_scripts', 'snuba')())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/src/snuba/snuba/cli/migrations.py", line 97, in migrate
    runner.run_all(
  File "/usr/src/snuba/snuba/migrations/runner.py", line 176, in run_all
    pending_migrations = self._get_pending_migrations()
  File "/usr/src/snuba/snuba/migrations/runner.py", line 392, in _get_pending_migrations
    group_migrations = self._get_pending_migrations_for_group(group)
  File "/usr/src/snuba/snuba/migrations/runner.py", line 415, in _get_pending_migrations_for_group
    raise MigrationInProgress(str(migration_key))
snuba.migrations.errors.MigrationInProgress: group_attributes: 0001_group_attributes
```

This happens because this key haven´t been applied properly.

If you try to run this snuba migration for the snuba api pod, you will see this error:
```
{"module": "snuba.migrations.runner", "event": "Reversing migration: 0001_group_attributes", "severity": "info", "timestamp": "2023-08-01T10:38:48.864867Z"}
Traceback (most recent call last):
  File "/usr/local/bin/snuba", line 33, in <module>
    sys.exit(load_entry_point('snuba', 'console_scripts', 'snuba')())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/src/snuba/snuba/cli/migrations.py", line 209, in reverse
    runner.reverse_migration(migration_key, force=force, fake=fake)
  File "/usr/src/snuba/snuba/migrations/runner.py", line 326, in reverse_migration
    self._reverse_migration_impl(migration_key)
  File "/usr/src/snuba/snuba/migrations/runner.py", line 383, in _reverse_migration_impl
    migration.backwards(context, dry_run)
  File "/usr/src/snuba/snuba/migrations/migration.py", line 157, in backwards
    op.execute()
  File "/usr/src/snuba/snuba/migrations/operations.py", line 44, in execute
    cluster = get_cluster(self._storage_set)
  File "/usr/src/snuba/snuba/clusters/cluster.py", line 488, in get_cluster
    raise UndefinedClickhouseCluster(
snuba.clusters.cluster.UndefinedClickhouseCluster: StorageSetKey.GROUP_ATTRIBUTES is not defined in the CLUSTERS setting for this environment
```

I tested this with my Helm chart installation and solves the issue without any problem.

If it fails for you, you can access to a snuba api pod and execute this commands after applying these release to fix the problem:
```
snuba migrations reverse-in-progress
snuba migrations run --migration-id 0001_group_attributes --group group_attributes --force
```