### PR TITLE
fix (nginx-cm): Do not create relay server block if relay is disabled

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 23.11.0
+version: 23.11.1
 appVersion: 24.5.1
 dependencies:
   - name: memcached

--- a/charts/sentry/templates/configmap-nginx.yaml
+++ b/charts/sentry/templates/configmap-nginx.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "sentry.fullname" . }}-nginx
 data:
   server-block.conf: |
+    {{ if .Values.relay.enabled }}
     upstream relay {
       server {{ template "sentry.fullname" . }}-relay:{{ template "relay.port" }};
     }
+    {{ end -}}
 
     upstream sentry {
       server {{ template "sentry.fullname" . }}-web:{{ template "sentry.port" }};
@@ -25,6 +27,7 @@ data:
       proxy_busy_buffers_size    256k;
       proxy_set_header Host $host;
 
+      {{ if .Values.relay.enabled }}
       location /api/store/ {
         proxy_pass http://relay;
       }
@@ -32,6 +35,7 @@ data:
       location ~ ^/api/[1-9]\d*/ {
         proxy_pass http://relay;
       }
+      {{ end -}}
 
       {{ if or .Values.nginx.metrics.enabled .Values.nginx.metrics.serviceMonitor.enabled -}}
       location = /status/ {


### PR DESCRIPTION
Relay can be disabled using `.Values.relay.enabled` but the same is not reflected in the configmap for nginx. This cause the nginx server to error out with the logs

```txt
nginx 12:13:43.29 INFO  ==>
nginx 12:13:43.29 INFO  ==> Welcome to the Bitnami nginx container
nginx 12:13:43.29 INFO  ==> Subscribe to project updates by watching https://github.com/bitnami/containers
nginx 12:13:43.29 INFO  ==> Submit issues and feature requests at https://github.com/bitnami/containers/issues
nginx 12:13:43.29 INFO  ==> Upgrade to Tanzu Application Catalog for production environments to access custom-configured and pre-packaged software components. Gain enhanced features, including Software Bill of Materials (SBOM), CVE scan result reports, and VEX documents. To learn more, visit https://bitnami.com/enterprise
nginx 12:13:43.37 INFO  ==>
nginx 12:13:43.37 INFO  ==> ** Starting NGINX setup **
nginx 12:13:43.38 INFO  ==> Validating settings in NGINX_* env vars
nginx 12:13:43.47 INFO  ==> No custom scripts in /docker-entrypoint-initdb.d
nginx 12:13:43.48 INFO  ==> Initializing NGINX
realpath: /bitnami/nginx/conf/vhosts: No such file or directory
nginx 12:13:43.58 INFO  ==> ** NGINX setup finished! **
nginx 12:13:43.67 INFO  ==> ** Starting NGINX **
2024/07/04 12:13:43 [emerg] 1#1: host not found in upstream "sentry-relay:3000" in /opt/bitnami/nginx/conf/server_blocks/server-block.conf:2
nginx: [emerg] host not found in upstream "sentry-relay:3000" in /opt/bitnami/nginx/conf/server_blocks/server-block.conf:2
```