### PR TITLE
feat: reintroduce "Extend Redis functionality"

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -477,16 +477,16 @@ Common Snuba environment variables
   value: /etc/snuba/settings.py
 - name: DEFAULT_BROKERS
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
-{{- if .Values.redis.enabled }}
-{{- if .Values.redis.password }}
+{{- if and (.Values.redis.enabled) (.Values.redis.auth.enabled) }}
+{{- if .Values.redis.auth.password }}
 - name: REDIS_PASSWORD
-  value: {{ .Values.redis.password | quote }}
-{{- else if .Values.redis.existingSecret }}
+  value: {{ .Values.redis.auth.password | quote }}
+{{- else if .Values.redis.auth.existingSecret }}
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ default (include "sentry.redis.fullname" .) .Values.redis.existingSecret }}
-      key: {{ default "redis-password" .Values.redis.existingSecretKey }}
+      name: {{ default (include "sentry.redis.fullname" .) .Values.redis.auth.existingSecret }}
+      key: {{ default "redis-password" .Values.redis.auth.existingSecretPasswordKey }}
 {{- end }}
 {{- else if .Values.externalRedis.password }}
 - name: REDIS_PASSWORD

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -527,15 +527,14 @@ Common Snuba environment variables
   value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" . }}
 {{- end -}}
 
-{{- $redisHost := include "sentry.redis.host" . -}}
-{{- $redisPort := include "sentry.redis.port" . -}}
-{{- $redisDb     := include "sentry.redis.db" . -}}
-{{- $redisProto  := ternary "rediss" "redis" (eq (include "sentry.redis.ssl" .) "true")  -}}
-
 {{/*
 Common Sentry environment variables
 */}}
 {{- define "sentry.env" -}}
+{{- $redisHost := include "sentry.redis.host" . -}}
+{{- $redisPort := include "sentry.redis.port" . -}}
+{{- $redisDb     := include "sentry.redis.db" . -}}
+{{- $redisProto  := ternary "rediss" "redis" (eq (include "sentry.redis.ssl" .) "true")  -}}
 - name: SNUBA
   value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" . }}
 - name: VROOM

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -286,7 +286,7 @@ Set redis port
 Set redis password
 */}}
 {{- define "sentry.redis.password" -}}
-{{- if .Values.redis.enabled -}}
+{{- if and (.Values.redis.enabled) (.Values.redis.auth.enabled) -}}
 {{ .Values.redis.auth.password }}
 {{- else -}}
 {{ .Values.externalRedis.password }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -660,13 +660,6 @@ Common Sentry environment variables
 - name: BROKER_URL
   value: "{{ $redisProto }}://:$(HELM_CHARTS_SENTRY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
 {{- end }}
-{{- if and (.Values.externalRedis.brokerUrl) (.Values.externalRedis.brokerUrl.existingSecret) }}
-- name: BROKER_URL
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Values.externalRedis.brokerUrl.existingSecret }}
-      key: {{ default "broker_url" .Values.externalRedis.brokerUrl.existingSecretKey }}
-{{- end }}
 {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -617,11 +617,16 @@ Common Sentry environment variables
       key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKey }}
 {{- end }}
 {{- if .Values.redis.enabled }}
+{{- if .Values.redis.password }}
+- name: REDIS_PASSWORD
+  value: {{ .Values.redis.password | quote }}
+{{- else if .Values.redis.existingSecret }}
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ default (include "sentry.redis.fullname" .) .Values.redis.existingSecret }}
       key: {{ default "redis-password" .Values.redis.existingSecretKey }}
+{{- end }}
 {{- else if .Values.externalRedis.password }}
 - name: REDIS_PASSWORD
   value: {{ .Values.externalRedis.password | quote }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -501,7 +501,7 @@ Common Snuba environment variables
   value: "[::]:1218"
 {{- end }}
 - name: REDIS_PORT
-  value:  {{ default "6379" (include "sentry.redis.port" . |quote ) -}}
+  value:  {{ default "6379" (include "sentry.redis.port" . | quote ) -}}
 {{- end -}}
 
 {{- define "vroom.env" -}}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -477,7 +477,18 @@ Common Snuba environment variables
   value: /etc/snuba/settings.py
 - name: DEFAULT_BROKERS
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
-{{- if .Values.externalRedis.password }}
+{{- if .Values.redis.enabled }}
+{{- if .Values.redis.password }}
+- name: REDIS_PASSWORD
+  value: {{ .Values.redis.password | quote }}
+{{- else if .Values.redis.existingSecret }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (include "sentry.redis.fullname" .) .Values.redis.existingSecret }}
+      key: {{ default "redis-password" .Values.redis.existingSecretKey }}
+{{- end }}
+{{- else if .Values.externalRedis.password }}
 - name: REDIS_PASSWORD
   value: {{ .Values.externalRedis.password | quote }}
 {{- else if .Values.externalRedis.existingSecret }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -310,9 +310,9 @@ Set redis ssl
 */}}
 {{- define "sentry.redis.ssl" -}}
 {{- if .Values.redis.enabled -}}
