### PR TITLE
fix: conditionally set auto-offset-reset for snuba subscription consumers

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -72,7 +72,10 @@ spec:
         command:
           - "snuba"
           - "subscriptions-scheduler-executor"
-          - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
+          {{- if .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.snuba.subscriptionConsumerEvents.autoOffsetReset }}"
+          {{- end }}
           - "--dataset=events"
           - "--entity=events"
           {{- if .Values.snuba.subscriptionConsumerEvents.noStrictOffsetReset }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -72,7 +72,10 @@ spec:
         command:
           - "snuba"
           - "subscriptions-scheduler-executor"
-          - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerMetrics.autoOffsetReset }}"
+          {{- if .Values.snuba.subscriptionConsumerMetrics.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.snuba.subscriptionConsumerMetrics.autoOffsetReset }}"
+          {{- end }}
           - "--dataset=metrics"
           - "--entity=metrics_sets"
           - "--entity=metrics_counters"

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -72,7 +72,10 @@ spec:
         command:
           - "snuba"
           - "subscriptions-scheduler-executor"
-          - "--auto-offset-reset={{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
+          {{- if .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.snuba.subscriptionConsumerTransactions.autoOffsetReset }}"
+          {{- end }}
           - "--dataset=transactions"
           - "--entity=transactions"
           {{- if .Values.snuba.subscriptionConsumerTransactions.noStrictOffsetReset }}


### PR DESCRIPTION
### Description
This pull request addresses an issue where the `auto-offset-reset` parameter was being unconditionally set for Snuba subscription consumers, even when the value was not explicitly defined in the configuration. This could lead to unintended behavior and potential errors.

To resolve this, I've added a conditional check to ensure that the `auto-offset-reset` parameter is only included in the command if it is explicitly defined in the values configuration. This change applies to the following Snuba subscription consumer deployments:

- `deployment-snuba-subscription-consumer-events.yaml`
- `deployment-snuba-subscription-consumer-metrics.yaml`
- `deployment-snuba-subscription-consumer-transactions.yaml`

### Changes Made
- Added a conditional check around the `auto-offset-reset` parameter in the command section of each deployment template.
- The parameter is now only included if the corresponding value is defined in the `values.yaml` file.

### Related Issues
- #1537

Related Pull Requests:
- #1535

@Mokto  Please review and let me know if there are any additional changes or improvements needed.

Thank you!