### PR TITLE
docs: `postgresql-password` secret key name

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1975,14 +1975,14 @@ postgresql:
 
 ## This value is only used when postgresql.enabled is set to false
 ## Set either externalPostgresql.password or externalPostgresql.existingSecret to configure password
-## externalPostgresql.existingSecret should have a key of 'postgres-password' which holds the password
+## externalPostgresql.existingSecret should have a key of 'postgresql-password' which holds the password
 externalPostgresql:
   # host: postgres
   port: 5432
   username: postgres
   # password: postgres
   # existingSecret: secret-name
-  ## set existingSecretKey if key name inside existingSecret is different from 'postgres-password'
+  ## set existingSecretKey if key name inside existingSecret is different from 'postgresql-password'
   # existingSecretKey: secret-key-name
   database: sentry
   # sslMode: require


### PR DESCRIPTION
There's a typo in the comments, web pod is expecting `postgresql-password` secret key instead of `postgres-password`