### PR TITLE
fix: fail lint and test charts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args="--timeout 1000s"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch --helm-extra-args --timeout 1000s ${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch --helm-extra-args --timeout 1000s ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args="--timeout 1000s"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/
 
 ## How this chart works
 
-`helm repo add sentry https://sentry-kubernetes.github.io/charts`
-
+```
+helm repo add sentry https://sentry-kubernetes.github.io/charts
+helm repo update
+helm install my-sentry sentry/sentry --wait --timeout=1000s
+```
 ## Values
 
 For now the full list of values is not documented but you can get inspired by the values.yaml specific to each directory.
@@ -193,7 +196,7 @@ Otherwise, you should delete the old ClickHouse volumes in-order to upgrade to t
 
 ## Upgrading from 12.x.x version of this Chart to 13.0.0
 
-The service annotions have been moved from the `service` section to the respective service's service sub-section. So what was:
+The service annotations have been moved from the `service` section to the respective service's service sub-section. So what was:
 
 ```yaml
 service:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -15,7 +15,7 @@ user:
   # existingSecretKey: admin-password
 
 # this is required on the first installation, as sentry has to be initialized first
-# recommended to set false for updating the helm chart afterwards,
+# recommended to set false for updating the helm chart afterward,
 # as you will have some downtime on each update if it's a hook
 # deploys relay & snuba consumers as post hooks
 asHook: true
@@ -2190,4 +2190,3 @@ revisionHistoryLimit: 10
 #   options: []
 
 extraManifests: []
-

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2190,3 +2190,4 @@ revisionHistoryLimit: 10
 #   options: []
 
 extraManifests: []
+

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -15,7 +15,7 @@ user:
   # existingSecretKey: admin-password
 
 # this is required on the first installation, as sentry has to be initialized first
-# recommended to set false for updating the helm chart afterward,
+# recommended to set false for updating the helm chart afterwards,
 # as you will have some downtime on each update if it's a hook
 # deploys relay & snuba consumers as post hooks
 asHook: true
@@ -1656,7 +1656,7 @@ ingress:
   # if you are using AWS ALB Ingress controller, switch this to 'aws-alb'
   # if you are using GKE Ingress controller, switch this to 'gke'
   regexPathStyle: nginx
-  # If you are using AWS ALB Ingress controller, switch to true if you want activate the http to https redirection.
+  # If you are using AWS ALB Ingress controller, switch to true if you want to activate the http to https redirection.
   alb:
     httpRedirect: false
   # annotations:


### PR DESCRIPTION
Run local helm chart
```
time helm install sentry --timeout 3600s  -n test . --values values.yaml 
coalesce.go:237: warning: skipped value for kafka.config: Not a table.
NAME: sentry
LAST DEPLOYED: Thu Aug 29 13:49:16 2024
NAMESPACE: test
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
* When running upgrades, make sure to give back the `system.secretKey` value.

kubectl -n test get configmap sentry-sentry -o json | grep -m1 -Po '(?<=system.secret-key: )[^\\]*'

real	11m54.850s
user	0m23.565s
sys	0m0.937s
```

jobs work for a long time (The time is not final):
```
k get jobs -n test
NAME                        COMPLETIONS   DURATION   AGE
sentry-db-check             1/1           94s        11m
sentry-db-init              1/1           2m4s       2m13s
sentry-kafka-provisioning   1/1           6m20s      9m36s
sentry-snuba-db-init        1/1           6s         3m15s
sentry-snuba-migrate        1/1           54s        3m8s
sentry-user-create          0/1           8s         8s
```

@Mokto @@shcherbak @adonskoy Fix: https://github.com/sentry-kubernetes/charts/pull/1404

After create new release will be fix:
https://github.com/sentry-kubernetes/charts/issues/1370
https://github.com/sentry-kubernetes/charts/discussions/998
https://github.com/sentry-kubernetes/charts/discussions/791