### PR TITLE
fix: missing profiling config

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.6.1
+version: 20.6.2
 appVersion: 23.9.1
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -454,6 +454,7 @@ data:
                 "organizations:profiling-global-suspect-functions",
                 "organizations:profiling-cpu-chart",
                 "organizations:profiling-memory-chart",
+                "organizations:profiling-view",
                 {{ end -}}
 
                 "organizations:dashboards-mep",


### PR DESCRIPTION
Missing view config for profiling:

![image](https://github.com/sentry-kubernetes/charts/assets/56931733/14a29858-c210-439f-b94c-3262d2e727e7)
