### PR TITLE
fix: template fails when existingSecretKeys is undefined

### DIFF
--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -1992,7 +1992,7 @@ externalPostgresql:
   # password: postgres
   # existingSecret: secret-name
   ## set existingSecretKeys in a secret, if not specified, value from the secret won't be used 
-  # existingSecretKeys:
+  existingSecretKeys: {}
   #   password: password
   #   username: username
   #   database: database


### PR DESCRIPTION
fixes https://github.com/sentry-kubernetes/charts/issues/1322