-{{ default "false" .Values.redis.ssl }}
+{{ default false .Values.redis.ssl }}
 {{- else -}}
-{{ default "false" .Values.externalRedis.ssl }}
+{{ default false .Values.externalRedis.ssl }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -291,7 +291,6 @@ Set redis password
 {{- else if .Values.externalRedis.password -}}
 {{ .Values.externalRedis.password }}
 {{- else }}
-""
 {{- end -}}
 {{- end -}}
 

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -287,7 +287,7 @@ Set redis password
 */}}
 {{- define "sentry.redis.password" -}}
 {{- if .Values.redis.enabled -}}
-{{ .Values.redis.password }}
+{{ .Values.redis.auth.password }}
 {{- else -}}
 {{ .Values.externalRedis.password }}
 {{- end -}}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -288,8 +288,10 @@ Set redis password
 {{- define "sentry.redis.password" -}}
 {{- if and (.Values.redis.enabled) (.Values.redis.auth.enabled) -}}
 {{ .Values.redis.auth.password }}
-{{- else -}}
+{{- else if .Values.externalRedis.password -}}
 {{ .Values.externalRedis.password }}
+{{- else }}
+""
 {{- end -}}
 {{- end -}}
 

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -64,7 +64,7 @@ config.yml: |-
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
 
-    {{- if $redisPass }}
+    {{- if and ($redisPass) (not .Values.externalRedis.existingSecret) }}
     redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- else }}
     redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -64,9 +64,11 @@ config.yml: |-
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
 
-    {{- if and ($redisPass) (not .Values.externalRedis.existingSecret) (not .Values.redis.auth.existingSecret) }}
+    {{- if $redisPass }}
+    {{- if and (not .Values.externalRedis.existingSecret) (not .Values.redis.auth.existingSecret)}}
     redis: "{{ $redisProto }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
-    {{- else if not ($redisPass) }}
+    {{- end }}
+    {{- else }}
     redis: "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- end }}
     topics:

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -64,9 +64,9 @@ config.yml: |-
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
 
-    {{- if and ($redisPass) (not .Values.externalRedis.existingSecret) }}
+    {{- if and (not (eq $redisPass "")) (not .Values.externalRedis.existingSecret) }}
     redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
-    {{- else if not ($redisPass) }}
+    {{- else if eq $redisPass "" }}
     redis: "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- end }}
     topics:

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -64,9 +64,9 @@ config.yml: |-
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
 
-    {{- if and (not (eq $redisPass "")) (not .Values.externalRedis.existingSecret) }}
-    redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
-    {{- else if eq $redisPass "" }}
+    {{- if and ($redisPass) (not .Values.externalRedis.existingSecret) (not .Values.redis.auth.existingSecret) }}
+    redis: "{{ $redisProto }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
+    {{- else if not ($redisPass) }}
     redis: "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- end }}
     topics:

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -2,6 +2,8 @@
 {{- $redisHost := include "sentry.redis.host" . -}}
 {{- $redisPort := include "sentry.redis.port" . -}}
 {{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisDb     := include "sentry.redis.db" . -}}
+{{- $redisProto  := ternary "rediss" "redis" (eq (include "sentry.redis.ssl" .) "true")  -}}
 config.yml: |-
   relay:
     {{- if .Values.relay.mode }}
@@ -63,9 +65,9 @@ config.yml: |-
       {{- end }}
 
     {{- if $redisPass }}
-    redis: "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
+    redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- else }}
-    redis: "redis://{{ $redisHost }}:{{ $redisPort }}"
+    redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- end }}
     topics:
       metrics_sessions: ingest-metrics

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -66,8 +66,8 @@ config.yml: |-
 
     {{- if and ($redisPass) (not .Values.externalRedis.existingSecret) }}
     redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
