### PR TITLE
fix: remove invalid --max-batch-size and --processes parameters from some consumers

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -9,13 +9,13 @@ helm repo add sentry https://sentry-kubernetes.github.io/charts
 ## Without overrides
 
 ```
-helm install sentry sentry/sentry
+helm install sentry sentry/sentry --wait --timeout=1000s
 ```
 
 ## With your own values file
 
 ```
-helm install sentry sentry/sentry -f values.yaml
+helm install sentry sentry/sentry -f values.yaml --wait --timeout=1000s
 ```
 
 # Upgrade

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -91,14 +91,6 @@ spec:
           - "/tmp/health.txt"
           {{- end }}
           - "--"
-          {{- if .Values.sentry.billingMetricsConsumer.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.billingMetricsConsumer.maxBatchSize }}"
-          {{- end }}
-          {{- if .Values.sentry.billingMetricsConsumer.concurrency }}
-          - "--processes"
-          - "{{ .Values.sentry.billingMetricsConsumer.concurrency }}"
-          {{- end }}
         {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -89,10 +89,6 @@ spec:
           - "/tmp/health.txt"
           {{- end }}
           - "--"
-          {{- if .Values.sentry.metricsConsumer.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.metricsConsumer.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.metricsConsumer.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.metricsConsumer.concurrency }}"

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -89,10 +89,6 @@ spec:
           - "/tmp/health.txt"
           {{- end }}
           - "--"
-          {{- if .Values.sentry.genericMetricsConsumer.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.genericMetricsConsumer.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.genericMetricsConsumer.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -520,7 +520,6 @@ sentry:
   billingMetricsConsumer:
     enabled: true
     replicas: 1
-    # concurrency: 4
     env: []
     resources: {}
     affinity: {}
@@ -529,7 +528,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-    # maxBatchSize: ""
 
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
@@ -562,7 +560,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-    # maxBatchSize: ""
     # maxPollIntervalMs: ""
     # logLevel: "info"
 
@@ -597,7 +594,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-    # maxBatchSize: ""
     # logLevel: "info"
     # maxPollIntervalMs: ""
 


### PR DESCRIPTION
Hello!

I have identified configuration errors related to the `--max-batch-size` and `--processes` parameters for three metrics consumers: `sentry-billing-metrics-consumer`, `sentry-generic-metrics-consumer`, and `sentry-metrics-consumer`. These errors occur because the specified parameters do not exist for these consumers.

**Changes:**
1. Removed lines related to the `--max-batch-size` parameter in the configuration files for each of the mentioned consumers.
2. Removed the `--processes` parameter for `billingMetricsConsumer`.
3. Removed comments related to the `--max-batch-size` and `--processes` parameters in the `values.yaml` file.

### Related Issues:
- Fixes #1415

Thank you for reviewing and providing feedback!