### PR TITLE
fix: actualize Sentry consumer additional options usage

### DIFF
--- a/sentry/templates/deployment-sentry-billing-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-billing-metrics-consumer.yaml
@@ -82,17 +82,18 @@ spec:
           - "billing-metrics-consumer"
           - "--consumer-group"
           - "billing-metrics-consumer"
-          {{- if .Values.sentry.billingMetricsConsumer.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.billingMetricsConsumer.concurrency }}"
+          {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.billingMetricsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.billingMetricsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
-          - "--healthcheck-file-path"
-          - "/tmp/health.txt"
+          {{- if .Values.sentry.billingMetricsConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.billingMetricsConsumer.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-generic-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-generic-metrics-consumer.yaml
@@ -80,17 +80,18 @@ spec:
           - "ingest-generic-metrics"
           - "--consumer-group"
           - "generic-metrics-consumer"
-          {{- if .Values.sentry.genericMetricsConsumer.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"
+          {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.genericMetricsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.genericMetricsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
-          - "--healthcheck-file-path"
-          - "/tmp/health.txt"
+          {{- if .Values.sentry.genericMetricsConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
@@ -82,17 +82,18 @@ spec:
           - "ingest-attachments"
           - "--consumer-group"
           - "ingest-consumer"
-          {{- if .Values.sentry.ingestConsumer.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.ingestConsumer.concurrency }}"
+          {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.ingestConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
-          - "--healthcheck-file-path"
-          - "/tmp/health.txt"
+          {{- if .Values.sentry.ingestConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestConsumer.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-events.yaml
@@ -82,20 +82,21 @@ spec:
           - "ingest-events"
           - "--consumer-group"
           - "ingest-consumer"
-          {{- if .Values.sentry.ingestConsumer.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.ingestConsumer.concurrency }}"
-          {{- end }}
-          {{- if .Values.sentry.ingestConsumer.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
           {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
+          {{- end }}
+          - "--"
+          {{- if .Values.sentry.ingestConsumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestConsumer.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-ingest-consumer-transactions.yaml
@@ -82,20 +82,21 @@ spec:
           - "ingest-transactions"
           - "--consumer-group"
           - "ingest-consumer"
-          {{- if .Values.sentry.ingestConsumer.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.ingestConsumer.concurrency }}"
-          {{- end }}
-          {{- if .Values.sentry.ingestConsumer.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
           {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
+          {{- end }}
+          - "--"
+          {{- if .Values.sentry.ingestConsumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumer.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestConsumer.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.ingestConsumer.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-metrics-consumer.yaml
+++ b/sentry/templates/deployment-sentry-metrics-consumer.yaml
@@ -80,17 +80,18 @@ spec:
           - "ingest-metrics"
           - "--consumer-group"
           - "metrics-consumer"
-          {{- if .Values.sentry.metricsConsumer.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.metricsConsumer.concurrency }}"
+          {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.metricsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.metricsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
-          - "--healthcheck-file-path"
-          - "/tmp/health.txt"
+          {{- if .Values.sentry.metricsConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.metricsConsumer.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -80,17 +80,18 @@ spec:
           - "generic-metrics-subscription-results"
           - "--consumer-group"
           - "query-subscription-consumer"
-          {{- if .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}"
+          {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
-          - "--healthcheck-file-path"
-          - "/tmp/health.txt"
+          {{- if .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
         livenessProbe:

--- a/sentry/templates/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-metrics.yaml
@@ -80,17 +80,18 @@ spec:
           - "metrics-subscription-results"
           - "--consumer-group"
           - "query-subscription-consumer"
-          {{- if .Values.sentry.subscriptionConsumerMetrics.concurrency }}
-          - "--concurrency"
-          - "{{ .Values.sentry.subscriptionConsumerMetrics.concurrency }}"
+          {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
-          - "--healthcheck-file-path"
-          - "/tmp/health.txt"
+          {{- if .Values.sentry.subscriptionConsumerMetrics.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.subscriptionConsumerMetrics.concurrency }}"
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
         livenessProbe:


### PR DESCRIPTION
`--max-batch-size` and `--concurrency` options are not supported directly in current version of Sentry consumer. Those are now additional options being passed after `--` delimiter, and concurrency is now called `--processes`.
Kept the parameter name as `concurrency` for compatibility though.
