### PR TITLE
docs: add persistence size notes for Zookeeper and PostgreSQL

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1939,6 +1939,9 @@ zookeeper:
   enabled: true
   nameOverride: zookeeper-clickhouse
   replicaCount: 1
+  ## When increasing the number of exceptions, you need to increase persistence.size
+  # persistence:
+  #   size: 8Gi
 
 # Settings for Kafka.
 # See https://github.com/bitnami/charts/tree/master/bitnami/kafka
@@ -2159,6 +2162,10 @@ postgresql:
   # primary:
   #   extendedConfiguration: |
   #     max_connections=100
+  ## When increasing the number of exceptions, you need to increase persistence.size
+  # primary:
+  #   persistence:
+  #     size: 8Gi
 
 ## This value is only used when postgresql.enabled is set to false
 ## Set either externalPostgresql.password or externalPostgresql.existingSecret to configure password


### PR DESCRIPTION
#### Description
This pull request adds notes to the `values.yaml` file to guide users on increasing the persistence size for Zookeeper and PostgreSQL when handling a higher number of exceptions. The goal is to ensure that users are aware of the necessary adjustments to avoid performance issues and data loss.

#### Changes Made
- **Zookeeper Persistence Size Note:** Added a comment under the `zookeeper` section to inform users about the need to increase the persistence size when handling more exceptions.
- **PostgreSQL Persistence Size Note:** Added a comment under the `postgresql` section to inform users about the need to increase the persistence size when handling more exceptions.

---
Feel free to review and provide feedback. Thank you!