### PR TITLE
ci: add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,78 @@
+
+name: "\U0001F41E  Bug report"
+description: File a bug report
+labels: ["status/triage", "type/bug"]
+assignees: []
+
+body:
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Issue submitter TODO list
+      description: By you checking these checkboxes we can be sure you've done the essential things.
+      options:
+        - label: I've searched for an already existing issues [here](https://github.com/sentry-kubernetes/charts/issues)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the bug (actual behavior)
+      description: A clear and concise description of what the bug is. Use a list, if there is more than one problem
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Your installation details
+      description: |
+        How do you run the app? Please provide as much info as possible:
+        1. values.yaml
+        2. Helm chart version
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Please write down the order of the actions required to reproduce the issue.
+        For the advanced setups/complicated issue, we might need you to provide
+        a minimal [reproducible example](https://stackoverflow.com/help/minimal-reproducible-example).
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: |
+        If applicable, add screenshots to help explain your problem
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Logs
+      description: |
+        If applicable, *upload* logs to help explain your problem
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here. E.G.:
+        1. Are there any alternative scenarios (different data/methods/configuration/setup) you have tried?
+          Were they successful or the same issue occurred? Please provide steps as well.
+        2. Related issues (if there are any).
+        3. Logs (if available)
+        4. Is there any serious impact or behaviour on the end-user because of this issue, that can be overlooked?
+    validations:
+      required: false


### PR DESCRIPTION
This pull request introduces a new issue template for bug reports in the repository. The template is designed to streamline the process of submitting bug reports by guiding users to provide essential information. This will help maintainers and contributors to quickly understand and address reported issues.

## Changes

- Added a new file `.github/ISSUE_TEMPLATE/bug.yml` with the following structure:
  - **Name:** "🐞 Bug report"
  - **Description:** "File a bug report"
  - **Labels:** ["status/triage", "type/bug"]
  - **Body:**
    - **Checkboxes:** Ensures users have searched for existing issues.
    - **Textarea:** Description of the bug (actual behavior). 
    - **Textarea:** Expected behavior. 
    - **Textarea:** Installation details (values.yaml, Helm chart version). 
    - **Textarea:** Steps to reproduce the issue. 
    - **Textarea:** Screenshots (if applicable). 
    - **Textarea:** Logs (if applicable). 
    - **Textarea:** Additional context.

## Benefits

- **Improved Issue Quality:** By guiding users to provide detailed information, the quality of bug reports will improve, making it easier for maintainers to reproduce and fix issues.
- **Efficiency:** The structured format reduces the time spent on clarifying details, allowing maintainers to focus on resolving the issue.
- **Consistency:** Ensures that all bug reports follow a consistent format, making it easier to track and manage issues.