### PR TITLE
feat(worker): separate worker definitions

### DIFF
--- a/sentry/templates/deployment-sentry-worker-events.yaml
+++ b/sentry/templates/deployment-sentry-worker-events.yaml
@@ -1,0 +1,155 @@
+{{- if .Values.sentry.workerEvents.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-worker
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: worker
+{{- if not .Values.sentry.workerEvents.autoscaling.enabled }}
+  replicas: {{ .Values.sentry.workerEvents.replicas }}
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include "sentry.config" . | sha256sum }}
+        {{- if .Values.sentry.workerEvents.annotations }}
+{{ toYaml .Values.sentry.workerEvents.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: worker
+        {{- if .Values.sentry.workerEvents.podLabels }}
+{{ toYaml .Values.sentry.workerEvents.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.workerEvents.affinity }}
+{{ toYaml .Values.sentry.workerEvents.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.workerEvents.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.workerEvents.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.workerEvents.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.workerEvents.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.workerEvents.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.workerEvents.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-worker
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "worker"
+          - "-Q"
+          - {{ .Values.sentry.workerEvents.queues }}
+          {{- if .Values.sentry.workerEvents.concurrency }}
+          - "-c"
+          - "{{ .Values.sentry.workerEvents.concurrency }}"
+          {{- end }}
+        env:
+        - name: C_FORCE_ROOT
+          value: "true"
+{{ include "sentry.env" . | indent 8 }}
+{{- if .Values.sentry.workerEvents.env }}
+{{ toYaml .Values.sentry.workerEvents.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if .Values.geodata.volumeName }}
+        - name: {{ .Values.geodata.volumeName }}
+          mountPath: {{ .Values.geodata.mountPath }}
+        {{- end }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- if .Values.sentry.workerEvents.volumeMounts }}
+{{ toYaml .Values.sentry.workerEvents.volumeMounts | indent 8 }}
+{{- end }}
+  {{- if .Values.sentry.workerEvents.livenessProbe.enabled }}
+        livenessProbe:
+          periodSeconds: {{ .Values.sentry.workerEvents.livenessProbe.periodSeconds }}
+          initialDelaySeconds: 10
+          timeoutSeconds: {{ .Values.sentry.workerEvents.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.sentry.workerEvents.livenessProbe.failureThreshold }}
+          exec:
+            command:
+              - sentry
+              - exec
+              - -c
+              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+{{- end }}
+        resources:
+{{ toYaml .Values.sentry.workerEvents.resources | indent 12 }}
+{{- if .Values.sentry.workerEvents.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.workerEvents.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if .Values.sentry.workerEvents.sidecars }}
+{{ toYaml .Values.sentry.workerEvents.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-worker
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+      {{- if .Values.sentry.workerEvents.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.workerEvents.priorityClassName }}"
+      {{- end }}
+{{- if .Values.sentry.workerEvents.volumes }}
+{{ toYaml .Values.sentry.workerEvents.volumes | indent 6 }}
+{{- end }}
+{{- end }}

--- a/sentry/templates/deployment-sentry-worker-transactions.yaml
+++ b/sentry/templates/deployment-sentry-worker-transactions.yaml
@@ -1,0 +1,155 @@
+{{- if .Values.sentry.workerTransactions.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-worker
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: worker
+{{- if not .Values.sentry.workerTransactions.autoscaling.enabled }}
+  replicas: {{ .Values.sentry.workerTransactions.replicas }}
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include "sentry.config" . | sha256sum }}
+        {{- if .Values.sentry.workerTransactions.annotations }}
+{{ toYaml .Values.sentry.workerTransactions.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: worker
+        {{- if .Values.sentry.workerTransactions.podLabels }}
+{{ toYaml .Values.sentry.workerTransactions.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.workerTransactions.affinity }}
+{{ toYaml .Values.sentry.workerTransactions.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.workerTransactions.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.workerTransactions.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.workerTransactions.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.workerTransactions.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.workerTransactions.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.workerTransactions.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-worker
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "worker"
+          - "-Q"
+          - {{ .Values.sentry.workerTransactions.queues }}
+          {{- if .Values.sentry.workerTransactions.concurrency }}
+          - "-c"
+          - "{{ .Values.sentry.workerTransactions.concurrency }}"
+          {{- end }}
+        env:
+        - name: C_FORCE_ROOT
+          value: "true"
+{{ include "sentry.env" . | indent 8 }}
+{{- if .Values.sentry.workerTransactions.env }}
+{{ toYaml .Values.sentry.workerTransactions.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if .Values.geodata.volumeName }}
+        - name: {{ .Values.geodata.volumeName }}
+          mountPath: {{ .Values.geodata.mountPath }}
+        {{- end }}
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- if .Values.sentry.workerTransactions.volumeMounts }}
+{{ toYaml .Values.sentry.workerTransactions.volumeMounts | indent 8 }}
+{{- end }}
+  {{- if .Values.sentry.workerTransactions.livenessProbe.enabled }}
+        livenessProbe:
+          periodSeconds: {{ .Values.sentry.workerTransactions.livenessProbe.periodSeconds }}
+          initialDelaySeconds: 10
+          timeoutSeconds: {{ .Values.sentry.workerTransactions.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.sentry.workerTransactions.livenessProbe.failureThreshold }}
+          exec:
+            command:
+              - sentry
+              - exec
+              - -c
+              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+{{- end }}
+        resources:
+{{ toYaml .Values.sentry.workerTransactions.resources | indent 12 }}
+{{- if .Values.sentry.workerTransactions.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.workerTransactions.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if .Values.sentry.workerTransactions.sidecars }}
+{{ toYaml .Values.sentry.workerTransactions.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-worker
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+      {{- if .Values.sentry.workerTransactions.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.workerTransactions.priorityClassName }}"
+      {{- end }}
+{{- if .Values.sentry.workerTransactions.volumes }}
+{{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}
+{{- end }}
+{{- end }}

--- a/sentry/templates/hpa-worker-events.yaml
+++ b/sentry/templates/hpa-worker-events.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.sentry.workerEvents.enabled .Values.sentry.workerEvents.autoscaling.enabled }}
+apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-worker
+  minReplicas: {{ .Values.sentry.workerEvents.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.workerEvents.autoscaling.maxReplicas }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
+  metrics:
+  - type: ContainerResource
+    containerResource:
+      container: {{ .Chart.Name }}-worker
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/sentry/templates/hpa-worker-transactions.yaml
+++ b/sentry/templates/hpa-worker-transactions.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.sentry.workerTransactions.enabled .Values.sentry.workerTransactions.autoscaling.enabled }}
+apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-worker
+  minReplicas: {{ .Values.sentry.workerTransactions.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.workerTransactions.autoscaling.maxReplicas }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
+  metrics:
+  - type: ContainerResource
+    containerResource:
+      container: {{ .Chart.Name }}-worker
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/sentry/templates/serviceaccount-sentry-worker.yaml
+++ b/sentry/templates/serviceaccount-sentry-worker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.worker.enabled }}
+{{- if and .Values.serviceAccount.enabled ( or .Values.sentry.worker.enabled .Values.sentry.workerEvents.enabled .Values.sentry.workerTransactions.enabled ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -210,6 +210,64 @@ sentry:
     volumes: []
     volumeMounts: []
 
+  # allows to dedicate some workers to specific queues
+  workerEvents:
+    enabled: false
+    queues: "events.save_event,post_process_errors"
+    replicas: 1
+    # concurrency: 4
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
+    # podLabels: []
+
+    # it's better to use prometheus adapter and scale based on
+    # the size of the rabbitmq queue
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 50
+    livenessProbe:
+      enabled: false
+      periodSeconds: 60
+      timeoutSeconds: 10
+      failureThreshold: 3
+    sidecars: []
+    volumes: []
+    volumeMounts: []
+
+  # allows to dedicate some workers to specific queues
+  workerTransactions:
+    enabled: true
+    queues: "events.save_event_transaction,post_process_transactions"
+    replicas: 1
+    # concurrency: 4
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    # tolerations: []
+    # podLabels: []
+
+    # it's better to use prometheus adapter and scale based on
+    # the size of the rabbitmq queue
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 50
+    livenessProbe:
+      enabled: false
+      periodSeconds: 60
+      timeoutSeconds: 10
+      failureThreshold: 3
+    sidecars: []
+    volumes: []
+    volumeMounts: []
+
   ingestConsumer:
     enabled: true
     replicas: 1


### PR DESCRIPTION
These changes give an opportunity to dedicate 2 additional worker deployments to particular queues. It allows processing rebalancing according to usage pattern. By default they configured for error and transaction processing, but queue lists may be redefined. Not a breaking change.