### PR TITLE
fix: reintroduced "Extend Redis functionality" broke S3 filestore

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -619,7 +619,6 @@ Common Sentry environment variables
     secretKeyRef:
       name: {{ .Values.filestore.s3.existingSecret }}
       key: {{ default "s3-secret-access-key" .Values.filestore.s3.secretAccessKeyRef }}
-      key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKey }}
 {{- end }}
 {{- if .Values.redis.enabled }}
 {{- if .Values.redis.password }}


### PR DESCRIPTION
Hello,

From commit 0b7a7b4c that reintroduced the external redis feature, the `S3_SECRET_ACCESS_KEY` env variable is overriden by postgresql password.