### PR TITLE
Allow customizing Kafka configuration for Relay + Fix sentry-user-create job not creating the user

### DIFF
--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -71,11 +71,12 @@ spec:
       - name: user-create-job
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["/bin/bash", "-c"]
-        # Create user but do not exit 1 when user already exists (exit code 3 from createuser command)
-        # https://docs.sentry.io/server/cli/createuser/
-        args:
-          - >
+        command:
+          - "/bin/bash"
+          - "-c"
+          # Create user but do not exit 1 when user already exists (exit code 3 from createuser command)
+          # https://docs.sentry.io/server/cli/createuser/
+          - |
             sentry createuser \
               --no-input \
               --superuser \

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -63,6 +63,9 @@ config.yml: |-
       - name: "api.version.request.timeout.ms"
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
+  {{- if .Values.relay.processing.additionalKafkaConfig }}
+  {{ toYaml .Values.relay.processing.additionalKafkaConfig | nindent 6 }}
+  {{- end }}
 
     {{- if $redisPass }}
     {{- if and (not .Values.externalRedis.existingSecret) (not .Values.redis.auth.existingSecret)}}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -151,6 +151,10 @@ relay:
     #  deliveryTimeoutMs:
     #  apiVersionRequestTimeoutMs:
 
+    # additionalKafkaConfig:
+    #  - name: security.protocol
+    #    value: "SSL"
+
 geodata:
   path: ""
   volumeName: ""


### PR DESCRIPTION
This PR adds `relay.processing.additionalKafkaConfig` to relay kafka in order to make sentry-relay be able to use more kafka settings like SSL. This also includes a fix for `user-create` job which job was exiting gracefully without creating the user.