### PR TITLE
Fix: Traefik path style

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.11.0
+version: 20.12.0
 appVersion: 23.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/ingress.yaml
+++ b/sentry/templates/ingress.yaml
@@ -139,7 +139,7 @@ spec:
               servicePort: {{ template "relay.port" . }}
               {{- end }}
         {{- if eq (default "nginx" .Values.ingress.regexPathStyle) "traefik" }}
-          - path: {{ default "/" .Values.ingress.path }}api/{[1-9][0-9]*}/{(.*)}
+          - path: {{ default "/" .Values.ingress.path }}api/{id:[1-9][0-9]*}/{path:.*}
         {{- else }}
           - path: {{ default "/" .Values.ingress.path }}api/[1-9][0-9]*/(.*)
         {{- end }}


### PR DESCRIPTION
Hello everyone!

I've encountered an issue with the regexPathStyle in Traefik. Currently, the pattern api/{id:[1-9][0-9]*}/{path:.*} is effectively handling Error Messaging, but it's not functioning correctly for XHR requests, such as logging out, issue merging/deleting, and commenting.

After reviewing the [Traefik documentation](https://doc.traefik.io/traefik/routing/routers/#rule), I suspect the path style might not be optimally configured. To address this, I've created a Pull Request with an updated path style. This change has successfully resolved the issue in my tests, ensuring both exception handling and XHR requests work seamlessly.

Related issue: https://github.com/sentry-kubernetes/charts/issues/1086

I'm looking forward to your feedback and suggestions on this adjustment.

Best regards,
Hai