### PR TITLE
set clickhouse max connections

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.5.0
-appVersion: 24.1.2
+version: 21.6.0
+appVersion: 24.2.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -450,6 +450,8 @@ Common Snuba environment variables
       name: {{ .Values.externalClickhouse.existingSecret }}
       key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey }}
 {{- end }}
+- name: CLICKHOUSE_MAX_CONNECTIONS
+  value {{ .Values.snuba.clickhouse.maxConnections | quote }}
 {{- end -}}
 
 {{- define "vroom.env" -}}

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -451,7 +451,7 @@ Common Snuba environment variables
       key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey }}
 {{- end }}
 - name: CLICKHOUSE_MAX_CONNECTIONS
-  value {{ .Values.snuba.clickhouse.maxConnections | quote }}
+  value: {{ .Values.snuba.clickhouse.maxConnections | quote }}
 {{- end -}}
 
 {{- define "vroom.env" -}}

--- a/sentry/templates/configmap-snuba.yaml
+++ b/sentry/templates/configmap-snuba.yaml
@@ -25,6 +25,7 @@ data:
         "port": int({{ include "sentry.clickhouse.port" . }}),
         "user":  env("CLICKHOUSE_USER", "default"),
         "password": env("CLICKHOUSE_PASSWORD", ""),
+        "max_connections": int(os.environ.get("CLICKHOUSE_MAX_CONNECTIONS", 100)),
         "database": env("CLICKHOUSE_DATABASE", "default"),
         "http_port": {{ include "sentry.clickhouse.http_port" . }},
         "storage_sets": {

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -952,6 +952,8 @@ snuba:
   migrateJob:
     env: []
 
+  clickhouse:
+    maxConnections: 100
 hooks:
   enabled: true
   removeOnSuccess: true


### PR DESCRIPTION
ref: https://github.com/getsentry/snuba/pull/4988
ref: https://github.com/sentry-kubernetes/charts/issues/977

Thank you always for the maintenance.
I've written a patch to fix the error Connection pool is full, discarding connection: sentry-clickhouse. Connection pool size: 1, so please check it.