### PR TITLE
docs: document replication factor and persistence size for future enhancements

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1922,7 +1922,7 @@ kafka:
   enabled: true
   provisioning:
     ## Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers.
-    # replicationFactor: 3
+    # replicationFactor: 1
     enabled: true
     # Topic list is based on files below.
     # - https://github.com/getsentry/snuba/blob/master/snuba/utils/streams/topics.py

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1921,6 +1921,8 @@ zookeeper:
 kafka:
   enabled: true
   provisioning:
+    ## Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers.
+    # replicationFactor: 3
     enabled: true
     # Topic list is based on files below.
     # - https://github.com/getsentry/snuba/blob/master/snuba/utils/streams/topics.py
@@ -2047,6 +2049,9 @@ kafka:
     replicaCount: 3
     ## if the load on the kafka controller increases, resourcesPreset must be increased
     # resourcesPreset: small # small, medium, large, xlarge, 2xlarge
+    ## if the load on the kafka controller increases, persistence.size must be increased
+    # persistence:
+    #   size: 8Gi
   ## Use this to enable an extra service account
   # serviceAccount:
   #   create: false


### PR DESCRIPTION
This pull request adds comments to the `values.yaml` file for the Kafka configuration, specifically focusing on the `replicationFactor` and `persistence.size` settings. These comments are intended to guide future enhancements and provide context for potential adjustments to improve data reliability and fault tolerance in Kafka deployments.

### Changes:
- Added a comment explaining the purpose of increasing the `replicationFactor` to enhance data reliability during Kafka pod failures.
- Added a comment suggesting an increase in `persistence.size` if the load on the Kafka controller increases.

### Comments:
- **replicationFactor**: "Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers."
- **persistence.size**: "If the load on the Kafka controller increases, persistence.size must be increased."

### Related Issues:
- #1458
- #1473

These comments will help maintainers and developers understand the rationale behind future changes and ensure that Kafka configurations remain robust and reliable.