### PR TITLE
feat: add logLevel and logFormat options for worker events and transactions

### DIFF
--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -80,6 +80,14 @@ spec:
           - "-c"
           - "{{ .Values.sentry.workerEvents.concurrency }}"
           {{- end }}
+          {{- if .Values.sentry.workerEvents.logLevel }}
+          - "--loglevel"
+          - "{{ .Values.sentry.workerEvents.logLevel }}"
+          {{- end }}
+          {{- if .Values.sentry.workerEvents.logFormat }}
+          - "--logformat"
+          - "{{ .Values.sentry.workerEvents.logFormat }}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -80,6 +80,14 @@ spec:
           - "-c"
           - "{{ .Values.sentry.workerTransactions.concurrency }}"
           {{- end }}
+          {{- if .Values.sentry.workerTransactions.logLevel }}
+          - "--loglevel"
+          - "{{ .Values.sentry.workerTransactions.logLevel }}"
+          {{- end }}
+          {{- if .Values.sentry.workerTransactions.logFormat }}
+          - "--logformat"
+          - "{{ .Values.sentry.workerTransactions.logFormat }}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -285,7 +285,8 @@ sentry:
     nodeSelector: {}
     # tolerations: []
     # podLabels: {}
-
+    # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
+    # logFormat: "machine" # human|machine
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -315,6 +316,8 @@ sentry:
     nodeSelector: {}
     # tolerations: []
     # podLabels: {}
+    # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
+    # logFormat: "machine" # human|machine
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:


### PR DESCRIPTION
### Description

This pull request enhances the logging configuration for Sentry worker deployments by introducing new options for setting the log level and log format. These changes allow for more granular control over the logging behavior of the worker processes, which can be particularly useful for debugging and monitoring purposes.

### Changes Made

1. **Added `logLevel` and `logFormat` Options**: New configuration options `logLevel` and `logFormat` have been added to the worker deployments for both events and transactions. These options can be set in the `values.yaml` file to customize the logging behavior.

2. **Updated `values.yaml`**: The `values.yaml` file has been updated to include documentation for the new `logLevel` and `logFormat` options, providing examples and descriptions for each.


### Testing
```
k get pod -n test | grep worker
sentry-worker-67579456f8-xkr8r                                    1/1     Running   2 (12m ago)   13m
sentry-worker-events-c856c7d6b-kfxm5                              1/1     Running   2 (12m ago)   13m
sentry-worker-transactions-666ff8f865-6kqtc                       1/1     Running   2 (12m ago)   13m
```
and
```
stern -n test -l role=worker-events
.................
sentry-worker-events-c856c7d6b-kfxm5 sentry-worker {"name":"py.warnings","event":"/.venv/lib/python3.11/site-packages/celery/app/utils.py:203: CDeprecationWarning: \n    The 'CELERY_RESULT_SERIALIZER' setting is deprecated and scheduled for removal in\n    version 6.0.0. Use the result_serializer instead\n\n  deprecated.warn(description=f'The {setting!r} setting',\n","level":"warning"}
```
and
```
stern -n test -l role=worker-transactions
sentry-worker-transactions-666ff8f865-6kqtc sentry-worker {"name":"py.warnings","event":"/.venv/lib/python3.11/site-packages/celery/app/utils.py:203: CDeprecationWarning: \n    The 'CELERY_CREATE_MISSING_QUEUES' setting is deprecated and scheduled for removal in\n    version 6.0.0. Use the task_create_missing_queues instead\n\n  deprecated.warn(description=f'The {setting!r} setting',\n","level":"warning"}
```

---
Please review the changes and let me know if there are any additional adjustments needed. Thank you!
