### PR TITLE
Fix/hpa metric issue

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -119,7 +119,7 @@ data:
       {{- if .Values.filestore.s3.default_acl }}
       default_acl: {{ .Values.filestore.s3.default_acl | quote }}
       {{- end }}
-      #add comfig params for s3
+      #add config params for s3
       {{- if .Values.filestore.s3.addressing_style }}
       addressing_style: {{ .Values.filestore.s3.addressing_style | quote }}
       {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
-      role: ingest-consumer
+      role: ingest-consumer-attachments
 {{- if not .Values.sentry.ingestConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestConsumer.replicas }}
 {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: ingest-consumer
+        role: ingest-consumer-attachments
         {{- if .Values.sentry.ingestConsumer.podLabels }}
 {{ toYaml .Values.sentry.ingestConsumer.podLabels | indent 8 }}
         {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
-      role: ingest-consumer
+      role: ingest-consumer-events
 {{- if not .Values.sentry.ingestConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestConsumer.replicas }}
 {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: ingest-consumer
+        role: ingest-consumer-events
         {{- if .Values.sentry.ingestConsumer.podLabels }}
 {{ toYaml .Values.sentry.ingestConsumer.podLabels | indent 8 }}
         {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
-      role: ingest-consumer
+      role: ingest-consumer-transactions
 {{- if not .Values.sentry.ingestConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestConsumer.replicas }}
 {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: ingest-consumer
+        role: ingest-consumer-transactions
         {{- if .Values.sentry.ingestConsumer.podLabels }}
 {{ toYaml .Values.sentry.ingestConsumer.podLabels | indent 8 }}
         {{- end }}

--- a/sentry/templates/hpa-ingestConsumer.yaml
+++ b/sentry/templates/hpa-ingestConsumer.yaml
@@ -2,12 +2,42 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-sentry-ingest-consumer
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-consumer-attachments
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-ingest-consumer
+    name: {{ template "sentry.fullname" . }}-ingest-consumer-attachments
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-consumer-events
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-consumer-events
+  minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+---
+{{- if .Values.sentry.ingestConsumer.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-consumer-transactions
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-consumer-transactions
   minReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.sentry.ingestConsumer.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumer.autoscaling.targetCPUUtilizationPercentage }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1123,7 +1123,7 @@ filestore:
     # credentialsFile: credentials.json
   # bucketName:
 
-  ## Currently unconfigured and changing this has no impact on the template configuration.
+  # Details refer to: https://develop.sentry.dev/services/filestore/#amazon-s3-backend
   s3: {}
   #  accessKey:
   #  secretKey:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1123,7 +1123,7 @@ filestore:
     # credentialsFile: credentials.json
   # bucketName:
 
-  # Details refer to: https://develop.sentry.dev/services/filestore/#amazon-s3-backend
+  # For details refer to: https://develop.sentry.dev/services/filestore/#amazon-s3-backend
   s3: {}
   #  accessKey:
   #  secretKey:


### PR DESCRIPTION
Thanks for the amazing Chart :tada: 

I faced a small issue:
HPA fails due to deployment: `sentry-ingest-consumer` not found.
The deployment names are different for events, transactions and attachments.

Created separate HPAs for them leads to:
_pods by selector app=sentry,release=sentry,role=ingest-consumer are controlled by multiple HPAs_
Therefore changed the role name as well

S3 seems to be working fine for me so thought to remove the commented line saying that _s3 is unconfigured_

Also the deployment breaks as the fields are immutable. Therefore for me I changed the deployment names in my personal deployment but in this PR.
we can then bump the Chart version to a minor update. 
Any thoughts ?