### PR TITLE
fix: correct argument order of consumers

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -93,10 +93,6 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerAttachments.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerAttachments.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerAttachments.logLevel }}"
@@ -105,6 +101,10 @@ spec:
           {{- if .Values.sentry.ingestConsumerAttachments.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerAttachments.concurrency }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestConsumerAttachments.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
           {{- end }}
         {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
         livenessProbe:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -93,13 +93,14 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerEvents.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.ingestConsumerEvents.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerEvents.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerEvents.logLevel }}"
+          {{- end }}
+          - "--"
+          {{- if .Values.sentry.ingestConsumerEvents.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumerEvents.maxBatchSize }}"
           {{- end }}
           {{- if .Values.sentry.ingestConsumerEvents.inputBlockSize }}
           - "--input-block-size"
@@ -109,7 +110,6 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestConsumerEvents.maxBatchTimeMs }}"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.ingestConsumerEvents.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerEvents.concurrency }}"

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -93,13 +93,14 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerTransactions.maxBatchSize }}
-          - "--max-batch-size"
-          - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchSize }}"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerTransactions.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerTransactions.logLevel }}"
+          {{- end }}
+          - "--"
+          {{- if .Values.sentry.ingestConsumerTransactions.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchSize }}"
           {{- end }}
           {{- if .Values.sentry.ingestConsumerTransactions.inputBlockSize }}
           - "--input-block-size"
@@ -109,7 +110,6 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchTimeMs }}"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.ingestConsumerTransactions.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerTransactions.concurrency }}"

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -88,11 +88,11 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}"

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -88,11 +88,11 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          - "--"
           {{- if .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}"
           {{- end }}
-          - "--"
           {{- if .Values.sentry.subscriptionConsumerMetrics.concurrency }}
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.concurrency }}"


### PR DESCRIPTION
Heya, I noticed an error message after upgrading sentry in some of my consumers

```
Usage: sentry run consumer [OPTIONS] CONSUMER_NAME [CONSUMER_ARGS]...
Try 'sentry run consumer --help' for help.

Error: No such option: --max-batch-size
```

after checking the template for it, I found a commit that already took care of a similar issue in the past (https://github.com/sentry-kubernetes/charts/commit/2861efa7192b8d8bc02835ef4ade16a21b2729f1). 

However there were some places and arguments missing in the move, so here we got!