### PR TITLE
feat(snuba): add events_analytics_platform to settings

### DIFF
--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -39,7 +39,6 @@ settings.py: |
           "events",
           "events_ro",
           "metrics",
-          "metrics_summaries",
           "migrations",
           "outcomes",
           "querylog",
@@ -53,8 +52,10 @@ settings.py: |
           "search_issues",
           "generic_metrics_counters",
           "spans",
+          "events_analytics_platform",
           "group_attributes",
           "generic_metrics_gauges",
+          "metrics_summaries",
           "profile_chunks",
       },
       {{- /*


### PR DESCRIPTION
Description
This pull request synchronizes the Snuba settings in the Helm chart with the latest version of the Snuba settings file from the Sentry repository. Specifically, it updates the settings to match the configuration found in https://github.com/getsentry/snuba/blob/master/snuba/settings/settings_distributed.py.

Changes Made
Added events_analytics_platform: This new entry is required for compatibility with Sentry version 24.9.0. It has been added to the settings to ensure proper functionality with the latest version of Sentry.

To enable Sentry version 24.9.0, you must add `events_analytics_platform` and update ClickHouse to version 23.3.19.32.

Please review the changes and let me know if there are any additional adjustments needed. Thank you!
