### PR TITLE
Add liveness Check to consumers

### DIFF
--- a/sentry/templates/deployment-sentry-billing-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-billing-metrics-consumer.yaml
@@ -90,6 +90,19 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.billingMetricsConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-generic-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-generic-metrics-consumer.yaml
@@ -88,6 +88,19 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.genericMetricsConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
@@ -90,6 +90,19 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
@@ -93,6 +93,19 @@ spec:
           {{- if .Values.sentry.ingestConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -93,6 +93,19 @@ spec:
           {{- if .Values.sentry.ingestConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-monitors.yaml
+++ b/sentry/templates/deployment-sentry-ingest-monitors.yaml
@@ -82,6 +82,19 @@ spec:
           - "ingest-monitors"
           - "--consumer-group"
           - "ingest-monitors"
+          {{- if .Values.sentry.ingestMonitors.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestMonitors.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-occurrences.yaml
+++ b/sentry/templates/deployment-sentry-ingest-occurrences.yaml
@@ -82,6 +82,19 @@ spec:
           - "ingest-occurrences"
           - "--consumer-group"
           - "ingest-occurrences"
+          {{- if .Values.sentry.ingestOccurrences.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestOccurrences.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-profiles.yaml
+++ b/sentry/templates/deployment-sentry-ingest-profiles.yaml
@@ -82,6 +82,19 @@ spec:
           - "ingest-profiles"
           - "--consumer-group"
           - "ingest-profiles"
+          {{- if .Values.sentry.ingestProfiles.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestProfiles.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-ingest-replay-recordings.yaml
+++ b/sentry/templates/deployment-sentry-ingest-replay-recordings.yaml
@@ -82,6 +82,19 @@ spec:
           - "ingest-replay-recordings"
           - "--consumer-group"
           - "ingest-replay-recordings"
+          {{- if .Values.sentry.ingestReplayRecordings.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.ingestReplayRecordings.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-metrics-consumer.yaml
@@ -88,6 +88,19 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.metricsConsumer.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-errors.yaml
@@ -82,6 +82,19 @@ spec:
           - "post-process-forwarder"
           - "--synchronize-commit-log-topic=snuba-commit-log"
           - "--synchronize-commit-group=snuba-consumers"
+          {{- if .Values.sentry.postProcessForwardErrors.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.postProcessForwardErrors.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}
 {{- if .Values.sentry.postProcessForwardErrors.env }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -83,6 +83,19 @@ spec:
           - "--synchronize-commit-log-topic=snuba-generic-events-commit-log"
           - "--synchronize-commit-group"
           - "generic_events_group"
+          {{- if .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}
 {{- if .Values.sentry.postProcessForwardIssuePlatform.env }}

--- a/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/sentry/templates/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -86,6 +86,19 @@ spec:
           {{- if .Values.sentry.postProcessForwardTransactions.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.sentry.postProcessForwardTransactions.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.postProcessForwardTransactions.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}
 {{- if .Values.sentry.postProcessForwardTransactions.env }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
@@ -73,6 +73,19 @@ spec:
           - "events-subscription-results"
           - "--consumer-group"
           - "query-subscription-consumer"
+          {{- if .Values.sentry.subscriptionConsumerEvents.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.subscriptionConsumerEvents.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}
 {{- if .Values.sentry.subscriptionConsumerEvents.env }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -88,6 +88,19 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-metrics.yaml
@@ -88,6 +88,19 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
@@ -73,6 +73,19 @@ spec:
           - "transactions-subscription-results"
           - "--consumer-group"
           - "query-subscription-consumer"
+          {{- if .Values.sentry.subscriptionConsumerTransactions.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.subscriptionConsumerTransactions.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.periodSeconds }}
+        {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}
 {{- if .Values.sentry.subscriptionConsumerTransactions.env }}

--- a/sentry/templates/deployment-snuba-consumer.yaml
+++ b/sentry/templates/deployment-snuba-consumer.yaml
@@ -112,6 +112,19 @@ spec:
           {{- if .Values.snuba.consumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.consumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.consumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.consumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.consumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/sentry/templates/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.genericMetricsCountersConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.genericMetricsCountersConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.genericMetricsCountersConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.genericMetricsDistributionConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/sentry/templates/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.genericMetricsSetsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.genericMetricsSetsConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.genericMetricsSetsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/sentry/templates/deployment-snuba-issue-occurrence-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.issueOccurrenceConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.issueOccurrenceConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.issueOccurrenceConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-metrics-consumer.yaml
+++ b/sentry/templates/deployment-snuba-metrics-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.metricsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.metricsConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.metricsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-outcomes-consumer.yaml
+++ b/sentry/templates/deployment-snuba-outcomes-consumer.yaml
@@ -108,6 +108,19 @@ spec:
           {{- if .Values.snuba.outcomesConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.outcomesConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.outcomesConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-profiling-functions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-profiling-functions-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.profilingFunctionsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.profilingFunctionsConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.profilingFunctionsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/sentry/templates/deployment-snuba-profiling-profiles-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.profilingProfilesConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.profilingProfilesConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.profilingProfilesConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-replays-consumer.yaml
+++ b/sentry/templates/deployment-snuba-replays-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.replaysConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.replaysConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.replaysConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -78,6 +78,19 @@ spec:
           - "--followed-consumer-group=snuba-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
+          {{- if .Values.snuba.subscriptionConsumerEvents.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.subscriptionConsumerEvents.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-metrics.yaml
@@ -79,6 +79,19 @@ spec:
           - "--followed-consumer-group=snuba-metrics-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
+          {{- if .Values.snuba.subscriptionConsumerMetrics.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.subscriptionConsumerMetrics.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -78,6 +78,19 @@ spec:
           - "--followed-consumer-group=transactions_group"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
+          {{- if .Values.snuba.subscriptionConsumerTransactions.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.subscriptionConsumerTransactions.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -114,6 +114,19 @@ spec:
           {{- if .Values.snuba.transactionsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
+          {{- if .Values.snuba.transactionsConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.transactionsConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -234,6 +234,10 @@ sentry:
     sidecars: []
     volumes: []
 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -260,6 +264,10 @@ sentry:
       targetCPUUtilizationPercentage: 50
     sidecars: []
     volumes: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -286,6 +294,10 @@ sentry:
     sidecars: []
     volumes: []
 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -311,6 +323,10 @@ sentry:
     sidecars: []
     volumes: []
 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -336,7 +352,10 @@ sentry:
       targetCPUUtilizationPercentage: 50
     sidecars: []
     volumes: []
-
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -365,6 +384,10 @@ sentry:
     sidecars: []
     volumes: []
 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -393,6 +416,10 @@ sentry:
     sidecars: []
     volumes: []
 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -421,6 +448,10 @@ sentry:
     sidecars: []
     volumes: []
 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -453,6 +484,10 @@ sentry:
     # podLabels: []
     sidecars: []
     volumes: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # volumeMounts: []
 
@@ -484,6 +519,10 @@ sentry:
     # podLabels: []
     sidecars: []
     volumes: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # volumeMounts: []
 
@@ -502,6 +541,10 @@ sentry:
     sidecars: []
     volumes: []
     # volumeMounts: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
 
   postProcessForwardTransactions:
     enabled: true
@@ -516,6 +559,10 @@ sentry:
     # podLabels: []
     sidecars: []
     volumes: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumeMounts: []
     # noStrictOffsetReset: false
   postProcessForwardIssuePlatform:
@@ -532,6 +579,10 @@ sentry:
     sidecars: []
     volumes: []
     # volumeMounts: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
 
   subscriptionConsumerGenericMetrics:
     enabled: true
@@ -547,6 +598,10 @@ sentry:
     sidecars: []
     volumes: []
     # volumeMounts: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
 
   subscriptionConsumerMetrics:
     enabled: true
@@ -562,6 +617,10 @@ sentry:
     sidecars: []
     volumes: []
     # volumeMounts: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
 
   cleanup:
     successfulJobsHistoryLimit: 5
@@ -625,6 +684,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -656,6 +719,10 @@ snuba:
     autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     maxBatchSize: "3"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -701,6 +768,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumes: []
     # volumeMounts: []
 
@@ -716,6 +787,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumes: []
     # volumeMounts: []
 
@@ -731,6 +806,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumes: []
     # volumeMounts: []
 
@@ -746,6 +825,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumes: []
     # volumeMounts: []
 
@@ -761,6 +844,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumes: []
     # volumeMounts: []
 
@@ -776,6 +863,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # volumes: []
     # volumeMounts: []
 
@@ -793,6 +884,10 @@ snuba:
     autoOffsetReset: "earliest"
     # volumes: []
     # volumeMounts: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
 
   subscriptionConsumerSessions:
     replicas: 1
@@ -823,6 +918,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -880,6 +979,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -908,6 +1011,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -936,6 +1043,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -964,6 +1075,10 @@ snuba:
     # tolerations: []
     # podLabels: []
     autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""


### PR DESCRIPTION
Consumers needed a liveness check. In multiple scenarios, we noticed that consumers weren't able to continue working due to the lags in topics, but by restarting the pod it will be fixed without any manual intervention.

Sentry & Snuba already provide this functionality for consumers, but it wasn't implemented in Kubernetes manifests. 