### PR TITLE
feat: add cache, logging, and kafka configuration options to sentry relay

### DIFF
--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -17,7 +17,7 @@ config.yml: |-
 
     {{- if .Values.relay.cache.envelopeBufferSize }}
     cache:
-      envelope_buffer_size: {{ .Values.relay.cache.envelopeBufferSize }}
+      envelope_buffer_size: {{ int64 .Values.relay.cache.envelopeBufferSize | quote }}
     {{- end }}
 
     {{- if .Values.relay.logging }}
@@ -41,23 +41,23 @@ config.yml: |-
         value: {{ (include "sentry.kafka.bootstrap_servers_string" .) | quote }}
       {{- if .Values.relay.processing.kafkaConfig.messageMaxBytes }}
       - name: "message.max.bytes"
-        value: {{ .Values.relay.processing.kafkaConfig.messageMaxBytes }}
+        value: {{ int64 .Values.relay.processing.kafkaConfig.messageMaxBytes | quote }}
       {{- end }}
       {{- if .Values.relay.processing.kafkaConfig.messageTimeoutMs }}
       - name: "message.timeout.ms"
-        value: {{ .Values.relay.processing.kafkaConfig.messageTimeoutMs }}
+        value: {{ int64 .Values.relay.processing.kafkaConfig.messageTimeoutMs | quote }}
       {{- end }}
       {{- if .Values.relay.processing.kafkaConfig.requestTimeoutMs }}
       - name: "request.timeout.ms"
-        value: {{ .Values.relay.processing.kafkaConfig.requestTimeoutMs }}
+        value: {{ int64 .Values.relay.processing.kafkaConfig.requestTimeoutMs | quote }}
       {{- end }}
       {{- if .Values.relay.processing.kafkaConfig.deliveryTimeoutMs }}
       - name: "delivery.timeout.ms"
-        value: {{ .Values.relay.processing.kafkaConfig.deliveryTimeoutMs }}
+        value: {{ int64 .Values.relay.processing.kafkaConfig.deliveryTimeoutMs | quote }}
       {{- end }}
       {{- if .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs }}
       - name: "api.version.request.timeout.ms"
-        value: {{ .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs }}
+        value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
 
     {{- if $redisPass }}

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -15,6 +15,21 @@ config.yml: |-
     {{- end }}
     port: {{ template "relay.port" }}
 
+    {{- if .Values.relay.cache.envelopeBufferSize }}
+    cache:
+      envelope_buffer_size: {{ .Values.relay.cache.envelopeBufferSize }}
+    {{- end }}
+
+    {{- if .Values.relay.logging }}
+    logging:
+      {{- if .Values.relay.logging.level }}
+      level: {{ .Values.relay.logging.level }}
+      {{- end }}
+      {{- if .Values.relay.logging.format }}
+      format: {{ .Values.relay.logging.format }}
+      {{- end }}
+    {{- end }}
+
   processing:
     enabled: true
     {{- if .Values.geodata.path }}
@@ -24,8 +39,26 @@ config.yml: |-
     kafka_config:
       - name: "bootstrap.servers"
         value: {{ (include "sentry.kafka.bootstrap_servers_string" .) | quote }}
+      {{- if .Values.relay.processing.kafkaConfig.messageMaxBytes }}
       - name: "message.max.bytes"
-        value: 50000000  # 50MB or bust
+        value: {{ .Values.relay.processing.kafkaConfig.messageMaxBytes }}
+      {{- end }}
+      {{- if .Values.relay.processing.kafkaConfig.messageTimeoutMs }}
+      - name: "message.timeout.ms"
+        value: {{ .Values.relay.processing.kafkaConfig.messageTimeoutMs }}
+      {{- end }}
+      {{- if .Values.relay.processing.kafkaConfig.requestTimeoutMs }}
+      - name: "request.timeout.ms"
+        value: {{ .Values.relay.processing.kafkaConfig.requestTimeoutMs }}
+      {{- end }}
+      {{- if .Values.relay.processing.kafkaConfig.deliveryTimeoutMs }}
+      - name: "delivery.timeout.ms"
+        value: {{ .Values.relay.processing.kafkaConfig.deliveryTimeoutMs }}
+      {{- end }}
+      {{- if .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs }}
+      - name: "api.version.request.timeout.ms"
+        value: {{ .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs }}
+      {{- end }}
 
     {{- if $redisPass }}
     redis: "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -15,9 +15,11 @@ config.yml: |-
     {{- end }}
     port: {{ template "relay.port" }}
 
+    {{- if .Values.relay.cache }}
     {{- if .Values.relay.cache.envelopeBufferSize }}
     cache:
       envelope_buffer_size: {{ int64 .Values.relay.cache.envelopeBufferSize | quote }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.relay.logging }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -139,18 +139,18 @@ relay:
     # env: []
     # volumes: []
     # volumeMounts: []
-  cache:
-    envelopeBufferSize: 100000
-  logging:
-    level: info
-    format: json
+  # cache:
+  #   envelopeBufferSize: 100000
+  # logging:
+  #   level: info
+  #   format: json
   processing:
     kafkaConfig:
-      messageMaxBytes: 5000000
-      messageTimeoutMs: 100000
-      requestTimeoutMs: 900000
-      deliveryTimeoutMs: 100000
-      apiVersionRequestTimeoutMs: 300000
+      messageMaxBytes: 50000000
+    #  messageTimeoutMs: 1000000
+    #  requestTimeoutMs: 900000
+    #  deliveryTimeoutMs: 1000000
+    #  apiVersionRequestTimeoutMs: 300000
 
 geodata:
   path: ""

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -139,6 +139,18 @@ relay:
     # env: []
     # volumes: []
     # volumeMounts: []
+  cache:
+    envelopeBufferSize: 100000
+  logging:
+    level: info
+    format: json
+  processing:
+    kafkaConfig:
+      messageMaxBytes: 5000000
+      messageTimeoutMs: 100000
+      requestTimeoutMs: 900000
+      deliveryTimeoutMs: 100000
+      apiVersionRequestTimeoutMs: 300000
 
 geodata:
   path: ""


### PR DESCRIPTION
This pull request enhances the Sentry Relay Helm Chart by introducing new configuration options to better manage caching, logging, and Kafka settings. The changes include:

### New Features:

1. **Caching Configuration:**
   - Added support for configuring the `envelope_buffer_size` under the `relay.cache` section.

2. **Logging Configuration:**
   - Introduced options to set the logging level (`level`) and format (`format`) under the `relay.logging` section.

3. **Kafka Configuration:**
   - Expanded Kafka configuration options under `relay.processing.kafkaConfig` to include:
     - `message.max.bytes`
     - `message.timeout.ms`
     - `request.timeout.ms`
     - `delivery.timeout.ms`
     - `api.version.request.timeout.ms`

### Changes in `values.yaml`:

- Added default values for the new configuration options to ensure backward compatibility and provide sensible defaults.

Thank you for reviewing this pull request!