### PR TITLE
feat(clickhouse): Allow overriding Clickhouse host

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -12,6 +12,6 @@ keywords:
 name: clickhouse
 sources:
   - https://github.com/sentry-kubernetes/charts
-version: 3.10.0
+version: 3.9.0
 maintainers:
   - name: sentry-kubernetes

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -12,6 +12,6 @@ keywords:
 name: clickhouse
 sources:
   - https://github.com/sentry-kubernetes/charts
-version: 3.9.0
+version: 3.10.0
 maintainers:
   - name: sentry-kubernetes

--- a/charts/clickhouse/templates/configmap-config.yaml
+++ b/charts/clickhouse/templates/configmap-config.yaml
@@ -21,7 +21,7 @@ data:
         <users_config>users.xml</users_config>
 
         <display_name>{{ template "clickhouse.fullname" . }}</display_name>
-        <listen_host>0.0.0.0</listen_host>
+        <listen_host>{{ .Values.clickhouse.listen_host | default "0.0.0.0" }}</listen_host>
         <http_port>{{ .Values.clickhouse.http_port | default "8123" }}</http_port>
         <tcp_port>{{ .Values.clickhouse.tcp_port | default "9000" }}</tcp_port>
         <interserver_http_port>{{ .Values.clickhouse.interserver_http_port | default "9009" }}</interserver_http_port>

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -118,6 +118,9 @@ clickhouse:
   ## Default value: /var/lib/clickhouse
   path: "/var/lib/clickhouse"
   ##
+  ## The host to listen on
+  listen_host: "0.0.0.0"
+  ##
   ## The port for connecting to the server over HTTP
   http_port: "8123"
   ##


### PR DESCRIPTION
When a cluster is IPv6 only, the Clickhouse health checks will fail due to Clickhouse binding to `0.0.0.0`.

This PR allows the Clickhouse `listen_host` to be overridden, so you can set it to `::` for IPv6 clusters.