### PR TITLE
feat: Allow to configure external postgres with values from secret

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -230,7 +230,46 @@ externalKafka:
     port: 9092
 ```
 
+## External Postgres configuration
 
+You can either pass postgres connection credentials directly in `values.yaml`:
+
+```yaml
+externalPostgresql:
+  host: postgres
+  port: 5432
+  username: postgres
+  password: postgres
+  database: sentry
+```
+
+or use existing `secret` like in the example below:
+
+```yaml
+externalPostgresql:
+  existingSecret: secret-name
+  existingSecretKeys:
+    password: password
+    username: username
+    database: database
+    port: port
+    host: host
+```
+
+it is possible to define which properties should be taken from secret or `values.yaml`, example below only takes `username` and `password` values from the secret:
+
+```yaml
+externalPostgresql:
+  existingSecret: secret-name
+  existingSecretKeys:
+    password: password
+    username: username
+  port: 8000
+  host: postgres
+  database: sentry
+```
+
+> ⚠️ `.Values.externalPostgresql.existingSecretKey` is depricated, `.Values.externalPostgresql.existingSecretKeys.password` should be used instead.
 
 # Usage
 

--- a/sentry/templates/_helper-sentry.tpl
+++ b/sentry/templates/_helper-sentry.tpl
@@ -128,11 +128,11 @@ sentry.conf.py: |-
   DATABASES = {
       "default": {
           "ENGINE": "sentry.db.postgres",
-          "NAME": {{ include "sentry.postgresql.database" . | quote }},
-          "USER": {{ include "sentry.postgresql.username" . | quote }},
+          "NAME": os.environ.get("POSTGRES_NAME", ""),
+          "USER": os.environ.get("POSTGRES_USER", ""),
           "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
-          "HOST": {{ include "sentry.postgresql.host" . | quote }},
-          "PORT": {{ template "sentry.postgresql.port" . }},
+          "HOST": os.environ.get("POSTGRES_HOST", ""),
+          "PORT": os.environ.get("POSTGRES_PORT", ""),
           {{- if .Values.postgresql.enabled }}
           "CONN_MAX_AGE": {{ .Values.postgresql.connMaxAge }},
           {{- else }}

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -515,7 +515,47 @@ Common Sentry environment variables
   valueFrom:
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
-      key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKey }}
+      key: {{ or .Values.externalPostgresql.existingSecretKeys.password .Values.externalPostgresql.existingSecretKey "postgresql-password" }}
+{{- end }}
+{{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.username }}
+- name: POSTGRES_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.username }}
+{{- else }}
+- name: POSTGRES_USER
+  value: {{ include "sentry.postgresql.username" . | quote }}
+{{- end }}
+{{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.database }}
+- name: POSTGRES_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.database }}
+{{- else }}
+- name: POSTGRES_NAME
+  value: {{ include "sentry.postgresql.database" . | quote }}
+{{- end }}
+{{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.host }}
+- name: POSTGRES_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.host }}
+{{- else }}
+- name: POSTGRES_HOST
+  value: {{ include "sentry.postgresql.host" . | quote }}
+{{- end }}
+{{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.port }}
+- name: POSTGRES_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.port }}
+{{- else }}
+- name: POSTGRES_PORT
+  value: {{ include "sentry.postgresql.port" . | quote }}
 {{- end }}
 {{- if and (eq .Values.filestore.backend "s3") .Values.filestore.s3.existingSecret }}
 - name: S3_ACCESS_KEY_ID

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1991,8 +1991,13 @@ externalPostgresql:
   username: postgres
   # password: postgres
   # existingSecret: secret-name
-  ## set existingSecretKey if key name inside existingSecret is different from 'postgresql-password'
-  # existingSecretKey: secret-key-name
+  ## set existingSecretKeys in a secret, if not specified, value from the secret won't be used 
+  # existingSecretKeys:
+  #   password: password
+  #   username: username
+  #   database: database
+  #   port: port
+  #   host: host
   database: sentry
   # sslMode: require
   ## Default connection max age is 0 (unlimited connections)


### PR DESCRIPTION
This change allows to configure external postgres with existing secret. The way it works is that all the variables for postgres connection config are loaded from the environment variables (now only password is). This makes a postgres configuration more flexible and opens up a possibility to load those variables from different sources, eg. secret, config map or directly in the deployment.

> ⚠️ This is a non breaking change, I made sure that `.Values.externalPostgresql.existingSecretKey` will still work but it should be noted that this property is depricated and `.Values.externalPostgresql.existingSecretKeys.password` should be used instead.

## Why?

In our case database provisioning is fully automated along with the secret that contains all the connection configuration. This change allows us to use existing secrets to configure external postgres.