### PR TITLE
fix: remove 'profiling-global-suspect-functions' as it is not supported on self hosted

### DIFF
--- a/charts/sentry/templates/_helper-sentry.tpl
+++ b/charts/sentry/templates/_helper-sentry.tpl
@@ -451,7 +451,6 @@ sentry.conf.py: |-
               "organizations:profiling-using-transactions",
               "organizations:profiling-beta",
               "organizations:profiling-stacktrace-links",
-              "organizations:profiling-global-suspect-functions",
               "organizations:profiling-cpu-chart",
               "organizations:profiling-memory-chart",
               "organizations:profiling-view",


### PR DESCRIPTION
As described here: https://github.com/getsentry/self-hosted/issues/3182

The error is thrown on Profiling Page by Most Regressed Functions panel. 

![image](https://github.com/sentry-kubernetes/charts/assets/23341314/2e5b2266-1968-4480-b999-e4e3ec745ac6)
