### PR TITLE
feat: add existingSecretEnv support for web and worker deployments

### DIFF
--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -99,6 +99,11 @@ spec:
 {{- if .Values.sentry.web.env }}
 {{ toYaml .Values.sentry.web.env | indent 8 }}
 {{- end }}
+{{- if .Values.sentry.web.existingSecretEnv }}
+        envFrom:
+          - secretRef:
+            name: "{{.Values.sentry.web.existingSecretEnv}}"
+{{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -97,6 +97,11 @@ spec:
 {{- if .Values.sentry.worker.env }}
 {{ toYaml .Values.sentry.worker.env | indent 8 }}
 {{- end }}
+{{- if .Values.sentry.worker.existingSecretEnv }}
+        envFrom:
+        - secretRef:
+          name: "{{.Values.sentry.worker.existingSecretEnv}}"
+{{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -167,6 +167,7 @@ sentry:
     strategyType: RollingUpdate
     replicas: 1
     env: []
+    existingSecretEnv: []
     probeFailureThreshold: 5
     probeInitialDelaySeconds: 10
     probePeriodSeconds: 10
@@ -224,6 +225,7 @@ sentry:
     replicas: 1
     # concurrency: 4
     env: []
+    existingSecretEnv: []
     resources: {}
     #  requests:
     #    cpu: 1000m


### PR DESCRIPTION
#### Description
This pull request introduces the `existingSecretEnv` parameter to support referencing existing Kubernetes secrets for environment variables in the `sentry.web` and `sentry.worker` deployments. This enhancement improves security by allowing environment variables to be managed securely using existing secrets.

#### Changes
- **Added `existingSecretEnv` Parameter**: The `existingSecretEnv` parameter is added to the `sentry.web` and `sentry.worker` sections in the `values.yaml` file.
- **Configured `envFrom` with `secretRef`**: The `deployment-sentry-web.yaml` and `deployment-sentry-worker.yaml` files are updated to use `envFrom` with `secretRef` to reference the existing secrets.

#### Rationale
- **Enhanced Security**: Using existing Kubernetes secrets for environment variables improves security by keeping sensitive information out of the configuration files.
- **Flexibility**: This change allows users to manage environment variables more flexibly and securely, leveraging existing secrets in their Kubernetes clusters.

Related Pull Requests:
- #1062

---
Feel free to review and provide feedback. Thank you!

