### PR TITLE
feat: define toleration globally

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -51,9 +51,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.hooks.dbCheck.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.hooks.dbCheck.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.hooks.dbCheck.tolerations) }}
       tolerations:
-{{ toYaml .Values.hooks.dbCheck.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.hooks.dbCheck.image.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -47,9 +47,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.hooks.dbInit.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.hooks.dbInit.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.hooks.dbInit.tolerations) }}
       tolerations:
-{{ toYaml .Values.hooks.dbInit.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.images.sentry.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.hooks.snubaInit.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.hooks.snubaInit.tolerations) }}
       tolerations:
-{{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.images.snuba.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.hooks.snubaInit.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.hooks.snubaInit.tolerations) }}
       tolerations:
-{{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.images.snuba.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -43,9 +43,9 @@ spec:
 {{ toYaml .Values.hooks.dbInit.nodeSelector | indent 8 }}
       {{- end }}
       restartPolicy: Never
-      {{- if .Values.hooks.dbInit.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.hooks.dbInit.tolerations) }}
       tolerations:
-{{ toYaml .Values.hooks.dbInit.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.images.sentry.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -57,9 +57,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.relay.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.relay.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.relay.tolerations) }}
       tolerations:
-{{ toYaml .Values.relay.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.relay.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -43,9 +43,9 @@ spec:
           nodeSelector:
 {{ toYaml .Values.sentry.cleanup.nodeSelector | indent 12 }}
             {{- end }}
-            {{- if .Values.sentry.cleanup.tolerations }}
+            {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.cleanup.tolerations) }}
           tolerations:
-{{ toYaml .Values.sentry.cleanup.tolerations | indent 12 }}
+{{ toYaml $tolerations | indent 12 }}
             {{- end }}
             {{- if .Values.dnsPolicy }}
           dnsPolicy: {{ .Values.dnsPolicy | quote }}

--- a/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
+++ b/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
@@ -41,9 +41,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.cron.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.cron.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.cron.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.cron.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.cron.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestConsumerAttachments.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestConsumerAttachments.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestConsumerAttachments.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestConsumerAttachments.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerAttachments.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestConsumerEvents.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestConsumerEvents.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestConsumerEvents.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestConsumerEvents.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestMonitors.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestMonitors.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestMonitors.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestMonitors.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestMonitors.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestOccurrences.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestOccurrences.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestOccurrences.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestOccurrences.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestOccurrences.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestProfiles.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestProfiles.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestProfiles.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestProfiles.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestProfiles.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestReplayRecordings.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestReplayRecordings.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestReplayRecordings.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestReplayRecordings.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestReplayRecordings.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.ingestConsumerTransactions.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.ingestConsumerTransactions.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.ingestConsumerTransactions.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.ingestConsumerTransactions.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -52,9 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.billingMetricsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.billingMetricsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.billingMetricsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.billingMetricsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.billingMetricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -41,9 +41,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.metrics.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.metrics.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.metrics.tolerations) }}
       tolerations:
-{{ toYaml .Values.metrics.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.metrics.schedulerName }}
       schedulerName: "{{ .Values.metrics.schedulerName }}"

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.metricsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.metricsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.metricsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.metricsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.metricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.genericMetricsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.genericMetricsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.genericMetricsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.genericMetricsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.genericMetricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.postProcessForwardErrors.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.postProcessForwardErrors.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.postProcessForwardErrors.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.postProcessForwardErrors.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardErrors.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.postProcessForwardIssuePlatform.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.postProcessForwardIssuePlatform.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.postProcessForwardIssuePlatform.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.postProcessForwardIssuePlatform.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardIssuePlatform.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.postProcessForwardTransactions.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.postProcessForwardTransactions.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.postProcessForwardTransactions.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.postProcessForwardTransactions.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerEvents.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.subscriptionConsumerEvents.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.subscriptionConsumerEvents.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerGenericMetrics.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.subscriptionConsumerGenericMetrics.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerGenericMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerMetrics.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerMetrics.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.subscriptionConsumerMetrics.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.subscriptionConsumerMetrics.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -50,9 +50,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerTransactions.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.subscriptionConsumerTransactions.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.subscriptionConsumerTransactions.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.vroom.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.vroom.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.vroom.tolerations) }}
       tolerations:
