### PR TITLE
fix: add noStrictOffsetReset for ingest-consumer-attachments

### DIFF
--- a/charts/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/deployment-sentry-ingest-consumer-attachments.yaml
@@ -86,6 +86,9 @@ spec:
           - "ingest-attachments"
           - "--consumer-group"
           - "ingest-consumer"
+          {{- if .Values.sentry.ingestConsumerAttachments.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
           {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"


### PR DESCRIPTION
This value is listed for the consumer: https://github.com/sentry-kubernetes/charts/blob/develop/charts/sentry/values.yaml#L319

Seems that it was omitted during ingestConsumer split