### PR TITLE
Provision kafka topics in kafka-provisioning hook

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.3.1
+version: 20.4.0
 appVersion: 23.7.2
 dependencies:
   - name: memcached

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -77,7 +77,16 @@ spec:
       containers:
       - name: snuba-init
         image: "{{ template "snuba.image" . }}"
-        command: [snuba, bootstrap, --no-migrate, --no-kafka, --force]
+        command:
+        - snuba
+        - bootstrap
+        - --no-migrate
+        {{- if .Values.hooks.snubaInit.kafka.enabled }}
+        - --kafka
+        {{- else }}
+        - --no-kafka
+        {{- end }}
+        - --force
         env:
         - name: LOG_LEVEL
           value: debug

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -77,7 +77,7 @@ spec:
       containers:
       - name: snuba-init
         image: "{{ template "snuba.image" . }}"
-        command: [snuba, bootstrap, --no-migrate, --force]
+        command: [snuba, bootstrap, --no-migrate, --no-kafka, --force]
         env:
         - name: LOG_LEVEL
           value: debug

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -824,7 +824,7 @@ hooks:
   snubaInit:
     # As snubaInit doesn't support configuring partition and replication factor, you can disable snubaInit's kafka topic creation by setting `kafka.enabled` to `false`,
     # and create the topics using `kafka.provisioning.topics` with the desired partition and replication factor.
-    # Note that when you set `kafka.enabled` to `false`, snuba component might fail to start if brand new topics are not created by `kafka.provisioning`.
+    # Note that when you set `kafka.enabled` to `false`, snuba component might fail to start if newly added topics are not created by `kafka.provisioning`.
     kafka:
       enabled: true
     # podLabels: []

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -822,6 +822,8 @@ hooks:
     # volumes: []
     # volumeMounts: []
   snubaInit:
+    kafka:
+      enabled: true
     # podLabels: []
     podAnnotations: {}
     resources:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1164,6 +1164,51 @@ kafka:
   provisioning:
     enabled: true
     topics:
+      - name: events
+      - name: event-replacements
+      - name: snuba-commit-log
+      - name: cdc
+      - name: transactions
+      - name: snuba-transactions-commit-log
+      - name: snuba-metrics
+      - name: outcomes
+      - name: ingest-sessions
+      - name: snuba-sessions-commit-log
+      - name: snuba-metrics-commit-log
+      - name: scheduled-subscriptions-events
+      - name: scheduled-subscriptions-transactions
+      - name: scheduled-subscriptions-sessions
+      - name: scheduled-subscriptions-metrics
+      - name: scheduled-subscriptions-generic-metrics-sets
+      - name: scheduled-subscriptions-generic-metrics-distributions
+      - name: scheduled-subscriptions-generic-metrics-counters
+      - name: events-subscription-results
+      - name: transactions-subscription-results
+      - name: sessions-subscription-results
+      - name: metrics-subscription-results
+      - name: generic-metrics-subscription-results
+      - name: snuba-queries
+      - name: processed-profiles
+      - name: profiles-call-tree
+      - name: ingest-replay-events
+      - name: snuba-generic-metrics
+      - name: snuba-generic-metrics-sets-commit-log
+      - name: snuba-generic-metrics-distributions-commit-log
+      - name: snuba-generic-metrics-counters-commit-log
+      - name: generic-events
+      - name: snuba-generic-events-commit-log
+      - name: group-attributes
+      - name: snuba-attribution
+      - name: snuba-dead-letter-metrics
+      - name: snuba-dead-letter-metrics-sets
+      - name: snuba-dead-letter-metrics-counters
+      - name: snuba-dead-letter-metrics-distributions
+      - name: snuba-dead-letter-sessions
+      - name: snuba-dead-letter-generic-metrics
+      - name: snuba-dead-letter-replays
+      - name: snuba-dead-letter-generic-events
+      - name: snuba-dead-letter-querylog
+      - name: snuba-dead-letter-group-attributes
       - name: ingest-attachments
       - name: ingest-transactions
       - name: ingest-events

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1168,7 +1168,9 @@ kafka:
   socketRequestMaxBytes: "50000000"
   provisioning:
     enabled: true
-    # Topic list is based on https://github.com/getsentry/snuba/blob/master/snuba/utils/streams/topics.py
+    # Topic list is based on files below.
+    # - https://github.com/getsentry/snuba/blob/master/snuba/utils/streams/topics.py
+    # - https://github.com/getsentry/self-hosted/blob/master/install/create-kafka-topics.sh#L6
     # Note that snuba component might fail if you set `hooks.snubaInit.kafka.enabled` to `false` and remove the topics from this default topic list.
     topics:
       - name: events

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -822,6 +822,9 @@ hooks:
     # volumes: []
     # volumeMounts: []
   snubaInit:
+    # As snubaInit doesn't support configuring partition and replication factor, you can disable snubaInit's kafka topic creation by setting `kafka.enabled` to `false`,
+    # and create the topics using `kafka.provisioning.topics` with the desired partition and replication factor.
+    # Note that when you set `kafka.enabled` to `false`, snuba component might fail to start if brand new topics are not created by `kafka.provisioning`.
     kafka:
       enabled: true
     # podLabels: []
@@ -1165,6 +1168,8 @@ kafka:
   socketRequestMaxBytes: "50000000"
   provisioning:
     enabled: true
+    # Topic list is based on https://github.com/getsentry/snuba/blob/master/snuba/utils/streams/topics.py
+    # Note that snuba component might fail if you set `hooks.snubaInit.kafka.enabled` to `false` and remove the topics from this default topic list.
     topics:
       - name: events
       - name: event-replacements

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1172,12 +1172,18 @@ kafka:
     # Note that snuba component might fail if you set `hooks.snubaInit.kafka.enabled` to `false` and remove the topics from this default topic list.
     topics:
       - name: events
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: event-replacements
       - name: snuba-commit-log
       - name: cdc
       - name: transactions
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: snuba-transactions-commit-log
       - name: snuba-metrics
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: outcomes
       - name: ingest-sessions
       - name: snuba-sessions-commit-log
@@ -1195,16 +1201,29 @@ kafka:
       - name: metrics-subscription-results
       - name: generic-metrics-subscription-results
       - name: snuba-queries
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: processed-profiles
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: profiles-call-tree
       - name: ingest-replay-events
+        config:
+          "message.timestamp.type": LogAppendTime
+          "max.message.bytes": "15000000"
       - name: snuba-generic-metrics
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: snuba-generic-metrics-sets-commit-log
       - name: snuba-generic-metrics-distributions-commit-log
       - name: snuba-generic-metrics-counters-commit-log
       - name: generic-events
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: snuba-generic-events-commit-log
       - name: group-attributes
+        config:
+          "message.timestamp.type": LogAppendTime
       - name: snuba-attribution
       - name: snuba-dead-letter-metrics
       - name: snuba-dead-letter-metrics-sets


### PR DESCRIPTION
Disable kafka topic creation in `snuba-init` hook and move them to kafka-provisioning hook.
This will make kafka topic's partition, replication factor and other topic configs configurable as [here](https://github.com/bitnami/charts/blob/main/bitnami/kafka/values.yaml#L2014-L2026)

- ref: https://github.com/getsentry/snuba/issues/2188#issuecomment-975189971