### PR TITLE
chore(renovate): configure weekly patch and minor updates, monthly major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "extends": ["config:recommended", ":rebaseStalePrs", "docker:disable"],
   "enabled": true,
   "prConcurrentLimit": 30,
-  "enabledManagers": ["helmv3", "github-actions"]
+  "enabledManagers": ["helmv3", "github-actions"],
+  "schedule": [
+    "before 5am on Monday"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": ["patch", "minor"],
+      "schedule": [
+        "before 5am on Monday"
+      ]
+    },
+    {
+      "updateTypes": ["major"],
+      "schedule": [
+        "before 5am on the first day of the month"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Configure Renovate Bot Update Schedule

This PR updates the Renovate Bot configuration to set the following update schedules:

- **Patch and Minor Updates**: Scheduled to run before 5am on Monday.
- **Major Updates**: Scheduled to run before 5am on the first day of the month.

This change ensures that patch and minor updates are applied weekly, while major updates are applied monthly, providing a more controlled and predictable update process.