-{{ toYaml .Values.vroom.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.vroom.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -45,9 +45,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.web.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.web.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.web.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.web.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.web.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -43,9 +43,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.workerEvents.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.workerEvents.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.workerEvents.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.workerEvents.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.workerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -43,9 +43,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.workerTransactions.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.workerTransactions.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.workerTransactions.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.workerTransactions.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.workerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -43,9 +43,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.sentry.worker.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.worker.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.sentry.worker.tolerations) }}
       tolerations:
-{{ toYaml .Values.sentry.worker.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.worker.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -42,9 +42,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.api.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.api.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.api.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.api.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.api.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.consumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.consumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.consumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.consumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.consumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.genericMetricsCountersConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.genericMetricsCountersConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.genericMetricsCountersConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.genericMetricsCountersConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsCountersConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.genericMetricsDistributionConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.genericMetricsDistributionConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.genericMetricsDistributionConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.genericMetricsDistributionConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsDistributionConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.genericMetricsSetsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.genericMetricsSetsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.genericMetricsSetsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.genericMetricsSetsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsSetsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.groupAttributesConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.groupAttributesConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.groupAttributesConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.groupAttributesConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.groupAttributesConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.issueOccurrenceConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.issueOccurrenceConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.issueOccurrenceConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.issueOccurrenceConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.issueOccurrenceConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.metricsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.metricsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.metricsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.metricsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.metricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.outcomesBillingConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.outcomesBillingConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.outcomesBillingConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.outcomesBillingConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.outcomesBillingConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.outcomesConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.outcomesConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.outcomesConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.outcomesConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.outcomesConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.profilingFunctionsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.profilingFunctionsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.profilingFunctionsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.profilingFunctionsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.profilingFunctionsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.profilingProfilesConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.profilingProfilesConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.profilingProfilesConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.profilingProfilesConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.profilingProfilesConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.replacer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.replacer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.replacer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.replacer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.replacer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.replaysConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.replaysConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.replaysConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.replaysConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.replaysConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.spansConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.spansConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.spansConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.spansConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.spansConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.subscriptionConsumerEvents.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.subscriptionConsumerEvents.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.subscriptionConsumerEvents.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.subscriptionConsumerMetrics.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.subscriptionConsumerMetrics.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.subscriptionConsumerMetrics.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.subscriptionConsumerMetrics.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.subscriptionConsumerTransactions.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.subscriptionConsumerTransactions.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.subscriptionConsumerTransactions.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -49,9 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.snuba.transactionsConsumer.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.snuba.transactionsConsumer.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.snuba.transactionsConsumer.tolerations) }}
       tolerations:
-{{ toYaml .Values.snuba.transactionsConsumer.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.transactionsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -42,9 +42,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.symbolicator.api.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.symbolicator.api.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.symbolicator.api.tolerations) }}
       tolerations:
-{{ toYaml .Values.symbolicator.api.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.symbolicator.api.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -43,9 +43,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.symbolicator.api.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.symbolicator.api.tolerations }}
+      {{- if $tolerations := (default .Values.global.tolerations .Values.symbolicator.api.tolerations) }}
       tolerations:
-{{ toYaml .Values.symbolicator.api.tolerations | indent 8 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.symbolicator.api.topologySpreadConstraints }}
       topologySpreadConstraints:


### PR DESCRIPTION
#### Changes
This pull request adds possibility set toleration globally. The main reason for this changes is isolate sentry installation to dedicated node group

#### Details:
- Deployment Files:
   - Checking global.toleration if related toleration is not set
- Jobs Files:
  - Checking global.toleration if related toleration is not set

Please review and merge if everything looks good.

Thanks!