### PR TITLE
enable concurrency config on ingestMetricsConsumers

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v3
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.0.0
+version: 21.1.0
 appVersion: 23.11.2
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-metrics-consumer-perf.yaml
+++ b/sentry/templates/deployment-sentry-ingest-metrics-consumer-perf.yaml
@@ -78,6 +78,10 @@ spec:
         args:
           - "run"
           - "ingest-metrics-parallel-consumer"
+          {{- if .Values.sentry.ingestMetricsConsumerPerf.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestMetricsConsumerPerf.concurrency }}"
+          {{- end }}
           - "--ingest-profile"
           - "performance"
           {{- if .Values.sentry.ingestMetricsConsumerPerf.maxBatchSize }}

--- a/sentry/templates/deployment-sentry-ingest-metrics-consumer-rh.yaml
+++ b/sentry/templates/deployment-sentry-ingest-metrics-consumer-rh.yaml
@@ -78,6 +78,10 @@ spec:
         args:
           - "run"
           - "ingest-metrics-parallel-consumer"
+          {{- if .Values.sentry.ingestMetricsConsumerRh.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestMetricsConsumerRh.concurrency }}"
+          {{- end }}
           - "--ingest-profile"
           - "release-health"
           {{- if .Values.sentry.ingestMetricsConsumerRh.maxBatchSize }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -226,7 +226,7 @@ sentry:
 
   ingestMetricsConsumerPerf:
     replicas: 1
-    # concurrency: 4
+    concurrency: 1
     env: []
     resources: {}
     affinity: {}
@@ -253,7 +253,7 @@ sentry:
 
   ingestMetricsConsumerRh:
     replicas: 1
-    # concurrency: 4
+    concurrency: 1
     env: []
     resources: {}
     affinity: {}


### PR DESCRIPTION
concurrency config on ingestMetricsConsumerPerf & ingestMetricsConsumerRh now works as expected.

please note that resource usage will increase with more processes.