### PR TITLE
fix: add timeout for correct test charts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/
 
 ## How this chart works
 
-`helm repo add sentry https://sentry-kubernetes.github.io/charts`
+```
+helm repo add sentry https://sentry-kubernetes.github.io/charts
+helm repo update
+helm install my-sentry sentry/sentry --wait --timeout=1000s
+```
 
 ## Values
 


### PR DESCRIPTION
This PR introduces a modification to the Helm chart deployment process in GitHub Action by setting a timeout of 1000 seconds for the `helm install` command. This change aims to balance the deployment time while ensuring that critical jobs have sufficient time to complete.

### Key Changes:
- **Helm Install Timeout**: The `helm install` command now includes `--timeout 1000s` to provide a reasonable window for deployment completion.
- **Job Durations**: Several jobs, such as `sentry-kafka-provisioning` and `sentry-db-init`, have been observed to take significant time to complete, highlighting the importance of a carefully considered timeout.


### Related Issues:
- Fixes #1404

Please review and provide feedback. Thank you!