### PR TITLE
fix(snuba): add profile_chunks to the storage sets

### DIFF
--- a/sentry/templates/_helper-snuba.tpl
+++ b/sentry/templates/_helper-snuba.tpl
@@ -41,6 +41,7 @@ settings.py: |
           "spans",
           "group_attributes",
           "generic_metrics_gauges",
+          "profile_chunks",
       },
       {{- /*
         The default clickhouse installation runs in distributed mode, while the external


### PR DESCRIPTION
Add the `profile_chunks` to the clickhouse storage sets.  This storage started being used in 24.5.1.