### PR TITLE
fix: correct Helm hook configuration for geoip-install-job and PVC

### DIFF
--- a/charts/sentry/templates/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/deployment-geoip-job.yaml
@@ -4,8 +4,8 @@ kind: Job
 metadata:
   name: geoip-install-job
   annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-weight": "3"
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "9"
 spec:
   template:
     spec:

--- a/charts/sentry/templates/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/deployment-geoip-job.yaml
@@ -10,6 +10,12 @@ spec:
   template:
     spec:
       initContainers:
+        - name: init-create-geoip-dir
+          image: busybox
+          command: ['sh', '-c', 'mkdir -p /usr/share/GeoIP']
+          volumeMounts:
+            - name: {{ .Values.geodata.volumeName }}
+              mountPath: {{ .Values.geodata.mountPath }}
         - name: init-geoip-conf
           image: busybox
           command: ['sh', '-c', 'echo -e "AccountID $(echo $GEOIPUPDATE_ACCOUNT_ID)\nLicenseKey $(echo $GEOIPUPDATE_LICENSE_KEY)\nEditionIDs $(echo $GEOIPUPDATE_EDITION_IDS)" > /usr/share/GeoIP/GeoIP.conf']

--- a/charts/sentry/templates/pvc-geoip.yaml
+++ b/charts/sentry/templates/pvc-geoip.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -153,7 +153,7 @@ spec:
             mountPath: /work/.relay/config.yml
             subPath: config.yml
             readOnly: true
-          {{- if .Values.geodata.volumeName }}
+          {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
           - name: {{ .Values.geodata.volumeName }}
             mountPath: {{ .Values.geodata.mountPath }}
           {{- end }}

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -202,16 +202,11 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
 {{- if .Values.relay.volumes }}
 {{ toYaml .Values.relay.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.geodata.volumeName }}
-      - name: {{ .Values.geodata.volumeName }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.geodata.volumeName }}
-      {{- end }}
       {{- if .Values.relay.priorityClassName }}
       priorityClassName: "{{ .Values.relay.priorityClassName }}"
       {{- end }}

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -207,6 +207,11 @@ spec:
 {{- if .Values.relay.volumes }}
 {{ toYaml .Values.relay.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.geodata.volumeName }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.geodata.volumeName }}
+      {{- end }}
       {{- if .Values.relay.priorityClassName }}
       priorityClassName: "{{ .Values.relay.priorityClassName }}"
       {{- end }}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -189,14 +189,9 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
 {{- if .Values.sentry.web.volumes }}
 {{ toYaml .Values.sentry.web.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.geodata.volumeName }}
-      - name: {{ .Values.geodata.volumeName }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.geodata.volumeName }}
-      {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -110,7 +110,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -194,4 +194,9 @@ spec:
 {{- if .Values.sentry.web.volumes }}
 {{ toYaml .Values.sentry.web.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.geodata.volumeName }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.geodata.volumeName }}
+      {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -161,4 +161,9 @@ spec:
 {{- if .Values.sentry.workerEvents.volumes }}
 {{ toYaml .Values.sentry.workerEvents.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.geodata.volumeName }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.geodata.volumeName }}
+      {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -153,7 +153,7 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
       {{- if .Values.sentry.workerEvents.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.workerEvents.priorityClassName }}"
@@ -161,9 +161,4 @@ spec:
 {{- if .Values.sentry.workerEvents.volumes }}
 {{ toYaml .Values.sentry.workerEvents.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.geodata.volumeName }}
-      - name: {{ .Values.geodata.volumeName }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.geodata.volumeName }}
-      {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -93,7 +93,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -161,4 +161,9 @@ spec:
 {{- if .Values.sentry.workerTransactions.volumes }}
 {{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.geodata.volumeName }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.geodata.volumeName }}
+      {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -156,14 +156,9 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
 {{- if .Values.sentry.workerTransactions.volumes }}
 {{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.geodata.volumeName }}
-      - name: {{ .Values.geodata.volumeName }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.geodata.volumeName }}
-      {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -93,7 +93,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -108,7 +108,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}
@@ -171,7 +171,7 @@ spec:
 {{- if .Values.sentry.worker.volumes }}
 {{ toYaml .Values.sentry.worker.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.geodata.volumeName }}
