### PR TITLE
docs: update configuration documentation to support more replicas

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2109,6 +2109,10 @@ postgresql:
   ## Default connection max age is 0 (unlimited connections)
   ## Set to a higher number to close connections after a period of time in seconds
   connMaxAge: 0
+  ## If you are increasing the number of replicas, you need to increase max_connections
+  # primary:
+  #   extendedConfiguration: |
+  #     max_connections=100
 
 ## This value is only used when postgresql.enabled is set to false
 ## Set either externalPostgresql.password or externalPostgresql.existingSecret to configure password


### PR DESCRIPTION
*Description:*
This PR updates the PostgreSQL configuration documentation to include a note about increasing the `max_connections` setting when scaling to support more replicas. The change is necessary to ensure that users are aware of the need to adjust this setting to handle the increased load and prevent connection issues.

*Changes:*
- Added a comment in the `values.yaml` file to inform users about the need to increase `max_connections` when scaling replicas.

*Related Issues:*
- Closes #1488

Please review and provide feedback. Thank you!