### PR TITLE
Allow custom response headers for gke

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.3.1
+version: 21.3.2
 appVersion: 24.1.1
 dependencies:
   - name: memcached

--- a/sentry/templates/gke/backendconfig-sentry-relay.yaml
+++ b/sentry/templates/gke/backendconfig-sentry-relay.yaml
@@ -10,6 +10,14 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  {{- if .Values.relay.customResponseHeaders }}
+  customResponseHeaders:
+    headers:
+      {{- if .Values.ingress.tls }}
+      - "strict-transport-security: max-age=31536000; includeSubDomains"
+      {{- end -}}
+      {{ toYaml .Values.relay.customResponseHeaders | nindent 6 }}
+  {{- end }}      
   healthCheck:
     checkIntervalSec: {{ .Values.relay.probePeriodSeconds }}
     timeoutSec: {{ .Values.relay.probeTimeoutSeconds }}
@@ -18,8 +26,8 @@ spec:
     type: HTTP
     requestPath: {{ template "relay.healthCheck.requestPath" }}
     port: {{ template "relay.port" . }}
-{{- if .Values.relay.securityPolicy }}
+  {{- if .Values.relay.securityPolicy }}
   securityPolicy:
     name: {{ .Values.relay.securityPolicy }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/sentry/templates/gke/backendconfig-sentry-web.yaml
+++ b/sentry/templates/gke/backendconfig-sentry-web.yaml
@@ -10,6 +10,14 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  {{- if .Values.sentry.web.customResponseHeaders }}
+  customResponseHeaders:
+    headers:
+      {{- if .Values.ingress.tls }}
+      - "strict-transport-security: max-age=31536000; includeSubDomains"
+      {{- end -}}
+      {{ toYaml .Values.sentry.web.customResponseHeaders | nindent 6 }}
+  {{- end }} 
   healthCheck:
     checkIntervalSec: {{ .Values.sentry.web.probePeriodSeconds }}
     timeoutSec: {{ .Values.sentry.web.probeTimeoutSeconds }}
@@ -18,8 +26,8 @@ spec:
     type: HTTP
     requestPath: {{ template "sentry.healthCheck.requestPath" }}
     port: {{ .Values.service.externalPort }}
-{{- if .Values.sentry.web.securityPolicy }}
+  {{- if .Values.sentry.web.securityPolicy }}
   securityPolicy:
     name: {{ .Values.sentry.web.securityPolicy }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -101,7 +101,10 @@ relay:
   affinity: {}
   nodeSelector: {}
   securityContext: {}
+  # if you are using GKE Ingress controller use 'securityPolicy' to add Google Cloud Armor Ingress policy
   securityPolicy: ""
+  # if you are using GKE Ingress controller use 'customResponseHeaders' to add custom response header
+  customResponseHeaders: []
   containerSecurityContext: {}
   service:
     annotations: {}
@@ -147,7 +150,10 @@ sentry:
     affinity: {}
     nodeSelector: {}
     securityContext: {}
+    # if you are using GKE Ingress controller use 'securityPolicy' to add Google Cloud Armor Ingress policy
     securityPolicy: ""
+    # if you are using GKE Ingress controller use 'customResponseHeaders' to add custom response header
+    customResponseHeaders: []
     containerSecurityContext: {}
     service:
       annotations: {}


### PR DESCRIPTION
Hello, i added the configuration to allow custom response headers for GKE BackendConfig.

A sample configuration on values.yaml:
```yaml
relay:
  # if you are using GKE Ingress controller use 'securityPolicy' to add Google Cloud Armor Ingress policy
  securityPolicy: ""
  # if you are using GKE Ingress controller use 'customResponseHeaders' to add custom response header
  customResponseHeaders: []

sentry:
  web:
    # if you are using GKE Ingress controller use 'securityPolicy' to add Google Cloud Armor Ingress policy
    securityPolicy: ""
    # if you are using GKE Ingress controller use 'customResponseHeaders' to add custom response header
    customResponseHeaders:
      - "x-frame-options: DENY"
```

The output:
```yaml
# Source: sentry/templates/gke/backendconfig-sentry-web.yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: sentry-web
  namespace: "default"
  labels:
    app: sentry
    chart: "sentry-21.3.2"
    release: "sentry"
    heritage: "Helm"
spec:
  customResponseHeaders:
    headers:
      - "strict-transport-security: max-age=31536000; includeSubDomains"
      - 'x-frame-options: DENY' 
  healthCheck:
    checkIntervalSec: 10
    timeoutSec: 2
    healthyThreshold: 1
    unhealthyThreshold: 5  
    type: HTTP
    requestPath: /_health/
    port: 9000
```

The header `strict-transport-security` is active when the `ingress.tls` has been defined.

Hope this help 👋