### PR TITLE
Add noStrictOffsetReset to ingest-consumer-events

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 22.0.0
+version: 22.0.1
 appVersion: 24.2.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
@@ -89,6 +89,9 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"


### PR DESCRIPTION
Following suit with #1186 after encountering this error on the `sentry-ingest-consumer-events` pod

```shell
arroyo.errors.OffsetOutOfRange: KafkaError{code=_AUTO_OFFSET_RESET,val=-140,str="fetch failed due to requested offset not available on the broker: Broker: Offset out of range (broker 0)"}
```