### PR TITLE
feat: adding secrets for filestore s3 credentials

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.4.1
+version: 21.5.0
 appVersion: 24.1.2
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -500,6 +500,18 @@ Common Sentry environment variables
       name: {{ .Values.externalPostgresql.existingSecret }}
       key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKey }}
 {{- end }}
+{{- if and (eq .Values.filestore.backend "s3") .Values.filestore.s3.existingSecret }}
+- name: S3_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.s3.existingSecret }}
+      key: {{ default "s3-access-key-id" .Values.filestore.s3.accessKeyIdRef }}
+- name: S3_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.filestore.s3.existingSecret }}
+      key: {{ default "s3-secret-access-key" .Values.filestore.s3.secretAccessKeyRef }}
+{{- end }}
 {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}

--- a/sentry/templates/configmap-sentry.yaml
+++ b/sentry/templates/configmap-sentry.yaml
@@ -96,37 +96,6 @@ data:
     filestore.options:
       bucket_name: {{ .Values.filestore.gcs.bucketName | quote }}
     {{ end }}
-    {{- if eq .Values.filestore.backend "s3" }}
-    filestore.options:
-      {{- if .Values.filestore.s3.accessKey }}
-      access_key: {{ .Values.filestore.s3.accessKey | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.secretKey }}
-      secret_key: {{ .Values.filestore.s3.secretKey | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.bucketName }}
-      bucket_name: {{ .Values.filestore.s3.bucketName | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.endpointUrl }}
-      endpoint_url: {{ .Values.filestore.s3.endpointUrl | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.signature_version }}
-      signature_version: {{ .Values.filestore.s3.signature_version | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.region_name }}
-      region_name: {{ .Values.filestore.s3.region_name | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.default_acl }}
-      default_acl: {{ .Values.filestore.s3.default_acl | quote }}
-      {{- end }}
-      #add comfig params for s3
-      {{- if .Values.filestore.s3.addressing_style }}
-      addressing_style: {{ .Values.filestore.s3.addressing_style | quote }}
-      {{- end }}
-      {{- if .Values.filestore.s3.location }}
-      location: {{ .Values.filestore.s3.location | quote }}
-      {{- end }}
-    {{ end }}
 
     {{- if .Values.config.configYml }}
 {{ .Values.config.configYml | toYaml | indent 4 }}
@@ -521,6 +490,38 @@ data:
     SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port | quote }}))
     SENTRY_OPTIONS['mail.host'] = os.getenv("SENTRY_EMAIL_HOST", {{ .Values.mail.host | quote }})
     SENTRY_OPTIONS['mail.from'] = os.getenv("SENTRY_EMAIL_FROM", {{ .Values.mail.from | quote }})
+
+    #######################
+    # Filestore S3 Configuration #
+    #######################
+    {{- if eq .Values.filestore.backend "s3" }}
+    SENTRY_OPTIONS['filestore.options'] = {
+        'access_key': os.getenv("S3_ACCESS_KEY_ID", {{ .Values.filestore.s3.accessKey | default "" | quote }}),
+        'secret_key': os.getenv("S3_SECRET_ACCESS_KEY", {{ .Values.filestore.s3.secretKey | default "" | quote }}),
+        {{- if .Values.filestore.s3.bucketName }}
+        'bucket_name': {{ .Values.filestore.s3.bucketName | quote }},
+        {{- end }}
+        {{- if .Values.filestore.s3.endpointUrl }}
+        'endpoint_url': {{ .Values.filestore.s3.endpointUrl | quote }},
+        {{- end }}
+        {{- if .Values.filestore.s3.signature_version }}
+        'signature_version': {{ .Values.filestore.s3.signature_version | quote }},
+        {{- end }}
+        {{- if .Values.filestore.s3.region_name }}
+        'region_name': {{ .Values.filestore.s3.region_name | quote }},
+        {{- end }}
+        {{- if .Values.filestore.s3.default_acl }}
+        'default_acl': {{ .Values.filestore.s3.default_acl | quote }},
+        {{- end }}
+        #add comfig params for s3
+        {{- if .Values.filestore.s3.addressing_style }}
+        'addressing_style': {{ .Values.filestore.s3.addressing_style | quote }},
+        {{- end }}
+        {{- if .Values.filestore.s3.location }}
+        'location': {{ .Values.filestore.s3.location | quote }},
+        {{- end }}
+    }
+    {{- end }}
 
     #########################
     # Bitbucket Integration #

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1235,7 +1235,12 @@ filestore:
   # bucketName:
 
   ## Currently unconfigured and changing this has no impact on the template configuration.
+  ## Note that you can use a secret with default references "s3-access-key-id" and "s3-secret-access-key".
+  ## Otherwise, you can use custom secret references, or use plain text values.
   s3: {}
+  #  existingSecret:
+  #  accessKeyIdRef:
+  #  secretAccessKeyRef:
   #  accessKey:
   #  secretKey:
   #  bucketName:


### PR DESCRIPTION
This PR provides support for Kubernetes Secrets to store S3 credentials (both Acces Key ID and Secret Access Key).