### PR TITLE
feat: ability to override default clickhouse config

### DIFF
--- a/clickhouse/templates/configmap-config.yaml
+++ b/clickhouse/templates/configmap-config.yaml
@@ -73,7 +73,7 @@ data:
                       {{- end }}
                     </replica>
                     {{- end }}
-                </shard>   
+                </shard>
             {{- end }}
             </{{ include "clickhouse.fullname" . }}>
         </remote_servers>
@@ -162,11 +162,16 @@ data:
 
         {{- if .Values.clickhouse.configmap.merge_tree.enabled }}
         <merge_tree>
-            <parts_to_delay_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_delay_insert }}</parts_to_delay_insert> 
-            <parts_to_throw_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_throw_insert }}</parts_to_throw_insert> 
-            <max_part_loading_threads>{{ .Values.clickhouse.configmap.merge_tree.max_part_loading_threads }}</max_part_loading_threads> 
+            <parts_to_delay_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_delay_insert }}</parts_to_delay_insert>
+            <parts_to_throw_insert>{{ .Values.clickhouse.configmap.merge_tree.parts_to_throw_insert }}</parts_to_throw_insert>
+            <max_part_loading_threads>{{ .Values.clickhouse.configmap.merge_tree.max_part_loading_threads }}</max_part_loading_threads>
             <max_suspicious_broken_parts>{{ .Values.clickhouse.configmap.merge_tree.max_suspicious_broken_parts }}</max_suspicious_broken_parts>
         </merge_tree>
         {{- end }}
     </yandex>
+{{- if .Values.clickhouse.configmap.configOverride }}
+  override.xml: |-
+    <?xml version="1.0"?>
+    {{- .Values.clickhouse.configmap.configOverride | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/clickhouse/templates/statefulset-clickhouse.yaml
@@ -166,6 +166,10 @@ spec:
           items:
           - key: config.xml
             path: config.xml
+          {{- if .Values.clickhouse.configmap.configOverride }}
+          - key: override.xml
+            path: override.xml
+          {{- end }}
       - name: {{ include "clickhouse.fullname" . }}-metrica
         configMap:
           name: {{ include "clickhouse.fullname" . }}-metrica

--- a/clickhouse/values.yaml
+++ b/clickhouse/values.yaml
@@ -375,6 +375,16 @@ clickhouse:
       max_part_loading_threads: auto
       # If the number of broken parts in a single partition exceeds the max_suspicious_broken_parts value, automatic deletion is denied.
       max_suspicious_broken_parts: 100
+    ##
+    ## Allows to override default Clickhouse config via override.xml
+    ## E.g.
+    ## configOverride:
+    ##   <yandex>
+    ##     <query_log>
+    ##         <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
+    ##     </query_log>
+    ##   </yandex>
+    configOverride: ""
 
 ##
 ## Web interface for ClickHouse in the Tabix project.


### PR DESCRIPTION
This PR adds ability to override default Clickhouse config. This can be useful if you need to set TTL for system tables or completely disable them. Without this Clickhouse will filled the disk. The problem is described in more detail [here](https://kb.altinity.com/altinity-kb-setup-and-maintenance/altinity-kb-system-tables-eat-my-disk/).

Example of values:

```yml
clickhouse:
  clickhouse:
    configmap:
      configOverride: |
        <yandex>
            <asynchronous_metric_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </asynchronous_metric_log>
            <query_thread_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </query_thread_log>
            <trace_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </trace_log>
            <part_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </part_log>
            <query_views_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </query_views_log>
            <metric_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </metric_log>
            <query_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </query_log>
            <session_log>
                <ttl>event_date + INTERVAL 1 DAY DELETE</ttl>
            </session_log>
        </yandex>
```