### PR TITLE
feat: remove autoscaling configuration from sentry ingest components

### DIFF
--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -24,9 +24,7 @@ spec:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
       role: ingest-monitors
-{{- if not .Values.sentry.ingestMonitors.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestMonitors.replicas }}
-{{- end }}
   template:
     metadata:
       annotations:

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -24,9 +24,7 @@ spec:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
       role: ingest-occurrences
-{{- if not .Values.sentry.ingestOccurrences.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestOccurrences.replicas }}
-{{- end }}
   template:
     metadata:
       annotations:

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -24,9 +24,7 @@ spec:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
       role: ingest-profiles
-{{- if not .Values.sentry.ingestProfiles.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestProfiles.replicas }}
-{{- end }}
   template:
     metadata:
       annotations:

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -24,9 +24,7 @@ spec:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
       role: ingest-replay-recordings
-{{- if not .Values.sentry.ingestReplayRecordings.autoscaling.enabled }}
   replicas: {{ .Values.sentry.ingestReplayRecordings.replicas }}
-{{- end }}
   template:
     metadata:
       annotations:

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -24,9 +24,7 @@ spec:
       app: {{ template "sentry.fullname" . }}
       release: "{{ .Release.Name }}"
       role: billing-metrics-consumer
-{{- if not .Values.sentry.billingMetricsConsumer.autoscaling.enabled }}
   replicas: {{ .Values.sentry.billingMetricsConsumer.replicas }}
-{{- end }}
   template:
     metadata:
       annotations:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -415,14 +415,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -445,14 +437,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -464,6 +448,7 @@ sentry:
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
+
   ingestOccurrences:
     enabled: true
     replicas: 1
@@ -475,14 +460,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -506,14 +483,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -536,14 +505,6 @@ sentry:
     containerSecurityContext: {}
     # tolerations: []
     # podLabels: []
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -570,14 +531,6 @@ sentry:
     # podLabels: []
     # maxPollIntervalMs: ""
     # logLevel: "info"
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -604,14 +557,6 @@ sentry:
     # podLabels: []
     # logLevel: "info"
     # maxPollIntervalMs: ""
-
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
-    autoscaling:
-      enabled: false
-      minReplicas: 1
-      maxReplicas: 3
-      targetCPUUtilizationPercentage: 50
     sidecars: []
     topologySpreadConstraints: []
     volumes: []


### PR DESCRIPTION
#### Changes:

This pull request removes the autoscaling configuration from the Sentry Ingest components. The primary reason for this change is that the number of replicas needs to be kept equal to the number of partitions in Kafka, which is managed manually. 

#### Details:

- **Deployment Files**:
  - Removed conditions for setting the number of replicas if autoscaling is disabled.
  - Removed autoscaling settings from the Deployment templates.

- **values.yaml**:
  - Removed autoscaling settings for all Sentry Ingest components.

#### Related Pull Request:
- #1424

Please review and merge if everything looks good.

Thanks!