### PR TITLE
feat: allow to configure extra manifests through values.yaml

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -109,6 +109,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | `snuba.transactionsConsumer.enabled`       | Enable Snuba transactions consumer                                                                                                                                | `true`                          |
 | `symbolicator.api.enabled`                    | Enable Symbolicator                                                                                                                                                 | `false`                        |
 | `symbolicator.api.config`                     | Config file for Symbolicator, see [its docs](https://getsentry.github.io/symbolicator/#configuration)                                                               | see values.yaml                |
+| `extraManifests`                              | Extra K8s manifests to deploy                                                                                                                                       | []                             |
 
 ## NGINX and/or Ingress
 

--- a/sentry/templates/extra-manifest.yaml
+++ b/sentry/templates/extra-manifest.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -2079,3 +2079,5 @@ revisionHistoryLimit: 10
 #   nameservers: []
 #   searches: []
 #   options: []
+
+extraManifests: []


### PR DESCRIPTION
This change allows users to deploy additional kubernetes manifests within this chart.

## Why?

By adding additional objects (like [external-secret](https://external-secrets.io/latest/)) I can mount secrets on which this app depends on, very useful when chart is deployed through tools like ArgoCD. It's generic enough that it will find many more use cases.

I was inspired by this thread: https://github.com/argoproj/argo-helm/pull/1094