### PR TITLE
fix(deployment-sentry-ingest-consumers): added suffix for each consumer

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v3
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.0.0
+version: 21.0.1
 appVersion: 23.11.2
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
-      role: ingest-consumer
+      role: ingest-consumer-attachments
 {{- if not .Values.sentry.ingestConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestConsumer.replicas }}
 {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: ingest-consumer
+        role: ingest-consumer-attachments
         {{- if .Values.sentry.ingestConsumer.podLabels }}
 {{ toYaml .Values.sentry.ingestConsumer.podLabels | indent 8 }}
         {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
-      role: ingest-consumer
+      role: ingest-consumer-events
 {{- if not .Values.sentry.ingestConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestConsumer.replicas }}
 {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: ingest-consumer
+        role: ingest-consumer-events
         {{- if .Values.sentry.ingestConsumer.podLabels }}
 {{ toYaml .Values.sentry.ingestConsumer.podLabels | indent 8 }}
         {{- end }}

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
-      role: ingest-consumer
+      role: ingest-consumer-transactions
 {{- if not .Values.sentry.ingestConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestConsumer.replicas }}
 {{- end }}
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        role: ingest-consumer
+        role: ingest-consumer-transactions
         {{- if .Values.sentry.ingestConsumer.podLabels }}
 {{ toYaml .Values.sentry.ingestConsumer.podLabels | indent 8 }}
         {{- end }}


### PR DESCRIPTION
added attachments/events/transactions suffixes to their respective ingest-consumer to fix ambiguousselector in linked hpa

sentry-ingest-consumer-events deployment matches extra pods by labels #1090