### PR TITLE
feat: add logging and worker settings to Sentry web deployment

### DIFF
--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -72,7 +72,22 @@ spec:
       - name: {{ .Chart.Name }}-web
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry", "run", "web"]
+        command: ["sentry"]
+        args:
+          - "run"
+          - "web"
+          {{- if .Values.sentry.web.workers }}
+          - "--workers"
+          - "{{ .Values.sentry.web.workers }}"
+          {{- end }}
+          {{- if .Values.sentry.web.logLevel }}
+          - "--loglevel"
+          - "{{ .Values.sentry.web.logLevel }}"
+          {{- end }}
+          {{- if .Values.sentry.web.logFormat }}
+          - "--logformat"
+          - "{{ .Values.sentry.web.logFormat }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "sentry.port" }}
         env:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -183,7 +183,8 @@ sentry:
     # customCA:
     #   secretName: custom-ca
     #   item: ca.crt
-
+    # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
+    # logFormat: "human" # human|machine
     autoscaling:
       enabled: false
       minReplicas: 2
@@ -193,6 +194,7 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
+    # workers: 3
 
   features:
     orgSubdomains: false


### PR DESCRIPTION
@Mokto  This PR introduces new configuration options for the Sentry web deployment, enabling users to customize the log level, log format, and the number of workers. These changes improve the flexibility and performance of the Sentry web deployment.

**Changes include:**
- Enabled customization of log level and log format for Sentry web.
- Added the ability to set the number of workers for better performance.
- Updated `values.yaml` to include new configuration options.

This enhancement allows users to better manage and monitor the Sentry web deployment.