-    {{- else }}
-    redis: "{{ $redisProto }}://{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
+    {{- else if not ($redisPass) }}
+    redis: "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
     {{- end }}
     topics:
       metrics_sessions: ingest-metrics

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.relay.enabled }}
+{{- $redisHost := include "sentry.redis.host" . -}}
+{{- $redisPort := include "sentry.redis.port" . -}}
+{{- $redisDb     := include "sentry.redis.db" . -}}
+{{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisProto  := ternary "rediss" "redis" (eq (include "sentry.redis.ssl" .) "true")  -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,6 +92,15 @@ spec:
           env:
             - name: RELAY_PORT
               value: '{{ template "relay.port" }}'
+          {{- if and (not $redisPass) (.Values.externalRedis.existingSecret) }}
+            - name: HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalRedis.existingSecret }}
+                  key: {{ default "redis-password" .Values.externalRedis.existingSecretKey }}
+            - name: RELAY_REDIS_URL
+              value: {{ $redisProto }}://$(HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}
+          {{- end }}
 {{- if .Values.relay.init.env }}
 {{ toYaml .Values.relay.init.env | indent 12 }}
 {{- end }}
@@ -119,6 +134,15 @@ spec:
         env:
         - name: RELAY_PORT
           value: '{{ template "relay.port" }}'
