### PR TITLE
feat: use new kafka cluster config format

### DIFF
--- a/sentry/templates/_helper-sentry.tpl
+++ b/sentry/templates/_helper-sentry.tpl
@@ -204,7 +204,9 @@ sentry.conf.py: |-
   SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
   SENTRY_EVENTSTREAM_OPTIONS = {"producer_configuration": DEFAULT_KAFKA_OPTIONS}
 
-  KAFKA_CLUSTERS["default"] = DEFAULT_KAFKA_OPTIONS
+  KAFKA_CLUSTERS["default"] = {
+      "common": DEFAULT_KAFKA_OPTIONS
+  }
 
   ###############
   # Rate Limits #


### PR DESCRIPTION
Current kafka config format is legacy format.

https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L3395
https://github.com/getsentry/sentry/blob/master/src/sentry/utils/kafka_config.py#L52