### PR TITLE
Renovate: update only charts version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,13 @@
   "labels": ["renovate"],
   "packageRules": [
     {
-      "matchManagers": ["helmv3", "github-actions"],
+      "matchManagers": ["helmv3"],
+      "matchDatasources": ["helm"],
+      "stabilityDays": 7,
+      "enabled": true
+    },
+    {
+      "matchManagers": ["github-actions"],
       "stabilityDays": 7,
       "enabled": true
     }


### PR DESCRIPTION
I've added an extra rule for Helm to limit the datasource that renovate will check.