### PR TITLE
feat: enhance nginx config to handle disabled sentry relay

### DIFF
--- a/charts/sentry/templates/configmap-nginx.yaml
+++ b/charts/sentry/templates/configmap-nginx.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "sentry.fullname" . }}-nginx
 data:
   server-block.conf: |
+    {{ if .Values.relay.enabled }}
     upstream relay {
       server {{ template "sentry.fullname" . }}-relay:{{ template "relay.port" }};
     }
+    {{ end -}}
 
     upstream sentry {
       server {{ template "sentry.fullname" . }}-web:{{ template "sentry.port" }};
@@ -25,6 +27,7 @@ data:
       proxy_busy_buffers_size    256k;
       proxy_set_header Host $host;
 
+      {{ if .Values.relay.enabled }}
       location /api/store/ {
         proxy_pass http://relay;
       }
@@ -32,6 +35,7 @@ data:
       location ~ ^/api/[1-9]\d*/ {
         proxy_pass http://relay;
       }
+      {{ end -}}
 
       {{ if or .Values.nginx.metrics.enabled .Values.nginx.metrics.serviceMonitor.enabled -}}
       location = /status/ {


### PR DESCRIPTION
#### Changes:

This pull request introduces conditional Nginx configuration for Sentry Relay to handle scenarios where Relay is disabled. The Nginx configuration now dynamically adapts based on whether Relay is enabled or not, preventing deployment errors when Relay is turned off.

#### Details:

- **configmap-nginx.yaml**:
  - Added conditional statements to enable or disable Relay-related configuration blocks based on the value of `.Values.relay.enabled`.
  - This ensures that the Nginx configuration is correctly set up regardless of the Relay status.

#### Related Pull Request:
- #1350

Please review and merge if everything looks good.

Thanks!