### PR TITLE
fix: update doc to require existingsecretkeys for external postgresql

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2056,7 +2056,8 @@ externalPostgresql:
   username: postgres
   # password: postgres
   # existingSecret: secret-name
-  ## If externalPostgresql.existingSecret is used, externalPostgresql.existingSecretKeys.password must be specified.
+  # set existingSecretKeys in a secret, if not specified, value from the secret won't be used
+  # if externalPostgresql.existingSecret is used, externalPostgresql.existingSecretKeys.password must be specified.
   existingSecretKeys: {}
   #   password: password # Required if existingSecret is used.
   #   username: username

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2059,7 +2059,7 @@ externalPostgresql:
   # set existingSecretKeys in a secret, if not specified, value from the secret won't be used
   # if externalPostgresql.existingSecret is used, externalPostgresql.existingSecretKeys.password must be specified.
   existingSecretKeys: {}
-  #   password: postgresql-password # Required if existingSecret is used.
+  #   password: postgresql-password # Required if existingSecret is used. Key in existingSecret.
   #   username: username
   #   database: database
   #   port: port

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2059,7 +2059,7 @@ externalPostgresql:
   # set existingSecretKeys in a secret, if not specified, value from the secret won't be used
   # if externalPostgresql.existingSecret is used, externalPostgresql.existingSecretKeys.password must be specified.
   existingSecretKeys: {}
-  #   password: password # Required if existingSecret is used.
+  #   password: postgresql-password # Required if existingSecret is used.
   #   username: username
   #   database: database
   #   port: port

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2050,16 +2050,15 @@ postgresql:
 
 ## This value is only used when postgresql.enabled is set to false
 ## Set either externalPostgresql.password or externalPostgresql.existingSecret to configure password
-## externalPostgresql.existingSecret should have a key of 'postgresql-password' which holds the password
 externalPostgresql:
   # host: postgres
   port: 5432
   username: postgres
   # password: postgres
   # existingSecret: secret-name
-  ## set existingSecretKeys in a secret, if not specified, value from the secret won't be used
+  ## If externalPostgresql.existingSecret is used, externalPostgresql.existingSecretKeys.password must be specified.
   existingSecretKeys: {}
-  #   password: password
+  #   password: password # Required if existingSecret is used.
   #   username: username
   #   database: database
   #   port: port


### PR DESCRIPTION
#### Changes:

This pull request updates the Sentry Helm Chart documentation to clearly indicate that `existingSecretKeys.password` is required if `externalPostgresql.existingSecret` is used. This change enhances security and simplifies the configuration for connecting to an external PostgreSQL database.

#### Details:

- **values.yaml**:
  - Updated comments to clearly indicate that `existingSecretKeys.password` is required if `externalPostgresql.existingSecret` is used.
  - Removed outdated comments and improved documentation clarity.

#### Related Issues:
- Fixes #1433

Please review and merge if everything looks good.

Thanks!