### PR TITLE
fix: nginx configuration for metrics

### DIFF
--- a/sentry/templates/configmap-nginx.yaml
+++ b/sentry/templates/configmap-nginx.yaml
@@ -30,9 +30,10 @@ data:
         proxy_pass http://relay;
       }  
 
-      {{ if and .Values.nginx.metrics.enabled .Values.nginx.metrics.serviceMonitor.enabled -}}
+      {{ if or .Values.nginx.metrics.enabled .Values.nginx.metrics.serviceMonitor.enabled -}}
       location = /status/ {
-        stub_status;
+        stub_status on;
+        access_log off;
       }
 
       {{ end -}}


### PR DESCRIPTION
Fixes to `configmap-nginx.yaml`:

* It's valid/applicable to enable the status endpoint when either `metrics.enabled` or `metrices.serviceMonitor.enabled`. We don't need the `serviceMonitor` to scrape metrics, that's an optional Prometheus component.
* We shouldn't include the status endpoint in access logs
* Be explicit about `stub_status` enablement