### PR TITLE
When set to "controller only", port 9092 is not listened on.

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -411,6 +411,17 @@ Set Kafka Confluent port
 {{- end -}}
 
 {{/*
+Set Kafka Confluent Controller port
+*/}}
+{{- define "sentry.kafka.controller_port" -}}
+{{- if and (.Values.kafka.enabled) (.Values.kafka.service.ports.controller ) -}}
+{{- .Values.kafka.service.ports.controller }}
+{{- else if and (.Values.externalKafka) (not (kindIs "slice" .Values.externalKafka)) -}}
+{{ required "A valid .Values.externalKafka.port is required" .Values.externalKafka.port }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set Kafka bootstrap servers string
 */}}
 {{- define "sentry.kafka.bootstrap_servers_string" -}}

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -3,6 +3,7 @@
 {{- $clickhousePort := include "sentry.clickhouse.port" . -}}
 {{- $kafkaHost := include "sentry.kafka.host" . -}}
 {{- $kafkaPort := include "sentry.kafka.port" . -}}
+{{- $kafkaControllerPort := include "sentry.kafka.controller_port" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -140,7 +141,7 @@ spec:
                 KRAFT_STATUS=1
                 i=0; while [ $i -lt $KAFKA_REPLICAS ]; do
                   KRAFT_HOST={{ $kafkaHost }}-controller-$i.{{ $kafkaHost }}-controller-headless
-                  if ! nc -z "$KRAFT_HOST" {{ $kafkaPort }}; then
+                  if ! nc -z "$KRAFT_HOST" {{ $kafkaControllerPort }}; then
                     KRAFT_STATUS=0
                     echo "$KRAFT_HOST is not available yet"
                   fi


### PR DESCRIPTION
This issue probably relates to [this problem](https://github.com/sentry-kubernetes/charts/issues/1212). When set to [controllerOnly](https://github.com/bitnami/charts/blob/94ce52ab08a89a7881e8d443f153e284a3f65229/bitnami/kafka/templates/controller-eligible/statefulset.yaml#L253), port 9092 is not listened on, so this change is necessary.