### PR TITLE
docs: add ingressClassName comment in ingress configuration

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1705,6 +1705,7 @@ ingress:
   # if you are using AWS ALB Ingress controller, switch this to 'aws-alb'
   # if you are using GKE Ingress controller, switch this to 'gke'
   regexPathStyle: nginx
+  # ingressClassName: nginx
   # If you are using AWS ALB Ingress controller, switch to true if you want activate the http to https redirection.
   alb:
     httpRedirect: false


### PR DESCRIPTION
This pull request introduces a comment for the ingressClassName option in the ingress configuration section of values.yaml. The ingressClassName is commented out because there are other ingress classes that may be used depending on the environment, such as haproxy or istio. This addition is intended to provide a placeholder for future implementation and to guide users who may want to specify an ingress class for their deployments.