### PR TITLE
docs: document resourcesPreset usage for kafka controller

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2040,7 +2040,8 @@ kafka:
     enabled: true
   controller:
     replicaCount: 3
-
+    ## if the load on the kafka controller increases, resourcesPreset must be increased
+    # resourcesPreset: small # small, medium, large, xlarge, 2xlarge
   ## Use this to enable an extra service account
   # serviceAccount:
   #   create: false


### PR DESCRIPTION
This pull request adds documentation for the `resourcesPreset` option in the Kafka controller configuration. The new documentation explains how to use the `resourcesPreset` option to manage resource allocation based on the load on the Kafka controller.

### Changes:
- Added a comment in the `values.yaml` file explaining the purpose and usage of the `resourcesPreset` option.
- Updated the relevant sections in the documentation to include details about the `resourcesPreset` option.

### Benefits:
- Provides clear guidance on how to adjust resource allocation for the Kafka controller based on its load.
- Improves the overall clarity and usability of the Kafka controller configuration.

### Related Issues:
- Fixes #1491

Please review the documentation changes and provide feedback.
