### PR TITLE
feat: discord integration

### DIFF
--- a/sentry/templates/_helper-sentry.tpl
+++ b/sentry/templates/_helper-sentry.tpl
@@ -60,6 +60,16 @@ config.yml: |-
   slack.signing-secret: {{ .Values.slack.signingSecret | quote }}
   {{ end }}
 
+  ###########
+  # Discord #
+  ###########
+  {{- if and (.Values.discord.applicationId) (.Values.discord.publicKey) (.Values.discord.clientSecret) (.Values.discord.botToken) (not .Values.discord.existingSecret) }}
+  discord.application-id: {{ .Values.discord.applicationId | quote }}
+  discord.public-key: {{ .Values.discord.publicKey | quote }}
+  discord.client-secret: {{ .Values.discord.clientSecret | quote }}
+  discord.bot-token: {{ .Values.discord.botToken | quote }}
+  {{ end }}
+
   #########
   # Redis #
   #########
@@ -583,6 +593,16 @@ sentry.conf.py: |-
   SENTRY_OPTIONS['slack.client-id'] = os.environ.get("SLACK_CLIENT_ID")
   SENTRY_OPTIONS['slack.client-secret'] = os.environ.get("SLACK_CLIENT_SECRET")
   SENTRY_OPTIONS['slack.signing-secret'] = os.environ.get("SLACK_SIGNING_SECRET")
+{{- end }}
+
+{{- if .Values.discord.existingSecret }}
+  ###########
+  # DISCORD #
+  ###########
+  SENTRY_OPTIONS['discord.application-id'] = os.environ.get("DISCORD_APPLICATION_ID")
+  SENTRY_OPTIONS['discord.public-key'] = os.environ.get("DISCORD_PUBLIC_KEY")
+  SENTRY_OPTIONS['discord.client-secret'] = os.environ.get("DISCORD_CLIENT_SECRET")
+  SENTRY_OPTIONS['discord.bot-token'] = os.environ.get("DISCORD_BOT_TOKEN")
 {{- end }}
 
 {{- if .Values.google.existingSecret }}

--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -560,6 +560,28 @@ Common Sentry environment variables
       name: {{ .Values.slack.existingSecret }}
       key: {{ default "signing-secret" .Values.slack.existingSecretSigningSecret }}
 {{- end }}
+{{- if .Values.discord.existingSecret }}
+- name: DISCORD_APPLICATION_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.discord.existingSecret }}
+      key: {{ default "application-id" .Values.slack.existingSecretApplicationId }}
+- name: DISCORD_PUBLIC_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.discord.existingSecret }}
+      key: {{ default "public-key" .Values.slack.existingSecretPublicKey }}
+- name: DISCORD_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.discord.existingSecret }}
+      key: {{ default "client-secret" .Values.slack.existingSecretClientSecret }}
+- name: DISCORD_BOT_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.discord.existingSecret }}
+      key: {{ default "bot-token" .Values.slack.existingSecretBotToken }}      
+{{- end }}
 {{- if and .Values.github.existingSecret }}
 - name: GITHUB_APP_PRIVATE_KEY
   valueFrom:

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1594,6 +1594,15 @@ slack: {}
 #   existingSecret:
 #   Reference -> https://develop.sentry.dev/integrations/slack/
 
+discord: {}
+# discord:
+#   applicationId:
+#   publicKey:
+#   clientSecret:
+#   botToken:
+#   existingSecret:
+#   Reference -> https://develop.sentry.dev/integrations/discord/
+
 openai: {}
 #   existingSecret: "xxxxx"
 #   existingSecretKey: ""   # by default "api-token"


### PR DESCRIPTION
This PR provides configuration for Discord integration.
Today it is possible to enable Discord using the `config.configYml`, but there's no option for adding configuration from a secret.