### PR TITLE
feat: add excludequeues option to sentry worker deployment

### DIFF
--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -74,6 +74,10 @@ spec:
         args:
           - "run"
           - "worker"
+          {{- if .Values.sentry.worker.excludeQueues }}
+          - "--exclude-queues"
+          - "{{ .Values.sentry.worker.excludeQueues }}"
+          {{- end }}
           {{- if .Values.sentry.worker.concurrency }}
           - "-c"
           - "{{ .Values.sentry.worker.concurrency }}"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -215,7 +215,7 @@ sentry:
     # podLabels: []
     # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
     # logFormat: "machine" # human|machine
-
+    # excludeQueues: ""
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:


### PR DESCRIPTION
This pull request introduces a new configuration option for the Sentry worker deployment: excludeQueues. This option allows users to specify queues that should be excluded from the worker's processing.

**Changes:
Deployment Template Update:**

Added a conditional check for the excludeQueues parameter in the deployment-sentry-worker.yaml template.

If the excludeQueues parameter is defined in values.yaml, it will be passed as an argument to the Sentry worker command.

**Values.yaml Update:**

Added a commented-out excludeQueues parameter in the values.yaml file to provide an example for users.

