### PR TITLE
fix: invalid parameter in deployments

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -93,7 +93,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.ingestConsumerAttachments.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
@@ -102,6 +101,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerAttachments.concurrency }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -93,7 +93,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.ingestConsumerEvents.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerEvents.maxBatchSize }}"
@@ -114,6 +113,7 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestConsumerEvents.maxBatchTimeMs }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.ingestConsumerEvents.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -93,7 +93,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.ingestConsumerTransactions.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchSize }}"
@@ -114,6 +113,7 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchTimeMs }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.ingestConsumerTransactions.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -88,7 +88,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.metricsConsumer.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.metricsConsumer.concurrency }}"
@@ -101,6 +100,7 @@ spec:
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.metricsConsumer.maxPollIntervalMs }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -88,7 +88,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.genericMetricsConsumer.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"
@@ -101,6 +100,7 @@ spec:
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.genericMetricsConsumer.maxPollIntervalMs }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -94,13 +94,13 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.postProcessForwardTransactions.processes }}
           - "--mode"
           - "multiprocess"
           - "--processes"
           - "{{ .Values.sentry.postProcessForwardTransactions.processes }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.postProcessForwardTransactions.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -88,7 +88,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}"
@@ -97,6 +96,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -88,7 +88,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}"
@@ -97,6 +96,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.concurrency }}"
           {{- end }}
+          - "--"
         {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
         livenessProbe:
           exec:


### PR DESCRIPTION
Fixing additional parameters for sentry deployments when every additional parameter will cause the 'invalid parameter' error:
`
spec:
    containers:
    - args:
      - run
      - consumer
      - ingest-generic-metrics
      - --consumer-group
      - generic-metrics-consumer
      - --healthcheck-file-path
      - /tmp/health.txt
      - --
      - --max-poll-interval-ms
      - "90000"
`