### PR TITLE
feat: add geoip support to sentry deployment

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -205,6 +205,34 @@ geodata:
   path: /geodata/GeoLite2-City.mmdb
 ```
 
+or
+
+Warning:
+storage must support ReadWriteMany
+
+```yaml
+# enable and reference the volume
+geodata:
+  accountID: "example"
+  licenseKey: "example"
+  editionIDs: "example"
+  persistence:
+    ## database data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    size: 1Gi
+  volumeName: "data-sentry-geoip"
+  # mountPath of the volume containing the database
+  mountPath: "/usr/share/GeoIP"
+  # path to the geoip database inside the volumemount
+  path: "/usr/share/GeoIP/GeoLite2-City.mmdb"
+```
+
 ## External Kafka configuration
 
 You can either provide a single host, which is there by default in `values.yaml`, like this:

--- a/charts/sentry/templates/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/deployment-geoip-job.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.geodata.accountID }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: geoip-install-job
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "3"
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: init-geoip-conf
+          image: busybox
+          command: ['sh', '-c', 'echo -e "AccountID $(echo $GEOIPUPDATE_ACCOUNT_ID)\nLicenseKey $(echo $GEOIPUPDATE_LICENSE_KEY)\nEditionIDs $(echo $GEOIPUPDATE_EDITION_IDS)" > /usr/share/GeoIP/GeoIP.conf']
+          envFrom:
+            - secretRef:
+                name: {{ template "sentry.fullname" . }}-geoip-env
+          volumeMounts:
+            - name: {{ .Values.geodata.volumeName }}
+              mountPath: {{ .Values.geodata.mountPath }}
+      containers:
+        - name: geoipupdate
+          image: ghcr.io/maxmind/geoipupdate:v7.0.1
+          envFrom:
+            - secretRef:
+                name: {{ template "sentry.fullname" . }}-geoip-env
+          volumeMounts:
+            - name: {{ .Values.geodata.volumeName }}
+              mountPath: {{ .Values.geodata.mountPath }}
+      volumes:
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: data-sentry-geoip
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/sentry/templates/pvc-geoip.yaml
+++ b/charts/sentry/templates/pvc-geoip.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.geodata.accountID }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-sentry-geoip
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.geodata.persistence.size }}
+{{- end -}}
+{{- if (eq "-" .Values.geodata.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.geodata.persistence.storageClass }}"
+{{- end }}

--- a/charts/sentry/templates/pvc-geoip.yaml
+++ b/charts/sentry/templates/pvc-geoip.yaml
@@ -14,9 +14,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.geodata.persistence.size }}
-{{- end -}}
 {{- if (eq "-" .Values.geodata.persistence.storageClass) }}
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.geodata.persistence.storageClass }}"
+  {{- end }}
 {{- end }}

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -199,6 +199,11 @@ spec:
           defaultMode: 0644
       - name: credentials
         emptyDir: {}
+      {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: data-sentry-geoip
+      {{- end }}
 {{- if .Values.relay.volumes }}
 {{ toYaml .Values.relay.volumes | indent 6 }}
 {{- end }}

--- a/charts/sentry/templates/secret-geoip-env.yaml
+++ b/charts/sentry/templates/secret-geoip-env.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.geodata.accountID }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sentry.fullname" . }}-geoip-env
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  GEOIPUPDATE_ACCOUNT_ID: {{ .Values.geodata.accountID | b64enc | quote }}
+  GEOIPUPDATE_LICENSE_KEY: {{ .Values.geodata.licenseKey | b64enc | quote }}
+  GEOIPUPDATE_EDITION_IDS: {{ .Values.geodata.editionIDs | b64enc | quote }}
+{{- end -}}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -186,6 +186,11 @@ spec:
       {{- if .Values.sentry.web.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.web.priorityClassName }}"
       {{- end }}
+      {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: data-sentry-geoip
+      {{- end }}
 {{- if .Values.sentry.web.volumes }}
 {{ toYaml .Values.sentry.web.volumes | indent 6 }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -150,6 +150,11 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
+      {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: data-sentry-geoip
+      {{- end }}
       {{- if .Values.sentry.workerEvents.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.workerEvents.priorityClassName }}"
       {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -153,6 +153,11 @@ spec:
       {{- if .Values.sentry.workerTransactions.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.workerTransactions.priorityClassName }}"
       {{- end }}
+      {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: data-sentry-geoip
+      {{- end }}
 {{- if .Values.sentry.workerTransactions.volumes }}
 {{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -155,10 +155,26 @@ relay:
     #  - name: security.protocol
     #    value: "SSL"
 
+# enable and reference the volume
 geodata:
-  path: ""
+  accountID: ""
+  licenseKey: ""
+  editionIDs: ""
+  persistence:
+    ## database data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    size: 1Gi
   volumeName: ""
+  # mountPath of the volume containing the database
   mountPath: ""
+  # path to the geoip database inside the volumemount
+  path: ""
 
 sentry:
   # to not generate a sentry-secret, use these 2 values to reference an existing secret


### PR DESCRIPTION
This pull request introduces support for GeoIP in the Sentry deployment. The changes include:

1. **New Configuration Options**:
   - Added new configuration options for GeoIP in the `values.yaml` file.
   - The new options include `accountID`, `licenseKey`, `editionIDs`, `persistence`, `volumeName`, `mountPath`, and `path`.

2. **New Templates**:
   - Added a new `deployment-geoip-job.yaml` template to handle the GeoIP database update job.
   - Added a new `pvc-geoip.yaml` template for the PersistentVolumeClaim (PVC) to store the GeoIP database.
   - Added a new `secret-geoip-env.yaml` template to manage the environment variables required for GeoIP configuration.

3. **Volume Mounts**:
   - Added volume mounts for the GeoIP database in the `deployment-relay.yaml`, `deployment-sentry-web.yaml`, and `deployment-sentry-worker-events.yaml` templates.

4. **Documentation**:
   - Updated the `README.md` file with an example of how to configure GeoIP in the Sentry deployment.