### PR TITLE
chore: remove unused init parameters vroom from values.yaml

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -87,13 +87,6 @@ vroom:
   # topologySpreadConstraints: []
   volumes: []
   volumeMounts: []
-  # TODO: No files in the current directory use the parameter:
-  init:
-    resources: {}
-    # additionalArgs: []
-    # env: []
-    # volumes: []
-    # volumeMounts: []
 
 relay:
   enabled: true


### PR DESCRIPTION
This pull request removes unused init parameters from the values.yaml file. These parameters were previously defined but are no longer used in the current configuration. 

**Changes Made:**

Removed unused parameters such as resources, additionalArgs, env, volumes, and volumeMounts from the init section.