+      {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
           claimName: {{ .Values.geodata.volumeName }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -171,4 +171,9 @@ spec:
 {{- if .Values.sentry.worker.volumes }}
 {{ toYaml .Values.sentry.worker.volumes | indent 6 }}
 {{- end }}
+      {{- if .Values.geodata.volumeName }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.geodata.volumeName }}
+      {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -165,13 +165,13 @@ geodata:
     ## If undefined (the default) or set to null, no storageClassName spec is
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
-    # storageClass: "-"
+    # storageClass: "" # for example: csi-s3
     size: 1Gi
-  volumeName: ""
+  volumeName: "" # for example: data-sentry-geoip
   # mountPath of the volume containing the database
-  mountPath: ""
+  mountPath: "" # for example: /usr/share/GeoIP
   # path to the geoip database inside the volumemount
-  path: ""
+  path: "" # for example: /usr/share/GeoIP/GeoLite2-City.mmdb
 
 sentry:
   # to not generate a sentry-secret, use these 2 values to reference an existing secret

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -167,11 +167,11 @@ geodata:
     ##   GKE, AWS & OpenStack)
     # storageClass: "" # for example: csi-s3
     size: 1Gi
-  volumeName: "" # for example: data-sentry-geoip
+  volumeName: ""  # for example: data-sentry-geoip
   # mountPath of the volume containing the database
-  mountPath: "" # for example: /usr/share/GeoIP
+  mountPath: ""  # for example: /usr/share/GeoIP
   # path to the geoip database inside the volumemount
-  path: "" # for example: /usr/share/GeoIP/GeoLite2-City.mmdb
+  path: ""  # for example: /usr/share/GeoIP/GeoLite2-City.mmdb
 
 sentry:
   # to not generate a sentry-secret, use these 2 values to reference an existing secret


### PR DESCRIPTION
This PR addresses two issues related to the GeoIP volume and Helm hook configuration in the Sentry Helm chart:

1. **Add GeoIP Volume to Sentry Deployments:**
   - Previously, the `data-sentry-geoip` volume was not being added to several Sentry deployment manifests, leading to errors during installation. This PR adds the `data-sentry-geoip` volume to the following deployment manifests:
     - `deployment-relay.yaml`
     - `deployment-sentry-web.yaml`
     - `deployment-sentry-worker-events.yaml`
     - `deployment-sentry-worker-transactions.yaml`
     - `deployment-sentry-worker.yaml`

2. **Fix Helm Hook Configuration for GeoIP Installation Job:**
   - The GeoIP installation job was previously configured to run before the chart installation, which could lead to errors since the Persistent Volume Claim (PVC) was not yet created. This PR changes the Helm hook configuration for the GeoIP installation job to run after the chart installation and ensures the PVC is created before the GeoIP installation job runs.

#### Changes

1. **deployment-relay.yaml:**
   - Added the `data-sentry-geoip` volume to the `volumes` section.

2. **deployment-sentry-web.yaml:**
   - Added the `data-sentry-geoip` volume to the `volumes` section.

3. **deployment-sentry-worker-events.yaml:**
   - Added the `data-sentry-geoip` volume to the `volumes` section.

4. **deployment-sentry-worker-transactions.yaml:**
   - Added the `data-sentry-geoip` volume to the `volumes` section.

5. **deployment-sentry-worker.yaml:**
   - Added the `data-sentry-geoip` volume to the `volumes` section.

6. **values.yaml:**
   - Updated comments in the `data-sentry-geoip` section to provide examples for `storageClass`, `volumeName`, `mountPath`, and `path`.

7. **deployment-geoip-job.yaml:**
   - Changed the `helm.sh/hook` annotation value from `pre-install` to `post-install`.
   - Changed the `helm.sh/hook-weight` annotation value from `3` to `9` to ensure the job runs after the main resources are installed.

8. **pvc-geoip.yaml:**
   - Added `helm.sh/hook` annotation with the value `pre-install`.
   - Added `helm.sh/hook-weight` annotation with the value `-1` to ensure the PVC is created before the GeoIP installation job runs.

Related Pull Requests:
- #1516
- #1524


---
Feel free to review and provide feedback. Thank you!