### PR TITLE
docs(ingress): add additional nginx ingress annotations for buffer settings

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1700,6 +1700,9 @@ ingress:
   #   If you are using nginx ingress controller, please use at least those 2 annotations
   #   kubernetes.io/ingress.class: nginx
   #   nginx.ingress.kubernetes.io/use-regex: "true"
+  #   https://github.com/getsentry/self-hosted/issues/1927
+  #   nginx.ingress.kubernetes.io/proxy-buffers-number: "16"
+  #   nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
   #
   # hostname:
   # additionalHostNames: []


### PR DESCRIPTION
This pull request enhances the Ingress configuration in the values.yaml file by adding additional Nginx annotations for buffer settings. These annotations are recommended for handling large payloads and improving performance, as suggested in issue [#1927](https://github.com/getsentry/self-hosted/issues/1927).

Changes:

 - Added nginx.ingress.kubernetes.io/proxy-buffers-number: "16" and nginx.ingress.kubernetes.io/proxy-buffer-size: "32k" annotations to the values.yaml file.

These annotations are commented out by default, allowing users to easily enable them if needed.