### PR TITLE
Add "ingest-monitors" to Kafka topics provisioning

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.2.0
+version: 20.3.0
 appVersion: 23.7.1
 dependencies:
   - name: memcached

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.3.0
+version: 20.2.1
 appVersion: 23.7.1
 dependencies:
   - name: memcached

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1050,6 +1050,7 @@ kafka:
       - name: ingest-replay-recordings
       - name: ingest-metrics
       - name: ingest-performance-metrics
+      - name: ingest-monitors
       - name: profiles
   zookeeper:
     enabled: true


### PR DESCRIPTION
The `ingest-monitors` Kafka topic is not getting automatically provisioned, causing the ingest-monitor deployment to fail by default.

This PR adds the `ingest-monitors` topic to the `kafka.provisioning.topics` list to automatically provision the topic.