### PR TITLE
Correct order of arguments of sentry consumers and add missed params in values.yaml

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -97,11 +97,11 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.ingestConsumerAttachments.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerAttachments.concurrency }}"
           {{- end }}
-          - "--"
         {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -97,10 +97,6 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerEvents.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerEvents.concurrency }}
-          - "--processes"
-          - "{{ .Values.sentry.ingestConsumerEvents.concurrency }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerEvents.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerEvents.logLevel }}"
@@ -114,6 +110,10 @@ spec:
           - "{{ .Values.sentry.ingestConsumerEvents.maxBatchTimeMs }}"
           {{- end }}
           - "--"
+          {{- if .Values.sentry.ingestConsumerEvents.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestConsumerEvents.concurrency }}"
+          {{- end }}
         {{- if .Values.sentry.ingestConsumerEvents.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -97,10 +97,6 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerTransactions.concurrency }}
-          - "--processes"
-          - "{{ .Values.sentry.ingestConsumerTransactions.concurrency }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerTransactions.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerTransactions.logLevel }}"
@@ -114,6 +110,10 @@ spec:
           - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchTimeMs }}"
           {{- end }}
           - "--"
+          {{- if .Values.sentry.ingestConsumerTransactions.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestConsumerTransactions.concurrency }}"
+          {{- end }}
         {{- if .Values.sentry.ingestConsumerTransactions.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -88,10 +88,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          {{- if .Values.sentry.metricsConsumer.concurrency }}
-          - "--processes"
-          - "{{ .Values.sentry.metricsConsumer.concurrency }}"
-          {{- end }}
           {{- if .Values.sentry.metricsConsumer.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.metricsConsumer.logLevel }}"
@@ -101,6 +97,10 @@ spec:
           - "{{ .Values.sentry.metricsConsumer.maxPollIntervalMs }}"
           {{- end }}
           - "--"
+          {{- if .Values.sentry.metricsConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.metricsConsumer.concurrency }}"
+          {{- end }}
         {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -88,10 +88,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          {{- if .Values.sentry.genericMetricsConsumer.concurrency }}
-          - "--processes"
-          - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"
-          {{- end }}
           {{- if .Values.sentry.genericMetricsConsumer.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.genericMetricsConsumer.logLevel }}"
@@ -101,6 +97,10 @@ spec:
           - "{{ .Values.sentry.genericMetricsConsumer.maxPollIntervalMs }}"
           {{- end }}
           - "--"
+          {{- if .Values.sentry.genericMetricsConsumer.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"
+          {{- end }}
         {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -94,13 +94,13 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.postProcessForwardTransactions.processes }}
           - "--mode"
           - "multiprocess"
           - "--processes"
           - "{{ .Values.sentry.postProcessForwardTransactions.processes }}"
           {{- end }}
-          - "--"
         {{- if .Values.sentry.postProcessForwardTransactions.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -92,11 +92,11 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}"
           {{- end }}
-          - "--"
         {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -92,11 +92,11 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.subscriptionConsumerMetrics.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.concurrency }}"
           {{- end }}
-          - "--"
         {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -770,6 +770,7 @@ sentry:
   subscriptionConsumerGenericMetrics:
     enabled: true
     replicas: 1
+    # concurrency: 1
     env: []
     resources: {}
     affinity: {}
@@ -790,6 +791,7 @@ sentry:
   subscriptionConsumerMetrics:
     enabled: true
     replicas: 1
+    # concurrency: 1
     env: []
     resources: {}
     affinity: {}


### PR DESCRIPTION
Fix #1463

Correct order of arguments for sentry 24.7.1:
```
docker run --rm --entrypoint sentry getsentry/sentry:24.7.1 run consumer --help | grep -A 1 -B 13 "\-\-processes"

  Launch a "new-style" consumer based on its "consumer name".

  Example:

      sentry run consumer ingest-profiles --consumer-group ingest-profiles

  runs the ingest-profiles consumer with the consumer group ingest-profiles.

  Consumers are defined in 'sentry.consumers'. Each consumer can take
  additional CLI options. Those can be passed after '--':

      sentry run consumer ingest-occurrences --consumer-group occurrence-
      consumer -- --processes 1

```