### PR TITLE
fix: hide content-disposition header on /static for Safari

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.8.1
+version: 20.8.2
 appVersion: 23.10.1
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -42,7 +42,7 @@ data:
       }
 
       location /_static/ {
-			  proxy_hide_header Content-Disposition;
-		  }
+        proxy_hide_header Content-Disposition;
+      }
     }
 {{- end }}

--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -28,7 +28,7 @@ data:
 
       location ~ ^/api/[1-9]\d*/ {
         proxy_pass http://relay;
-      }
+      }  
 
       {{ if and .Values.nginx.metrics.enabled .Values.nginx.metrics.serviceMonitor.enabled -}}
       location = /status/ {
@@ -40,5 +40,9 @@ data:
       location / {
         proxy_pass http://sentry;
       }
+
+      location /_static/ {
+			  proxy_hide_header Content-Disposition;
+		  }
     }
 {{- end }}


### PR DESCRIPTION
Theres a bug in Sentry, which prevens Safari from rendering assets (JS). 
https://github.com/getsentry/self-hosted/issues/2285

It was fixed for the self-hosted deploy by adding a 'proxy_hide_header' statement. 
https://github.com/getsentry/self-hosted/commit/ab9dbbd41a31cac5b106fea24a12ba23a0e165fa