### PR TITLE
Make loglevel configurable

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.10.1
+version: 20.11.0
 appVersion: 23.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-cron.yaml
+++ b/sentry/templates/deployment-sentry-cron.yaml
@@ -67,6 +67,9 @@ spec:
         args:
           - "run"
           - "cron"
+          {{- if .Values.sentry.cron.logLevel }}
+          - "-l{{ .Values.sentry.cron.logLevel}}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -414,6 +414,8 @@ sentry:
     sidecars: []
     volumes: []
     # volumeMounts: []
+    ## Log level can be any of: DEBUG, INFO, WARNING, ERROR, CRITICAL, FATAL
+    # logLevel: info
 
   subscriptionConsumerEvents:
     replicas: 1


### PR DESCRIPTION
Make log level configure for the sentry cron service, this can be handy to inspect it's output if desired