### PR TITLE
feat: Allow to set max_suspicious_broken_parts in merge_tree settings…

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.5.1
+version: 3.6.0
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.5.0
+version: 3.5.1
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/configmap-config.yaml
+++ b/clickhouse/templates/configmap-config.yaml
@@ -165,6 +165,7 @@ data:
             <parts_to_delay_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_delay_insert }}</parts_to_delay_insert> 
             <parts_to_throw_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_throw_insert }}</parts_to_throw_insert> 
             <max_part_loading_threads>{{ .Values.clickhouse.configmap.merge_tree.max_part_loading_threads }}</max_part_loading_threads> 
+            <max_suspicious_broken_parts>100</max_suspicious_broken_parts>
         </merge_tree>
         {{- end }}
     </yandex>

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -371,6 +371,8 @@ clickhouse:
       parts_to_throw_insert: 300
       # The maximum number of threads that read parts when ClickHouse starts.
       max_part_loading_threads: auto
+      # If the number of broken parts in a single partition exceeds the max_suspicious_broken_parts value, automatic deletion is denied.
+      max_suspicious_broken_parts: 100
 
 ##
 ## Web interface for ClickHouse in the Tabix project.


### PR DESCRIPTION
A few days ago I faced a problem in one of our clickhouse replicas. When clickhouse tries to init db it needs to merge broken parts of data to a single partition and it needs to delete those files afterward. If the number of those files exceeded the number set in the configuration it denied deletion ([here](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings)) and db doesn't init, so what we need to do is increase the max_suspicious_broken_parts value to cover those broken file numbers.

Unfortunately, it is not possible to set the above settings via chart values so I decided to add handling these specific params.