### PR TITLE
fix(memcache): do not set SERVER_MAX_VALUE_LENGTH with latest django versions

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.3.0
+version: 21.3.1
 appVersion: 24.1.1
 dependencies:
   - name: memcached

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -153,8 +153,6 @@ data:
             "OPTIONS": {"ignore_exc": True}
         }
     }
-    import memcache
-    memcache.SERVER_MAX_VALUE_LENGTH = {{ .Values.memcached.maxItemSize }}
     {{- end }}
 
     DATABASES = {


### PR DESCRIPTION
Memcache module is no longer present in the Django package. Leaving this in the configuration will cause startup failures