### PR TITLE
fix: Create missing service accounts

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.3.1
+version: 20.3.2
 appVersion: 23.7.2
 dependencies:
   - name: memcached

--- a/sentry/templates/cronjob-sentry-cleanup.yaml
+++ b/sentry/templates/cronjob-sentry-cleanup.yaml
@@ -130,7 +130,7 @@ spec:
           {{- if .Values.sentry.cleanup.priorityClassName }}
           priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"
           {{- end }}
-          {{- if .Values.sentry.cleanup.serviceAccount }}
-          serviceAccountName: {{ .Values.sentry.cleanup.serviceAccount.name }}
+          {{- if .Values.serviceAccount.enabled }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}-cleanup
           {{- end }}
 {{- end }}

--- a/sentry/templates/serviceaccount-sentry-cleanup.yaml
+++ b/sentry/templates/serviceaccount-sentry-cleanup.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-cleanup
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/sentry/templates/serviceaccount-sentry-vroom.yaml
+++ b/sentry/templates/serviceaccount-sentry-vroom.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableProfiling }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-vroom
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}


### PR DESCRIPTION
When you try to enable the profiling option with the `serviceAccount.enabled as true`, it fails because the vroom service account is not available.
It throw the following error:
` Warning  FailedCreate  29s (x17 over 5m58s)  replicaset-controller  Error creating: pods "sentry-vroom-fd8b6496c-" is forbidden: error looking up service account sentry/sentry-vroom: serviceaccount "sentry-vroom" not found`


Something similar happens with the cleanup cronjob service account, when you enable the `serviceAccount.enabled as true` it should create a service account for the cleanup cronjob, but this doesn´t happen.
I modified the code of the cleanup cronjob to match the same format of the rest of deployments, this is needed to have a better manage of the service account privileges