### PR TITLE
(clickhouse) Fix merge_tree section format in configmap-config.yaml

### DIFF
--- a/clickhouse/Chart.yaml
+++ b/clickhouse/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 name: clickhouse
 sources:
 - https://github.com/sentry-kubernetes/charts
-version: 3.7.0
+version: 3.7.1
 maintainers:
   - name: sentry-kubernetes

--- a/clickhouse/templates/configmap-config.yaml
+++ b/clickhouse/templates/configmap-config.yaml
@@ -166,7 +166,6 @@ data:
             <parts_to_throw_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_throw_insert }}</parts_to_throw_insert> 
             <max_part_loading_threads>{{ .Values.clickhouse.configmap.merge_tree.max_part_loading_threads }}</max_part_loading_threads> 
             <max_suspicious_broken_parts>{{ .Values.clickhouse.configmap.merge_tree.max_suspicious_broken_parts }}</max_suspicious_broken_parts>
-          </merge_tree>
         </merge_tree>
         {{- end }}
     </yandex>


### PR DESCRIPTION
Otherwise if merge_tree is enabled, the pods of StatefulSet will be in a crash-loop with Clickhouse unable to merge configs