### PR TITLE
add missing snuba-spans topic

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.6.1
+version: 20.6.2
 appVersion: 23.9.1
 dependencies:
   - name: memcached

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1463,6 +1463,7 @@ kafka:
       - name: ingest-monitors
       - name: profiles
       - name: ingest-occurrences
+      - name: snuba-spans
   zookeeper:
     enabled: true
   kraft:


### PR DESCRIPTION
snuba 23.9.1 contains https://github.com/getsentry/snuba/pull/4654 which adds `snuba-spans` topic.
- https://github.com/getsentry/snuba/blob/23.9.1/snuba/utils/streams/topics.py