### PR TITLE
feat: Add HPA resources with labels and annotations for some deployments

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
@@ -3,6 +3,20 @@ apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry-ingest-consumer-attachments
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
@@ -3,6 +3,20 @@ apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry-ingest-consumer-events
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/sentry/templates/sentry/ingest/monitors/hpa-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/hpa-ingest-monitors.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestMonitors.enabled .Values.sentry.ingestMonitors.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-monitors
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-ingest-monitors
+  minReplicas: {{ .Values.sentry.ingestMonitors.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestMonitors.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestMonitors.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-ingest-monitors
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestMonitors.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestMonitors.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestOccurrences.enabled .Values.sentry.ingestOccurrences.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-occurrences
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-ingest-occurrences
+  minReplicas: {{ .Values.sentry.ingestOccurrences.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestOccurrences.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestOccurrences.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-ingest-occurrences
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestOccurrences.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestOccurrences.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/profiles/hpa-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/hpa-ingest-profiles.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.features.enableProfiling .Values.sentry.ingestProfiles.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-profiles
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-ingest-profiles
+  minReplicas: {{ .Values.sentry.ingestProfiles.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestProfiles.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestProfiles.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-ingest-profiles
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestProfiles.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestProfiles.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/hpa-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/hpa-ingest-replay-recordings.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestReplayRecordings.enabled .Values.sentry.ingestReplayRecordings.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-replay-recordings
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-ingest-replay-recordings
+  minReplicas: {{ .Values.sentry.ingestReplayRecordings.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestReplayRecordings.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestReplayRecordings.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-ingest-replay-recordings
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestReplayRecordings.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.ingestReplayRecordings.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/billing/hpa-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/hpa-billing-metrics-consumer.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.billingMetricsConsumer.enabled .Values.sentry.billingMetricsConsumer.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-billing-metrics-consumer
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-billing-metrics-consumer
+  minReplicas: {{ .Values.sentry.billingMetricsConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.billingMetricsConsumer.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.billingMetricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-billing-metrics-consumer
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.billingMetricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.billingMetricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/generic/hpa-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/hpa-generic-metrics-consumer.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.genericMetricsConsumer.enabled .Values.sentry.genericMetricsConsumer.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-generic-metrics-consumer
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-generic-metrics-consumer
+  minReplicas: {{ .Values.sentry.genericMetricsConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.genericMetricsConsumer.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.genericMetricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-generic-metrics-consumer
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.genericMetricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.genericMetricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/hpa-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/hpa-metrics-consumer.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if and .Values.sentry.metricsConsumer.enabled .Values.sentry.metricsConsumer.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ template "sentry.fullname" . }}-sentry-metrics-consumer
   labels:
     app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -15,26 +15,26 @@ metadata:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "sentry.fullname" . }}-vroom
-  minReplicas: {{ .Values.vroom.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.vroom.autoscaling.maxReplicas }}
+    name: {{ template "sentry.fullname" . }}-metrics-consumer
+  minReplicas: {{ .Values.sentry.metricsConsumer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.metricsConsumer.autoscaling.maxReplicas }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
-  targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.metricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
   - type: ContainerResource
     containerResource:
-      container: {{ .Chart.Name }}-vroom
+      container: {{ .Chart.Name }}-metrics-consumer
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.metricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
   - type: Resource
@@ -42,6 +42,6 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.sentry.metricsConsumer.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/symbolicator/hpa-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/hpa-symbolicator.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.symbolicator.enabled .Values.symbolicator.api.autoscaling.enabled }}
+apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-symbolicator-api
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-symbolicator-api
+  minReplicas: {{ .Values.symbolicator.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.symbolicator.api.autoscaling.maxReplicas }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
+  targetCPUUtilizationPercentage: {{ .Values.symbolicator.api.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
+  metrics:
+  - type: ContainerResource
+    containerResource:
+      container: {{ .Chart.Name }}-symbolicator
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.symbolicator.api.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.symbolicator.api.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1575,7 +1575,6 @@ symbolicator:
       #   diagnostics:
       #     retention: 1w
 
-    # TODO autoscaling in not yet implemented
     autoscaling:
       enabled: false
       minReplicas: 2


### PR DESCRIPTION
This pull request introduces Horizontal Pod Autoscaler (HPA) resources for various components within the Sentry Helm chart. The HPA resources are configured with labels and annotations to ensure consistency with the corresponding Deployment resources. This change enhances the management and visibility of these resources within the Kubernetes cluster.

**Changes Include:**

**Added HPA resources for the following components:**

- sentry-ingest-monitors
- sentry-ingest-occurrences
- sentry-ingest-profiles
- sentry-ingest-replay-recordings
- sentry-billing-metrics-consumer
- sentry-generic-metrics-consumer
- sentry-metrics-consumer
- sentry-symbolicator-api

**Add label and annotations:**
- sentry-ingest-consumer-attachments
- sentry-ingest-consumer-events
- sentry-vroom

Impact:

This change ensures that all HPA resources are consistently labeled and annotated, making it easier to manage and monitor them within the Kubernetes environment. It also aligns the HPA resources with the existing Deployment resources, improving overall consistency and maintainability.