### PR TITLE
add optional relabeling configs to serviceMonitor object

### DIFF
--- a/charts/sentry/templates/servicemonitor-metrics.yaml
+++ b/charts/sentry/templates/servicemonitor-metrics.yaml
@@ -21,6 +21,12 @@ spec:
       {{- if .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
   {{- if .Values.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector:
 {{ toYaml .Values.metrics.serviceMonitor.namespaceSelector | indent 4 -}}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2166,6 +2166,8 @@ metrics:
     #   any: true
     scrapeInterval: 30s
     # honorLabels: true
+    relabelings: []
+    metricRelabelings: []
 
 revisionHistoryLimit: 10
 


### PR DESCRIPTION
Updates the `serviceMonitor` object to optionally allow supplying `metricRelabelings` and `relabelings`. 

As described in the [Endpoint reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint) from the `serviceMonitor` spec. 
