### PR TITLE
feat: add topic partition counts in snuba config for correct provisioning

### DIFF
--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -9,6 +9,19 @@ settings.py: |
 
   DEBUG = env("DEBUG", "0").lower() in ("1", "true")
 
+{{- if .Values.kafka.enabled -}}
+  {{ if .Values.kafka.provisioning.enabled }}
+
+  # Set partition counts for provisioning topics from kafka chart.
+  TOPIC_PARTITION_COUNTS = {
+    {{- $numPartitions := .Values.kafka.provisioning.numPartitions -}}
+    {{- range .Values.kafka.provisioning.topics }}
+    {{ .name | quote }}: {{ default $numPartitions .partitions }},
+    {{- end }}
+  }
+  {{- end -}}
+{{- end }}
+
   # Clickhouse Options
   CLUSTERS = [
     {

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1925,11 +1925,16 @@ kafka:
     # Topic list is based on files below.
     # - https://github.com/getsentry/snuba/blob/master/snuba/utils/streams/topics.py
     # - https://github.com/getsentry/self-hosted/blob/master/install/create-kafka-topics.sh#L6
+    ## Default number of partitions for topics when unspecified
+    ##
+    # numPartitions: 1
     # Note that snuba component might fail if you set `hooks.snubaInit.kafka.enabled` to `false` and remove the topics from this default topic list.
     topics:
       - name: events
         config:
           "message.timestamp.type": LogAppendTime
+        ## Number of partitions for this topic
+        # partitions: 1
       - name: event-replacements
       - name: snuba-commit-log
         config:


### PR DESCRIPTION
If a different number of partitions is set when provisioning Kafka topics from kafka chart, it may cause issues with Snuba.

This issue is addressed in the following StackOverflow link: [KeyError: 1 - sentry snuba subscription consumer events](https://stackoverflow.com/questions/73294110/keyerror-1-sentry-snuba-subscription-consumer-events).

[Link](https://github.com/getsentry/snuba/blob/24.7.1/snuba/settings/__init__.py#L289) to snuba 24.7.1 - `TOPIC_PARTITION_COUNTS`
