### PR TITLE
fix hpa vroom configuration

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.5.3
+version: 20.5.4
 appVersion: 23.8.0
 dependencies:
   - name: memcached

--- a/sentry/templates/hpa-vroom.yaml
+++ b/sentry/templates/hpa-vroom.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.vroom.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-vroom
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-vroom
+  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}


### PR DESCRIPTION
Adding the HPA manifest missing for the `vroom` deployment.