### PR TITLE
Make Slack secret key configurable

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 20.11.0
+version: 20.12.0
 appVersion: 23.11.0
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -519,17 +519,17 @@ Common Sentry environment variables
   valueFrom:
     secretKeyRef:
       name: {{ .Values.slack.existingSecret }}
-      key: {{ default "client-id" .Values.github.existingSecretClientIdKey }}
+      key: {{ default "client-id" .Values.slack.existingSecretClientIdKey }}
 - name: SLACK_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ .Values.slack.existingSecret }}
-      key: {{ default "client-secret" .Values.github.existingSecretClientSecretKey }}
+      key: {{ default "client-secret" .Values.slack.existingSecretClientSecretKey }}
 - name: SLACK_SIGNING_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ .Values.slack.existingSecret }}
-      key: {{ default "signing-secret" .Values.github.existingSecretSigningSecretKey }}
+      key: {{ default "signing-secret" .Values.slack.existingSecretSigningSecretKey }}
 {{- end }}
 {{- if and .Values.github.existingSecret }}
 - name: GITHUB_APP_PRIVATE_KEY

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -519,17 +519,17 @@ Common Sentry environment variables
   valueFrom:
     secretKeyRef:
       name: {{ .Values.slack.existingSecret }}
-      key: "client-id"
+      key: {{ default "client-id" .Values.github.existingSecretClientIdKey }}
 - name: SLACK_CLIENT_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ .Values.slack.existingSecret }}
-      key: "client-secret"
+      key: {{ default "client-secret" .Values.github.existingSecretClientSecretKey }}
 - name: SLACK_SIGNING_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ .Values.slack.existingSecret }}
-      key: "signing-secret"
+      key: {{ default "signing-secret" .Values.github.existingSecretSigningSecretKey }}
 {{- end }}
 {{- if and .Values.github.existingSecret }}
 - name: GITHUB_APP_PRIVATE_KEY

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1184,8 +1184,8 @@ google: {}
 #   clientId: ""
 #   clientSecret: ""
 #   existingSecret: ""
-#   existingSecretClientIdKey: "" # by default "client-id"
-#   existingSecretClientSecretKey: "" # by default "client-secret"
+#   existingSecretClientIdKey: ""       # by default "client-id"
+#   existingSecretClientSecretKey: ""   # by default "client-secret"
 
 slack: {}
 # slack:
@@ -1193,9 +1193,13 @@ slack: {}
 #   clientSecret:
 #   signingSecret:
 #   existingSecret:
+#   existingSecretClientIdKey: ""       # by default "client-id"
+#   existingSecretClientSecretKey: ""   # by default "client-secret"
+#   existingSecretSigningSecretKey: ""  # by default "signing-secret"
 #   Reference -> https://develop.sentry.dev/integrations/slack/
 
 openai: {}
+# openai:
 #   existingSecret: "xxxxx"
 #   existingSecretKey: ""   # by default "api-token"
 


### PR DESCRIPTION
Make `slack` secret key like `client-id` configurable, similar to `github` and `google`.

Supersede and close #1035: This pull request is more up-to-date and also updates `values.yaml`.