### PR TITLE
fix: update geoip job hooks and volume handling

### DIFF
--- a/charts/sentry/templates/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/deployment-geoip-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: geoip-install-job
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "9"
 spec:
   template:

--- a/charts/sentry/templates/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/deployment-geoip-job.yaml
@@ -4,12 +4,18 @@ kind: Job
 metadata:
   name: geoip-install-job
   annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-weight": "3"
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "9"
 spec:
   template:
     spec:
       initContainers:
+        - name: init-create-geoip-dir
+          image: busybox
+          command: ['sh', '-c', 'mkdir -p /usr/share/GeoIP']
+          volumeMounts:
+            - name: {{ .Values.geodata.volumeName }}
+              mountPath: {{ .Values.geodata.mountPath }}
         - name: init-geoip-conf
           image: busybox
           command: ['sh', '-c', 'echo -e "AccountID $(echo $GEOIPUPDATE_ACCOUNT_ID)\nLicenseKey $(echo $GEOIPUPDATE_LICENSE_KEY)\nEditionIDs $(echo $GEOIPUPDATE_EDITION_IDS)" > /usr/share/GeoIP/GeoIP.conf']

--- a/charts/sentry/templates/pvc-geoip.yaml
+++ b/charts/sentry/templates/pvc-geoip.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/sentry/templates/pvc-geoip.yaml
+++ b/charts/sentry/templates/pvc-geoip.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-1"
 spec:
   accessModes:

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -153,7 +153,7 @@ spec:
             mountPath: /work/.relay/config.yml
             subPath: config.yml
             readOnly: true
-          {{- if .Values.geodata.volumeName }}
+          {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
           - name: {{ .Values.geodata.volumeName }}
             mountPath: {{ .Values.geodata.mountPath }}
           {{- end }}
@@ -202,7 +202,7 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
 {{- if .Values.relay.volumes }}
 {{ toYaml .Values.relay.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -110,7 +110,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}
@@ -189,7 +189,7 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
 {{- if .Values.sentry.web.volumes }}
 {{ toYaml .Values.sentry.web.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -93,7 +93,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}
@@ -153,7 +153,7 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
       {{- if .Values.sentry.workerEvents.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.workerEvents.priorityClassName }}"

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -93,7 +93,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}
@@ -156,7 +156,7 @@ spec:
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
-          claimName: data-sentry-geoip
+          claimName: {{ .Values.geodata.volumeName }}
       {{- end }}
 {{- if .Values.sentry.workerTransactions.volumes }}
 {{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -108,7 +108,7 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
-        {{- if .Values.geodata.volumeName }}
+        {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
         {{- end }}
@@ -171,4 +171,9 @@ spec:
 {{- if .Values.sentry.worker.volumes }}
 {{ toYaml .Values.sentry.worker.volumes | indent 6 }}
 {{- end }}
+      {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
+      - name: {{ .Values.geodata.volumeName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.geodata.volumeName }}
+      {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -165,13 +165,13 @@ geodata:
     ## If undefined (the default) or set to null, no storageClassName spec is
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
-    # storageClass: "-"
+    # storageClass: "" # for example: csi-s3
     size: 1Gi
-  volumeName: ""
+  volumeName: "" # for example: data-sentry-geoip
   # mountPath of the volume containing the database
-  mountPath: ""
+  mountPath: "" # for example: /usr/share/GeoIP
   # path to the geoip database inside the volumemount
-  path: ""
+  path: "" # for example: /usr/share/GeoIP/GeoLite2-City.mmdb
 
 sentry:
   # to not generate a sentry-secret, use these 2 values to reference an existing secret

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -167,11 +167,11 @@ geodata:
     ##   GKE, AWS & OpenStack)
     # storageClass: "" # for example: csi-s3
     size: 1Gi
-  volumeName: "" # for example: data-sentry-geoip
+  volumeName: ""  # for example: data-sentry-geoip
   # mountPath of the volume containing the database
-  mountPath: "" # for example: /usr/share/GeoIP
+  mountPath: ""  # for example: /usr/share/GeoIP
   # path to the geoip database inside the volumemount
-  path: "" # for example: /usr/share/GeoIP/GeoLite2-City.mmdb
+  path: ""  # for example: /usr/share/GeoIP/GeoLite2-City.mmdb
 
 sentry:
   # to not generate a sentry-secret, use these 2 values to reference an existing secret


### PR DESCRIPTION
### Description
This pull request introduces several improvements to the GeoIP job and volume configuration within the Sentry Helm chart. The changes are aimed at enhancing the reliability and flexibility of the GeoIP setup.

### Changes Overview
1. **GeoIP Job Hook Update**:
   - Changed the hook from `pre-install` to `post-install` with a weight of `9`.
   - Added an init container to create the GeoIP directory if it doesn't exist.

2. **Persistent Volume Claim (PVC) Annotations**:
   - Added annotations to the PVC to ensure it is created before the GeoIP job runs.

3. **Conditional Volume Mounting**:
   - Updated the volume mounting logic to only mount the GeoIP volume if both `volumeName` and `accountID` are defined.

4. **Dynamic PVC Claim Name**:
   - Updated the PVC claim name to use the dynamic value from `Values.geodata.volumeName`.

5. **Values.yaml Comments**:
   - Enhanced comments in `values.yaml` to provide clearer guidance on configuring GeoIP settings.

Related Pull Requests:
- #1516
- #1524
- #1527

---
Feel free to review and provide feedback. Thank you!