+        {{- if and (not $redisPass) (.Values.externalRedis.existingSecret) }}
+        - name: HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalRedis.existingSecret }}
+              key: {{ default "redis-password" .Values.externalRedis.existingSecretKey }}
+        - name: RELAY_REDIS_URL
+          value: {{ $redisProto }}://$(HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}
+        {{- end }}
 {{- if .Values.relay.env }}
 {{ toYaml .Values.relay.env | indent 8 }}
 {{- end }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -199,7 +199,7 @@ sentry.conf.py: |-
   BROKER_URL = os.environ.get("BROKER_URL", "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ template "sentry.rabbitmq.host" . }}:5672/{{ .Values.rabbitmq.vhost }}")
   {{- else if $redisPass }}
   BROKER_URL = os.environ.get("BROKER_URL", "{{ $redisProto }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}")
-  {{- else }}
+  {{- else if and (not .Values.externalRedis.existingSecret) (not .Values.redis.auth.existingSecret)}}
   BROKER_URL = os.environ.get("BROKER_URL", "{{ $redisProto }}://{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}")
   {{- end }}
 

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -63,8 +63,10 @@ settings.py: |
   # Redis Options
   REDIS_HOST = {{ include "sentry.redis.host" . | quote }}
   REDIS_PORT = {{ include "sentry.redis.port" . }}
-  {{- if or (not (eq $redisPass "")) (.Values.externalRedis.existingSecret) }}
+  {{- if or (not ($redisPass)) (.Values.externalRedis.existingSecret) (.Values.redis.auth.existingSecret) }}
   REDIS_PASSWORD = env("REDIS_PASSWORD", "")
+  {{- else if $redisPass }}
+  REDIS_PASSWORD = {{ $redisPass | quote }}
   {{- end }}
 
   {{- if .Values.redis.enabled }}

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -75,8 +75,8 @@ settings.py: |
   REDIS_DB = int(env("REDIS_DB", {{ default 1 .Values.externalRedis.db }}))
   {{- end }}
 
-  {{- if $redisSsl  }}
-  REDIS_SSL = {{ $redisSsl | quote }}
+  {{- if eq $redisSsl "true" }}
+  REDIS_SSL = True
   {{- end }}
 
 {{- if .Values.metrics.enabled }}

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -67,7 +67,7 @@ settings.py: |
   {{- if or (not (eq $redisPass "")) (.Values.externalRedis.existingSecret) }}
   REDIS_PASSWORD = env("REDIS_PASSWORD")
   {{- end }}
-  {{- if $redisDb }}
+  {{- if not (eq $redisDb "") }}
   REDIS_DB = {{ $redisDb }}
   {{- else }}
   REDIS_DB = int(env("REDIS_DB", 1))

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -64,7 +64,7 @@ settings.py: |
   # Redis Options
   REDIS_HOST = {{ include "sentry.redis.host" . | quote }}
   REDIS_PORT = {{ include "sentry.redis.port" . }}
-  {{- if or ($redisPass) (.Values.externalRedis.existingSecret) }}
+  {{- if or (not (eq $redisPass "")) (.Values.externalRedis.existingSecret) }}
   REDIS_PASSWORD = env("REDIS_PASSWORD")
   {{- end }}
   {{- if $redisDb }}

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -1,6 +1,5 @@
 {{- define "sentry.snuba.config" -}}
 {{- $redisPass := include "sentry.redis.password" . -}}
-{{- $redisDb   := include "sentry.redis.db" . -}}
 {{- $redisSsl  := include "sentry.redis.ssl" . -}}
 settings.py: |
   import os
@@ -65,13 +64,15 @@ settings.py: |
   REDIS_HOST = {{ include "sentry.redis.host" . | quote }}
   REDIS_PORT = {{ include "sentry.redis.port" . }}
   {{- if or (not (eq $redisPass "")) (.Values.externalRedis.existingSecret) }}
-  REDIS_PASSWORD = env("REDIS_PASSWORD")
+  REDIS_PASSWORD = env("REDIS_PASSWORD", "")
   {{- end }}
-  {{- if not (eq $redisDb "") }}
-  REDIS_DB = {{ $redisDb }}
+
+  {{- if .Values.redis.enabled }}
+  REDIS_DB = int(env("REDIS_DB", {{ default 1 .Values.redis.db }}))
   {{- else }}
-  REDIS_DB = int(env("REDIS_DB", 1))
+  REDIS_DB = int(env("REDIS_DB", {{ default 1 .Values.externalRedis.db }}))
   {{- end }}
+
   {{- if $redisSsl  }}
   REDIS_SSL = {{ $redisSsl | quote }}
   {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2091,6 +2091,18 @@ externalRedis:
   port: 6379
   ## Just omit the password field if your redis cluster doesn't use password
   # password: redis
+  # existingSecret: secret-name
+  ## set existingSecretKey if key name inside existingSecret is different from redis-password'
+  # existingSecretKey: secret-key-name
+  ## Integer database number to use for redis (This is an integer)
+  # db: 0
+  ## Use ssl for the connection to Redis (True/False)
+  # ssl: false
+  ## Use brokerUrl to configure a secret for the broker_url value
+  ## This allows to set a secure password for the broker.
+  #brokerUrl:
+  # existingSecret: secret-name
+  # existingSecretKey: sentry-key-name
 
 postgresql:
   enabled: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2100,8 +2100,6 @@ externalRedis:
   # db: 0
   ## Use ssl for the connection to Redis (True/False)
   # ssl: false
-  ## Use brokerUrl to configure a secret for the broker_url value
-  ## This allows to set a secure password for the broker.
 
 postgresql:
   enabled: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2100,9 +2100,9 @@ externalRedis:
   # ssl: false
   ## Use brokerUrl to configure a secret for the broker_url value
   ## This allows to set a secure password for the broker.
-  #brokerUrl:
-  # existingSecret: secret-name
-  # existingSecretKey: sentry-key-name
+  # brokerUrl:
+  #   existingSecret: secret-name
+  #   existingSecretKey: sentry-key-name
 
 postgresql:
   enabled: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2070,10 +2070,12 @@ redis:
   auth:
     enabled: false
     sentinel: false
+    ## Just omit the password field if your redis cluster doesn't use password
+    # password: redis
+    # existingSecret: secret-name
+    ## set existingSecretPasswordKey if key name inside existingSecret is different from redis-password'
+    # existingSecretPasswordKey: secret-key-name
   nameOverride: sentry-redis
-  usePassword: false
-  ## Just omit the password field if your redis cluster doesn't use password
-  # password: redis
   master:
     persistence:
       enabled: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2102,9 +2102,6 @@ externalRedis:
   # ssl: false
   ## Use brokerUrl to configure a secret for the broker_url value
   ## This allows to set a secure password for the broker.
-  # brokerUrl:
-  #   existingSecret: secret-name
-  #   existingSecretKey: sentry-key-name
 
 postgresql:
   enabled: true


### PR DESCRIPTION
This PR reintroduces https://github.com/sentry-kubernetes/charts/pull/914 with conflicts resolved.

Core Diff:
- Addressed https://github.com/sentry-kubernetes/charts/pull/914#discussion_r1391345725 with a workaround that declares an additional environment variable that references the externalRedis secret then use https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/ to plug Redis URL in. The dependency resolution is handled by Kubernetes so it is secure.
- Rename the password reference in values.yml for Redis subchart to `redis.auth.password` etc., this is because subchart relies on that path to create authentication so setting `redis.password` only will only *break* the integrated Redis connection (because Redis subchart will believe there is no password defined).
- Remove the need to specify brokerUrl secrets, it'll compute based on the existing secrets specified in the values
- Fixed misc issues that were failing the E2E