### PR TITLE
fix: revert ClickHouse replicas number

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1735,8 +1735,8 @@ config:
 
 clickhouse:
   enabled: true
-  replicas: "1"
   clickhouse:
+    replicas: "3"
     imageVersion: "21.8.13.6"
     configmap:
       remote_servers:


### PR DESCRIPTION
Revert the ClickHouse replicas value modified by this previous PR:
- https://github.com/sentry-kubernetes/charts/pull/1379

AFAIK you can't simply change the number of ClickHouse replicas on an existing installation and except it to work
As of today, in this chart setting *x* ClickHouse replicas will result in *x* shards created so the data is split across multiple servers.

I suggest we simply revert this for now.
I understand it would be great to provide better defaults for anyone doing a fresh install of this chart, so I think the best course of action would be to integrate the change I reverted in a major version release instead and inform on the consequences of this change.