### PR TITLE
add secret env for web and worker

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.9.2
+version: 20.10.0
 appVersion: 23.10.1
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-web.yaml
+++ b/sentry/templates/deployment-sentry-web.yaml
@@ -79,6 +79,11 @@ spec:
 {{- if .Values.sentry.web.env }}
 {{ toYaml .Values.sentry.web.env | indent 8 }}
 {{- end }}
+{{- if .Values.sentry.web.existingSecretEnv }}
+        envFrom:
+        - secretRef:
+          name: "{{.Values.sentry.web.existingSecretEnv}}"
+{{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/sentry/templates/deployment-sentry-worker.yaml
+++ b/sentry/templates/deployment-sentry-worker.yaml
@@ -80,6 +80,11 @@ spec:
 {{- if .Values.sentry.worker.env }}
 {{ toYaml .Values.sentry.worker.env | indent 8 }}
 {{- end }}
+{{- if .Values.sentry.worker.existingSecretEnv }}
+        envFrom:
+        - secretRef:
+          name: "{{.Values.sentry.worker.existingSecretEnv}}"
+{{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -137,6 +137,7 @@ sentry:
     strategyType: RollingUpdate
     replicas: 1
     env: []
+    existingSecretEnv: []
     probeFailureThreshold: 5
     probeInitialDelaySeconds: 10
     probePeriodSeconds: 10
@@ -175,6 +176,7 @@ sentry:
     replicas: 3
     # concurrency: 4
     env: []
+    existingSecretEnv: []
     resources: {}
     affinity: {}
     nodeSelector: {}


### PR DESCRIPTION
When we deployed our sentry instance, we added several config options and used gitops to manage our infrastructure config.

Our config option contains secrets so it's best to use some kind of external secret management (like SealedSecret) and then add the existing secret as environment variable.

This simple commit enable us to do exactly that.