### PR TITLE
fix: symbolicator storage class

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 25.13.3
+version: 25.13.2
 appVersion: 24.7.1
 dependencies:
   - name: memcached

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 25.13.2
+version: 25.13.3
 appVersion: 24.7.1
 dependencies:
   - name: memcached

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -150,7 +150,7 @@ spec:
         name: symbolicator-data
       spec:
         accessModes: {{ .Values.symbolicator.api.persistence.accessModes }}
-        {{- if hasKey .Values.symbolicator.api.persistence "storageClass" }}
+        {{- if hasKey .Values.symbolicator.api.persistence "storageClassName" }}
         storageClassName: {{ .Values.symbolicator.api.persistence.storageClassName | quote }}
         {{- end }}
         resources:


### PR DESCRIPTION
Hello, I made a small fix to the symbolicator's `storageClassName`. The condition was previously reading the `storageClass` key, but the property was being set using `storageClassName`. 👋