### PR TITLE
feat(symbolicator): implement deployment and statefulset selection

### DIFF
--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.symbolicator.enabled }}
-{{- if .Values.symbolicator.api.usedeployment }}
+{{- if not .Values.symbolicator.api.usedeployment }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "sentry.fullname" . }}-symbolicator-api
   labels:
@@ -10,6 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  serviceName: {{ template "sentry.fullname" . }}-symbolicator-api
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
@@ -126,8 +127,10 @@ spec:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-symbolicator
+      {{- if not .Values.symbolicator.api.persistence.enabled }}
       - name: symbolicator-data
         emptyDir: {}
+      {{- end }}
       {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
       - name: sentry-google-cloud-key
         secret:
@@ -139,5 +142,20 @@ spec:
       {{- if .Values.symbolicator.api.priorityClassName }}
       priorityClassName: "{{ .Values.symbolicator.api.priorityClassName }}"
       {{- end }}
+  {{- if .Values.symbolicator.api.persistence.enabled }}
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: symbolicator-data
+      spec:
+        accessModes: {{ .Values.symbolicator.api.persistence.accessModes }}
+        {{- if hasKey .Values.symbolicator.api.persistence "storageClass" }}
+        storageClassName: {{ .Values.symbolicator.api.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.symbolicator.api.persistence.size }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1545,7 +1545,7 @@ mail:
 symbolicator:
   enabled: false
   api:
-    usedeployment: true # Set true to use Deployment, false for StatefulSet
+    usedeployment: true  # Set true to use Deployment, false for StatefulSet
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
       accessModes: ["ReadWriteOnce"]

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1545,6 +1545,12 @@ mail:
 symbolicator:
   enabled: false
   api:
+    usedeployment: true # Set true to use Deployment, false for StatefulSet
+    persistence:
+      enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: standard
+      size: "10Gi"
     replicas: 1
     env: []
     probeInitialDelaySeconds: 10

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1549,7 +1549,7 @@ symbolicator:
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
       accessModes: ["ReadWriteOnce"]
-      storageClassName: standard
+      # storageClassName: standard
       size: "10Gi"
     replicas: 1
     env: []


### PR DESCRIPTION
@Mokto  This pull request introduces the ability to choose between Deployment and StatefulSet for the symbolicator service. Additionally, it allows configuring PersistentVolumeClaim or emptyDir for data persistence.

**Deployment and StatefulSet Selection:**
- Added a new value symbolicator.api.usedeployment in values.yaml to toggle between Deployment and StatefulSet.
- Updated deployment-symbolicator.yaml to include the usedeployment condition.
- Created statefulset-symbolicator.yaml for the StatefulSet configuration.

**Persistence Configuration:**
- Added symbolicator.api.persistence options in values.yaml to configure PersistentVolumeClaim or emptyDir.
- Updated both deployment-symbolicator.yaml and statefulset-symbolicator.yaml to use the new persistence configuration.

**Values.yaml Updates:**
- Added usedeployment and persistence options under symbolicator.api in values.yaml.