### PR TITLE
Add 'max-worker-lifetime-delta' to sentry.conf.py

### DIFF
--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -322,6 +322,7 @@ data:
         'max-requests': 100000,
         'max-requests-delta': 500,
         'max-worker-lifetime': 86400,
+        'max-worker-lifetime-delta': 600,
         # Duplicate options from sentry default just so we don't get
         # bit by sentry changing a default value that we depend on.
         'thunder-lock': True,


### PR DESCRIPTION
We add _max-worker-lifetime-delta_ to _sentry.conf.py_ and set it to 5 mins.
This is done to prevent all workers being killed at the same time when their _max-worker-lifetime_ is up.
Each worker now has a lifetime of: _max-worker-lifetime + worker-id * max-worker-lifetime-delta_

Sources:
https://github.com/unbit/uwsgi/pull/2021
https://github.com/unbit/uwsgi/issues/2020
https://github.com/unbit/uwsgi-docs/pull/498