### PR TITLE
fix: del --max-batch-time-ms and enable maxBatchTimeMs in values

### DIFF
--- a/charts/sentry/templates/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-consumers"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.consumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.consumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.consumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-gen-metrics-counters-consumers"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.genericMetricsCountersConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.genericMetricsCountersConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.genericMetricsCountersConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-gen-metrics-distributions-consumers"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.genericMetricsDistributionConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.genericMetricsDistributionConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.genericMetricsDistributionConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-gen-metrics-sets-consumers"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.genericMetricsSetsConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.genericMetricsSetsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.genericMetricsSetsConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-group-attributes-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-group-attributes-group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.groupAttributesConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.groupAttributesConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.groupAttributesConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-issue-occurrence-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "generic_events_group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.issueOccurrenceConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.issueOccurrenceConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.issueOccurrenceConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-metrics-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-metrics-consumers"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.metricsConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.metricsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.metricsConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-outcomes-billing-consumer.yaml
@@ -87,8 +87,6 @@ spec:
           - "{{ .Values.snuba.outcomesBillingConsumer.autoOffsetReset }}"
           - "--raw-events-topic"
           - "outcomes-billing"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.outcomesBillingConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.outcomesBillingConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-profiling-functions-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "functions_raw_group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.profilingFunctionsConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.profilingFunctionsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.profilingFunctionsConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-profiling-profiles-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "profiles_group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.profilingProfilesConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.profilingProfilesConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.profilingProfilesConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-replays-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "replays_group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.replaysConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.replaysConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.replaysConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-spans-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-spans-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "snuba-spans-group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.spansConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.spansConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.spansConsumer.maxBatchSize }}"

--- a/charts/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -85,8 +85,6 @@ spec:
           - "transactions_group"
           - "--auto-offset-reset"
           - "{{ .Values.snuba.transactionsConsumer.autoOffsetReset }}"
-          - "--max-batch-time-ms"
-          - "750"
           {{- if .Values.snuba.transactionsConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.transactionsConsumer.maxBatchSize }}"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -871,7 +871,7 @@ snuba:
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
 
@@ -939,7 +939,7 @@ snuba:
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
 
@@ -989,6 +989,14 @@ snuba:
       periodSeconds: 320
     # volumes: []
     # volumeMounts: []
+    # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    maxBatchTimeMs: 750
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
   subscriptionConsumerEvents:
     enabled: true
@@ -1029,6 +1037,14 @@ snuba:
       periodSeconds: 320
     # volumes: []
     # volumeMounts: []
+    # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    maxBatchTimeMs: 750
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
   genericMetricsDistributionConsumer:
     enabled: true
@@ -1049,6 +1065,14 @@ snuba:
       periodSeconds: 320
     # volumes: []
     # volumeMounts: []
+    # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    maxBatchTimeMs: 750
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
   genericMetricsSetsConsumer:
     enabled: true
@@ -1069,6 +1093,14 @@ snuba:
       periodSeconds: 320
     # volumes: []
     # volumeMounts: []
+    # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    maxBatchTimeMs: 750
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
   subscriptionConsumerMetrics:
     enabled: true
@@ -1145,14 +1177,14 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -1208,14 +1240,15 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
+
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -1241,14 +1274,14 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -1274,14 +1307,14 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -1307,14 +1340,14 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -1341,14 +1374,14 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
     # volumeMounts:
     #   - mountPath: /dev/shm
@@ -1375,14 +1408,14 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
-    # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
-    # maxBatchTimeMs: ""
+    maxBatchTimeMs: 750
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
+    # noStrictOffsetReset: false
 
     # volumeMounts:
     #   - mountPath: /dev/shm


### PR DESCRIPTION
### Description:
In this pull request, changes have been made to the Snuba configuration to enhance flexibility and simplify management of the --max-batch-time-ms parameter. Previously, this parameter was hardcoded in several deployment templates, limiting the configurability for users.

### Key Changes:
- **Removed Hardcoded Parameter**: The `--max-batch-time-ms` parameter has been removed from all deployment templates where it was previously hardcoded.
- **Added Configuration to values.yaml**: Introduced the `maxBatchTimeMs` parameter in the `values.yaml` file for all relevant Snuba consumers. This allows users to configure the `--max-batch-time-ms` value directly through the Helm chart values, enhancing flexibility and ease of management.

These changes are aimed at improving the manageability and configurability of the Snuba configuration, making it more adaptable to various deployment scenarios and user preferences.

Please review and provide feedback. Thank you!