### PR TITLE
Configuring kafka to use zookeeper uses only brokers

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -113,28 +113,30 @@ spec:
             while [ $KAFKA_STATUS -eq 0 ]; do
               KAFKA_STATUS=1
               {{- if .Values.kafka.enabled }}
-              KAFKA_REPLICAS={{ .Values.kafka.controller.replicaCount | default 3 }}
+
               {{- if .Values.kafka.zookeeper.enabled }}
-              echo "Kafka Zookeeper is enabled, checking if Zookeeper is up"
-              ZOOKEEPER_STATUS=0
-              while [ $ZOOKEEPER_STATUS -eq 0 ]; do
-                ZOOKEEPER_STATUS=1
+              KAFKA_REPLICAS={{ .Values.kafka.broker.replicaCount | default 3 }}
+              echo "Kafka Zookeeper is enabled, checking if kafka brokers are up"
+              KZ_STATUS=0
+              while [ $KZ_STATUS -eq 0 ]; do
+                KZ_STATUS=1
                 i=0; while [ $i -lt $KAFKA_REPLICAS ]; do
-                  ZOOKEEPER_HOST={{ $kafkaHost }}-$i.{{ $kafkaHost }}-headless
-                  if ! nc -z "$ZOOKEEPER_HOST" {{ .Values.kafka.zookeeper.port }}; then
-                    ZOOKEEPER_STATUS=0
-                    echo "$ZOOKEEPER_HOST is not available yet"
+                  KZ_HOST={{ $kafkaHost }}-broker-$i.{{ $kafkaHost }}-broker-headless
+                  if ! nc -z "$KZ_HOST" {{ $kafkaPort }}; then
+                    KZ_STATUS=0
+                    echo "$KZ_HOST is not available yet"
                   fi
                   i=$((i+1))
                 done
-                if [ "$ZOOKEEPER_STATUS" -eq 0 ]; then
-                  echo "Zookeeper not ready. Sleeping for 10s before trying again"
+                if [ "$KZ_STATUS" -eq 0 ]; then
+                  echo "Kafka not ready. Sleeping for 10s before trying again"
                   sleep 10;
                 fi
               done
               echo "Zookeeper is up"
               {{- end }}
               {{- if .Values.kafka.kraft.enabled }}
+              KAFKA_REPLICAS={{ .Values.kafka.controller.replicaCount | default 3 }}
               echo "Kafka Kraft is enabled, checking if Kraft controllers are up"
               KRAFT_STATUS=0
               while [ $KRAFT_STATUS -eq 0 ]; do


### PR DESCRIPTION
Hello,

When I use Kafka with zookeeper (disabling kraft), the `db-check` job fails because expected service name does not exists.

values.yaml :
```yaml
kafka:
  networkPolicy:
    enabled: false
  kraft:
    enabled: false
  zookeeper:
    enabled: true
    port: 2181
  controller:
    replicaCount: 0
  broker:
    replicaCount: 3
```