### PR TITLE
Switch to go version of sentry-kubernetes with first m…

### DIFF
--- a/charts/sentry-kubernetes/Chart.yaml
+++ b/charts/sentry-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry-kubernetes
 description: A Helm chart for sentry-kubernetes
   (https://github.com/getsentry/sentry-kubernetes)
 type: application
-version: 0.3.4
+version: 0.4.0
 appVersion: latest
 home: https://github.com/getsentry/sentry-kubernetes
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png

--- a/charts/sentry-kubernetes/Chart.yaml
+++ b/charts/sentry-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry-kubernetes
 description: A Helm chart for sentry-kubernetes
   (https://github.com/getsentry/sentry-kubernetes)
 type: application
-version: 0.4.0
+version: 0.3.4
 appVersion: latest
 home: https://github.com/getsentry/sentry-kubernetes
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png

--- a/charts/sentry-kubernetes/README.md
+++ b/charts/sentry-kubernetes/README.md
@@ -10,18 +10,89 @@ $ helm install sentry/sentry-kubernetes --name my-release --set sentry.dsn=<your
 
 ## Configuration
 
-The following table lists the configurable parameters of the sentry-kubernetes chart and their default values.
+The following table lists the configurable parameters of the sentry-kubernetes chart and their default values:
 
-| Parameter               | Description                                                                                                                 | Default                       |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `sentry.dsn`            | Sentry dsn                                                                                                                  | Empty                         |
-| `existingSecret`        | Existing secret to read DSN from                                                                                            | Empty                         |
-| `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
-| `sentry.release`        | Sentry release                                                                                                              | Empty                         |
-| `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |
-| `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
-| `image.tag`             | Container image tag                                                                                                         | `latest`                      |
-| `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
-| `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                            |
-| `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
-| `priorityClassName`     | pod priorityClassName                                                                                                       | Empty                         |
+| Parameter                       | Description                                                                                                                 | Default                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `sentry.dsn`                    | Sentry DSN                                                                                                                  | Empty                         |
+| `existingSecret`                | Existing secret to read DSN from                                                                                            | Empty                         |
+| `sentry.environment`            | Sentry environment                                                                                                          | Empty                         |
+| `sentry.release`                | Sentry release version                                                                                                      | Empty                         |
+| `sentry.logLevel`               | Sentry log level (trace, debug, info, warn, error, disabled)                                                                | `info`                        |
+| `sentry.watchNamespaces`        | Comma-separated list of namespaces to watch (set to `__all__` to watch all namespaces)                                      | `default`                     |
+| `sentry.watchHistorical`        | Set to `1` to report all existing (old) events, `0` to only report new events                                               | `0`                           |
+| `sentry.clusterConfigType`      | Cluster configuration type (`auto`, `in-cluster`, `out-cluster`)                                                            | `auto`                        |
+| `sentry.kubeconfigPath`         | Filesystem path to the kubeconfig used to connect to the cluster (used if `clusterConfigType` is `out-cluster`)             | Empty                         |
+| `sentry.monitorCronjobs`        | Set to `1` to enable Sentry Crons integration for CronJob objects                                                           | `0`                           |
+| `sentry.customDsns`             | Set to `1` to enable custom DSN specified in annotations with the key `k8s.sentry.io/dsn`                                   | `0`                           |
+| `image.repository`              | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
+| `image.tag`                     | Container image tag                                                                                                         | `latest`                      |
+| `rbac.create`                   | If `true`, create and use RBAC resources                                                                                    | `true`                        |
+| `serviceAccount.name`           | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | Empty                         |
+| `serviceAccount.create`         | If true, create a new service account                                                                                       | `true`                        |
+| `priorityClassName`             | Pod priorityClassName                                                                                                       | Empty                         |
+| `resources`                     | Resource requests and limits                                                                                                | `{}`                          |
+| `nodeSelector`                  | Node labels for pod assignment                                                                                              | `{}`                          |
+| `tolerations`                   | Tolerations for pod assignment                                                                                              | `[]`                          |
+| `podAnnotations`                | Annotations to add to the pod                                                                                               | `{}`                          |
+| `podLabels`                     | Additional labels to add to the pod                                                                                         | `{}`                          |
+| `rbac.custom_rules` | List of custom RBAC rules to extend default permissions. Each rule can specify `apiGroups`, `resources`, and `verbs`. | `[]`    |
+| `sentry.appendEnv`  | List of custom environment variables to append. Each item can specify a `name` and either a `value` or a `valueFrom` reference. | `[]`    |
+
+## Usage
+
+After installing the chart, you can configure various aspects of the sentry-kubernetes integration by modifying the `values.yaml` file or using `--set` flags during installation.
+
+### Example `values.yaml` Configuration
+
+Here's an example `values.yaml` that sets up sentry-kubernetes with custom configurations (remove unused values for default values):
+
+```yaml
+
+sentry:
+  dsn: <your-dsn>
+  environment: production
+  release: "1.0.0"
+  logLevel: info
+  watchNamespaces: "default,production"
+  watchHistorical: "1"
+  clusterConfigType: auto
+  kubeconfigPath: "/path/to/kubeconfig"
+  monitorCronjobs: "1"
+  customDsns: "1"
+  appendEnv:
+    - name: SENTRY_NEW_ENV_1
+      value: "newvalues"
+    - name: SENTRY_NEW_ENV_2
+      value: "newvalues"
+
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # Will replace the default rules
+  custom_rules:
+   - verbs:
+       - get
+       - list
+       - watch
+     apiGroups:
+       - 'apps'
+       - 'batch'
+       - ''
+     resources:
+       - events
+       - jobs
+       - deployments
+       - replicasets
+       - cronjobs
+       - pods
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+

--- a/charts/sentry-kubernetes/README.md
+++ b/charts/sentry-kubernetes/README.md
@@ -12,15 +12,15 @@ $ helm install sentry/sentry-kubernetes --name my-release --set sentry.dsn=<your
 
 The following table lists the configurable parameters of the sentry-kubernetes chart and their default values:
 
-| Parameter                       | Description                                                                                                                 | Default                       |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `sentry.dsn`                    | Sentry DSN                                                                                                                  | Empty                         |
-| `existingSecret`                | Existing secret to read DSN from                                                                                            | Empty                         |
-| `sentry.environment`            | Sentry environment                                                                                                          | Empty                         |
-| `sentry.release`                | Sentry release version                                                                                                      | Empty                         |
-| `sentry.logLevel`               | Sentry log level (trace, debug, info, warn, error, disabled)                                                                | `info`                        |
-| `sentry.watchNamespaces`        | Comma-separated list of namespaces to watch (set to `__all__` to watch all namespaces)                                      | `default`                     |
-| `sentry.watchHistorical`        | Set to `1` to report all existing (old) events, `0` to only report new events                                               | `0`                           |
+| Parameter               | Description                                                                                                                 | Default                       |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `sentry.dsn`            | Sentry DSN                                                                                                                  | Empty                         |
+| `existingSecret`        | Existing secret to read DSN from                                                                                            | Empty                         |
+| `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
+| `sentry.release`        | Sentry release version                                                                                                      | Empty                         |
+| `sentry.logLevel`       | Sentry log level (trace, debug, info, warn, error, disabled)                                                                | `info`                        |
+| `sentry.watchNamespaces`| Comma-separated list of namespaces to watch (set to `__all__` to watch all namespaces)                                      | `default`                     |
+| `sentry.watchHistorical`| Set to `1` to report all existing (old) events, `0` to only report new events                                               | `0`                           |
 | `sentry.clusterConfigType`      | Cluster configuration type (`auto`, `in-cluster`, `out-cluster`)                                                            | `auto`                        |
 | `sentry.kubeconfigPath`         | Filesystem path to the kubeconfig used to connect to the cluster (used if `clusterConfigType` is `out-cluster`)             | Empty                         |
 | `sentry.monitorCronjobs`        | Set to `1` to enable Sentry Crons integration for CronJob objects                                                           | `0`                           |

--- a/charts/sentry-kubernetes/README.md
+++ b/charts/sentry-kubernetes/README.md
@@ -25,12 +25,12 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `sentry.kubeconfigPath`         | Filesystem path to the kubeconfig used to connect to the cluster (used if `clusterConfigType` is `out-cluster`)             | Empty                         |
 | `sentry.monitorCronjobs`        | Set to `1` to enable Sentry Crons integration for CronJob objects                                                           | `0`                           |
 | `sentry.customDsns`             | Set to `1` to enable custom DSN specified in annotations with the key `k8s.sentry.io/dsn`                                   | `0`                           |
-| `image.repository`              | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
-| `image.tag`                     | Container image tag                                                                                                         | `latest`                      |
-| `rbac.create`                   | If `true`, create and use RBAC resources                                                                                    | `true`                        |
-| `serviceAccount.name`           | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | Empty                         |
-| `serviceAccount.create`         | If true, create a new service account                                                                                       | `true`                        |
-| `priorityClassName`             | Pod priorityClassName                                                                                                       | Empty                         |
+| `image.repository`      | Container image name                                                                                                | `getsentry/sentry-kubernetes` |
+| `image.tag`             | Container image tag                                                                                                 | `latest`                      |
+| `rbac.create`           | If `true`, create and use RBAC resources                                                                            | `true`                        |
+| `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | Empty                         |
+| `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
+| `priorityClassName`     | Pod priorityClassName                                                                                               | Empty                         |
 | `resources`                     | Resource requests and limits                                                                                                | `{}`                          |
 | `nodeSelector`                  | Node labels for pod assignment                                                                                              | `{}`                          |
 | `tolerations`                   | Tolerations for pod assignment                                                                                              | `[]`                          |

--- a/charts/sentry-kubernetes/README.md
+++ b/charts/sentry-kubernetes/README.md
@@ -25,8 +25,8 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `sentry.kubeconfigPath`         | Filesystem path to the kubeconfig used to connect to the cluster (used if `clusterConfigType` is `out-cluster`)             | Empty                         |
 | `sentry.monitorCronjobs`        | Set to `1` to enable Sentry Crons integration for CronJob objects                                                           | `0`                           |
 | `sentry.customDsns`             | Set to `1` to enable custom DSN specified in annotations with the key `k8s.sentry.io/dsn`                                   | `0`                           |
-| `image.repository`      | Container image name                                                                                                | `getsentry/sentry-kubernetes` |
-| `image.tag`             | Container image tag                                                                                                 | `latest`                      |
+| `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
+| `image.tag`             | Container image tag                                                                                                         | `latest`                      |
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | Empty                         |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |

--- a/charts/sentry-kubernetes/README.md
+++ b/charts/sentry-kubernetes/README.md
@@ -30,7 +30,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | Empty                         |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
-| `priorityClassName`     | Pod priorityClassName                                                                                               | Empty                         |
+| `priorityClassName`     | pod priorityClassName                                                                                                       | Empty                         |
 | `resources`                     | Resource requests and limits                                                                                                | `{}`                          |
 | `nodeSelector`                  | Node labels for pod assignment                                                                                              | `{}`                          |
 | `tolerations`                   | Tolerations for pod assignment                                                                                              | `[]`                          |

--- a/charts/sentry-kubernetes/README.md
+++ b/charts/sentry-kubernetes/README.md
@@ -27,7 +27,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `sentry.customDsns`             | Set to `1` to enable custom DSN specified in annotations with the key `k8s.sentry.io/dsn`                                   | `0`                           |
 | `image.repository`      | Container image name                                                                                                | `getsentry/sentry-kubernetes` |
 | `image.tag`             | Container image tag                                                                                                 | `latest`                      |
-| `rbac.create`           | If `true`, create and use RBAC resources                                                                            | `true`                        |
+| `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | Empty                         |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
 | `priorityClassName`     | Pod priorityClassName                                                                                               | Empty                         |

--- a/charts/sentry-kubernetes/templates/clusterrole.yaml
+++ b/charts/sentry-kubernetes/templates/clusterrole.yaml
@@ -5,6 +5,10 @@ metadata:
   labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
   name: {{ template "sentry-kubernetes.fullname" . }}
 rules:
+  # Custom rules inclusion
+  {{ if .Values.rbac.custom_rules }}
+    {{- toYaml .Values.rbac.custom_rules | nindent 4 }}
+  {{ else }}
   - apiGroups:
       - ""
     resources:
@@ -13,4 +17,5 @@ rules:
       - get
       - list
       - watch
+  {{ end }}
 {{- end -}}

--- a/charts/sentry-kubernetes/templates/deployment.yaml
+++ b/charts/sentry-kubernetes/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- end }}
       labels:
         app: {{ template "sentry-kubernetes.name" . }}
