### PR TITLE
fix: sentry metrics deployment annotations

### DIFF
--- a/sentry/templates/deployment-metrics.yaml
+++ b/sentry/templates/deployment-metrics.yaml
@@ -22,8 +22,8 @@ spec:
         checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
         checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
         checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
-        {{- if .Values.sentry.web.annotations }}
-{{ toYaml .Values.sentry.web.annotations | indent 8 }}
+        {{- if .Values.metrics.podAnnotations }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
         {{- end }}
       labels:
         app: {{ template "sentry.fullname" . }}-metrics

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1668,6 +1668,8 @@ memcached:
 metrics:
   enabled: false
 
+  podAnnotations: {}
+
   ## Configure extra options for liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   livenessProbe:


### PR DESCRIPTION
Annotations for the web deployment pod should be separated from the annotations for the metrics deployment.