### PR TITLE
chore: Set externalClickhouse singleNode to false as default

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1787,7 +1787,7 @@ externalClickhouse:
   ## (https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-remote-servers)
   ## or by executing `select * from system.clusters`
   ##
-  # clusterName: test_shard_localhost
+  clusterName: default
 
 # Settings for Zookeeper.
 # See https://github.com/bitnami/charts/tree/master/bitnami/zookeeper

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1779,7 +1779,7 @@ externalClickhouse:
   username: default
   password: ""
   database: default
-  singleNode: true
+  singleNode: false
   # existingSecret: secret-name
   ## set existingSecretKey if key name inside existingSecret is different from 'postgres-password'
   # existingSecretKey: secret-key-name


### PR DESCRIPTION
Clickhouse is never deployed as a single node by default. This parameter is even set to false when using Clickhouse that's included with this chart.

This parameter controls how Snuba views the Clickhouse deployment.

Overlooking to set this parameter to false when using external Clickhouse causes missing events in Sentry.