### PR TITLE
fix: Fix wrong service account for ingest-profiles deployment

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.5.0
+version: 20.5.1
 appVersion: 23.8.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-profiles.yaml
+++ b/sentry/templates/deployment-sentry-ingest-profiles.yaml
@@ -109,7 +109,7 @@ spec:
 {{ toYaml .Values.sentry.ingestProfiles.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-replay-recordings
+      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-profiles
       {{- end }}
       volumes:
       - name: config


### PR DESCRIPTION
The service account of the ingest-profiles deployment is wrong, this PR fixes that problem and points the service account to the right one.