### PR TITLE
fix: Set the right service account for ingest occurrences deployment

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.5.1
+version: 20.5.2
 appVersion: 23.8.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-occurrences.yaml
+++ b/sentry/templates/deployment-sentry-ingest-occurrences.yaml
@@ -111,7 +111,7 @@ spec:
 {{ toYaml .Values.sentry.ingestOccurrences.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-replay-recordings
+      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-occurrences
       {{- end }}
       volumes:
       - name: config


### PR DESCRIPTION
This PR fixes the wrong service account that uses the ingest occurrences deployment.