### PR TITLE
feat: update kafka for fix jmx-exporter scrape path

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 17.11.3
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 29.3.2
+  version: 29.3.8
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
   version: 3.11.0
@@ -23,5 +23,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.1.14
-digest: sha256:ef2505fe1f2dee394bace5eea75412d6dd599d498020ed347dd432b811bc0846
-generated: "2024-09-16T08:59:33.439808838Z"
+digest: sha256:34956efd50bb882bf8e027dbb5eb5930ed6d6068a302d185923c694894da4567
+generated: "2024-09-24T19:17:23.327601889+06:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     condition: redis.enabled
   - name: kafka
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 29.3.2
+    version: 29.3.8
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts


### PR DESCRIPTION
@Mokto  Update kafka for fix jmx-exporter scrape path:

#### Related Pull Request:
- https://github.com/bitnami/charts/pull/27236
- https://github.com/bitnami/charts/pull/27362
- https://github.com/bitnami/charts/pull/27613
- https://github.com/bitnami/charts/pull/27610
- https://github.com/bitnami/charts/pull/27455

#### Related Issues:
- #1476
- #1473
- #1458
- https://github.com/bitnami/charts/issues/27546

Please review and merge if everything looks good.

Thanks!