### PR TITLE
add kube service account for hook sentry-dbinit

### DIFF
--- a/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -98,6 +98,9 @@ spec:
 {{- if .Values.hooks.dbInit.sidecars }}
 {{ toYaml .Values.hooks.dbInit.sidecars | indent 6 }}
 {{- end }}
+      { { - if .Values.serviceAccount.enabled } }
+      serviceAccountName: { { .Values.serviceAccount.name } }-hook-sentry-dbinit
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/sentry/templates/serviceaccount-hook-sentry-dbinit.yaml
+++ b/sentry/templates/serviceaccount-hook-sentry-dbinit.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-hook-sentry-dbinit
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}


### PR DESCRIPTION
if running cloud-sql-proxy as sidecars with GKE Workload Identity, the dbinit hook job needs a kube service account for iam binding.