### PR TITLE
feat: add logLevel option to ingestConsumerAttachments

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -97,6 +97,10 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumerAttachments.logLevel }}
+          - "--log-level"
+          - "{{ .Values.sentry.ingestConsumerAttachments.logLevel }}"
+          {{- end }}
           - "--"
           {{- if .Values.sentry.ingestConsumerAttachments.concurrency }}
           - "--processes"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -313,7 +313,7 @@ sentry:
     # tolerations: []
     # podLabels: {}
     # maxBatchSize: ""
-    # logLevel: debug
+    # logLevel: info
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -313,7 +313,7 @@ sentry:
     # tolerations: []
     # podLabels: {}
     # maxBatchSize: ""
-
+    # logLevel: debug
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:


### PR DESCRIPTION
Add logLevel option to ingestConsumerAttachments

This PR introduces a new `logLevel` option for the `ingestConsumerAttachments` configuration in the Sentry Helm chart. This allows users to control the logging level of the ingest consumer attachments process.

### Changes:
- Added `logLevel` parameter to `values.yaml`.
- Updated `deployment-sentry-ingest-consumer-attachments.yaml` to include the new `logLevel` option in the command arguments.