### PR TITLE
feat: set ingressClassName to nginx as the most popular ingress controller

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1753,7 +1753,7 @@ ingress:
   # if you are using AWS ALB Ingress controller, switch this to 'aws-alb'
   # if you are using GKE Ingress controller, switch this to 'gke'
   regexPathStyle: nginx
-  ingressClassName: nginx # traefik, istio, haproxy and other
+  ingressClassName: nginx  # traefik, istio, haproxy and other
   # If you are using AWS ALB Ingress controller, switch to true if you want activate the http to https redirection.
   alb:
     httpRedirect: false

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1753,7 +1753,7 @@ ingress:
   # if you are using AWS ALB Ingress controller, switch this to 'aws-alb'
   # if you are using GKE Ingress controller, switch this to 'gke'
   regexPathStyle: nginx
-  # ingressClassName: nginx
+  ingressClassName: nginx # traefik, istio, haproxy and other
   # If you are using AWS ALB Ingress controller, switch to true if you want activate the http to https redirection.
   alb:
     httpRedirect: false


### PR DESCRIPTION
#### Description
This pull request introduces the `ingressClassName` parameter in the `values.yaml` file to support multiple ingress controllers. By default, `ingressClassName` is set to `nginx` as it is the most widely used ingress controller. The comment also provides guidance on how to switch to other supported controllers like `traefik`, `istio`, and `haproxy`.

#### Changes
- **Added `ingressClassName` Parameter**: The `ingressClassName` parameter is added to the `ingress` section of the `values.yaml` file.
- **Default to `nginx`**: The default value for `ingressClassName` is set to `nginx` due to its widespread usage and compatibility.
- **Support for Other Controllers**: The comment provides instructions on how to switch to other ingress controllers such as `traefik`, `istio`, and `haproxy`.

---
Feel free to review and provide feedback. Thank you!

