### PR TITLE
Resolve Safari Content-Disposition header bug

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.8.1
+version: 20.8.2
 appVersion: 23.10.1
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -21,6 +21,7 @@ data:
       proxy_buffers              4 256k;
       proxy_busy_buffers_size    256k;
       proxy_set_header Host $host;
+      proxy_hide_header          Content-Disposition;
 
       location /api/store/ {
         proxy_pass http://relay;


### PR DESCRIPTION
Related : https://github.com/getsentry/self-hosted/pull/2297

After adding this line to nginx config + redeploy of nginx deployment it seems to work again