-        release: {{.Release.Name }}
+        release: {{ .Release.Name }}
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}
@@ -30,31 +30,60 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-          - name: DSN
+          {{ if .Values.sentry.dsn }}
+          - name: SENTRY_DSN
             valueFrom:
               secretKeyRef:
                 name: {{ template "sentry-kubernetes.secretName" . }}
                 key: sentry.dsn
+          {{ end }}
           {{ if .Values.sentry.environment }}
-          - name: ENVIRONMENT
-            value: {{ .Values.sentry.environment }}
+          - name: SENTRY_ENVIRONMENT
+            value: {{ .Values.sentry.environment | quote }}
           {{ end }}
           {{ if .Values.sentry.release }}
-          - name: RELEASE
-            value: {{ .Values.sentry.release }}
+          - name: SENTRY_RELEASE
+            value: {{ .Values.sentry.release | quote}}
           {{ end }}
           {{ if .Values.sentry.logLevel }}
-          - name: LOG_LEVEL
-            value: {{ .Values.sentry.logLevel }}
+          - name: SENTRY_K8S_LOG_LEVEL
+            value: {{ .Values.sentry.logLevel | quote}}
+          {{ end }}
+          {{ if .Values.sentry.watchNamespaces }}
+          - name: SENTRY_K8S_WATCH_NAMESPACES
+            value: {{ .Values.sentry.watchNamespaces | quote}}
+          {{ end }}
+          {{ if .Values.sentry.watchHistorical }}
+          - name: SENTRY_K8S_WATCH_HISTORICAL
+            value: {{ .Values.sentry.watchHistorical | quote}}
+          {{ end }}
+          {{ if .Values.sentry.clusterConfigType }}
+          - name: SENTRY_K8S_CLUSTER_CONFIG_TYPE
+            value: {{ .Values.sentry.clusterConfigType | quote}}
+          {{ end }}
+          {{ if .Values.sentry.kubeconfigPath }}
+          - name: SENTRY_K8S_KUBECONFIG_PATH
+            value: {{ .Values.sentry.kubeconfigPath | quote}}
+          {{ end }}
+          {{ if .Values.sentry.monitorCronjobs }}
+          - name: SENTRY_K8S_MONITOR_CRONJOBS
+            value: {{ .Values.sentry.monitorCronjobs | quote}}
+          {{ end }}
+          {{ if .Values.sentry.customDsns }}
+          - name: SENTRY_K8S_CUSTOM_DSNS
+            value: {{ .Values.sentry.customDsns | quote}}
+          {{ end }}
+          {{ if .Values.sentry.appendEnv }}
+            {{- toYaml .Values.sentry.appendEnv | nindent 10 }}
           {{ end }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{- toYaml .Values.resources | nindent 10 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+        {{- toYaml .Values.tolerations | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "sentry-kubernetes.serviceAccountName" . }}

--- a/charts/sentry-kubernetes/values.yaml
+++ b/charts/sentry-kubernetes/values.yaml
@@ -2,11 +2,27 @@
 
 sentry:
   dsn: <change-me>
-  logLevel: ~
+  # environment: production
+  # release: "1.0.0"
+  # logLevel: info
+  # watchNamespaces: "default,production"
+  # watchHistorical: "1"
+  # clusterConfigType: auto
+  # kubeconfigPath: "/path/to/kubeconfig"
+  # monitorCronjobs: "1"
+  # customDsns: "1"
+  # This can be use to add custom env var to the pod if not yet supported by the chart.
+  # appendEnv:
+  #   - name: SENTRY_NEW_ENV_1
+  #     value: "newvalues"
+  #   - name: SENTRY_NEW_ENV_2
+  #     value: "newvalues"
+
 # Sentry DSN config using an existing secret:
 # existingSecret:
 image:
-  repository: getsentry/sentry-kubernetes
+  repository: ghcr.io/getsentry/sentry-kubernetes
+  # Tag should be set in hard in the charts when getsentry will do the job of releasing version.
   tag: latest
   pullPolicy: Always
 resources: {}
@@ -23,10 +39,28 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # if your need more specific cluster_roles for security reason, custom will be used in place
 
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  # Exemple of custom rules necessary for cronjob and other issues catching.
+  # custom_rules:
+  #  - verbs:
+  #      - get
+  #      - list
+  #      - watch
+  #    apiGroups:
+  #      - 'apps'
+  #      - 'batch'
+  #      - ''
+  #    resources:
+  #      - events
+  #      - jobs
+  #      - deployments
+  #      - replicasets
+  #      - cronjobs
+  #      - pods
 
 # Set priorityCLassName in deployment
 # priorityClassName: ""


### PR DESCRIPTION
…inimal version of the chart

I didn't implemented volume mount for the kubeconfig.
I think this need to be passed using a secret and we can pass it like SENTRY_DSN.