### PR TITLE
Add noStrictOffsetReset with ingestConsumer

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 21.5.0
+version: 21.6.1
 appVersion: 24.1.2
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -89,7 +89,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.ingestConsumer.noStrictOffsetReset }}
+          {{- if .Values.sentry.ingestConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
         env:

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -89,6 +89,9 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.snuba.ingestConsumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -233,6 +233,7 @@ sentry:
     #   - mountPath: /dev/shm
     #     name: dshm
 
+    # noStrictOffsetReset: false
   ingestReplayRecordings:
     replicas: 1
     env: []


### PR DESCRIPTION
Hello,

I encountered the following logs, and subsequently, I have resolved the issue:

```
% kubectl logs sentry-ingest-consumer-transactions-f65d74777-wvqdf
...
arroyo.errors.OffsetOutOfRange: KafkaError{code=_AUTO_OFFSET_RESET,val=-140,str="fetch failed due to requested offset not available on the broker: Broker: Offset out of range (broker 2)"}
Sentry is attempting to send 2 pending events
```