### PR TITLE
Fix/replace hardcoded value in clickhouse configmap

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.6.0
+version: 3.6.1
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/configmap-config.yaml
+++ b/clickhouse/templates/configmap-config.yaml
@@ -165,7 +165,8 @@ data:
             <parts_to_delay_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_delay_insert }}</parts_to_delay_insert> 
             <parts_to_throw_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_throw_insert }}</parts_to_throw_insert> 
             <max_part_loading_threads>{{ .Values.clickhouse.configmap.merge_tree.max_part_loading_threads }}</max_part_loading_threads> 
-            <max_suspicious_broken_parts>100</max_suspicious_broken_parts>
+            <max_suspicious_broken_parts>{{ .Values.clickhouse.configmap.merge_tree.max_suspicious_broken_parts }}</max_suspicious_broken_parts>
+          </merge_tree>
         </merge_tree>
         {{- end }}
     </yandex>


### PR DESCRIPTION
Replaced hardcoded `max_suspicious_broken_parts` value in `mergetree` section for clickhouse configmap.