### PR TITLE
ci: add waiting for pods to be running or completed in ci workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -48,3 +48,9 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"
+
+      - name: Wait for pods to be Running or Completed
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl wait --for=condition=Ready pod --all --timeout=10m
+          kubectl get pods --all-namespaces

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -49,6 +49,11 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"
 
+      - name: View all pods
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl get pods --all-namespaces
+
       - name: Sleep for 10 seconds
         if: steps.list-changed.outputs.changed == 'true'
         run: sleep 10

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,8 +56,9 @@ jobs:
       - name: Check Pod Status
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          if kubectl get pods --all-namespaces | grep -v Running; then
+          if output=$(kubectl get pods --all-namespaces | grep -v Running); then
             echo "Some pods are not in Running state"
+            echo "$output"
             exit 1
           else
             echo "All pods are in Running state"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -49,8 +49,16 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"
 
-      - name: Wait for pods to be Running or Completed
+      - name: Sleep for 2 minutes
+        run: sleep 120
+
+      - name: Check Pod Status
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          kubectl wait --for=condition=Ready pod --all --timeout=10m
-          kubectl get pods --all-namespaces
+          if kubectl get pods --all-namespaces | grep -v Running; then
+            echo "Some pods are not in Running state"
+            exit 1
+          else
+            echo "All pods are in Running state"
+            kubectl get pods --all-namespaces
+          fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -49,9 +49,9 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"
 
-      - name: Sleep for 2 minutes
+      - name: Sleep for 10 seconds
         if: steps.list-changed.outputs.changed == 'true'
-        run: sleep 120
+        run: sleep 10
 
       - name: Check Pod Status
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,11 +56,12 @@ jobs:
       - name: Check Pod Status
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          if output=$(kubectl get pods --all-namespaces | grep -v Running); then
-            echo "Some pods are not in Running state"
-            echo "$output"
+          NON_READY_PODS=$(kubectl get pods -A -o json | jq -r '.items[] | select(.status.containerStatuses[].ready == false) | "\(.metadata.namespace) \(.metadata.name)"' | sort -u | column -t)
+          if [ -n "$NON_READY_PODS" ]; then
+            echo "The following pods are not ready:"
+            echo "$NON_READY_PODS"
             exit 1
           else
-            echo "All pods are in Running state"
+            echo "All pods are ready."
             kubectl get pods --all-namespaces
           fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -50,6 +50,7 @@ jobs:
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"
 
       - name: Sleep for 2 minutes
+        if: steps.list-changed.outputs.changed == 'true'
         run: sleep 120
 
       - name: Check Pod Status

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1927,7 +1927,6 @@ clickhouse:
                 - ::/0
               profile: default
               quota: default
-
     persistentVolumeClaim:
       enabled: true
       dataPersistentVolume:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1539,7 +1539,6 @@ snuba:
 
   migrateJob:
     env: []
-
   clickhouse:
     maxConnections: 100
 

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2233,7 +2233,6 @@ rabbitmq:
     username: guest
     password: guest
   nameOverride: ""
-
   pdb:
     create: true
   persistence:


### PR DESCRIPTION
#### Description:
This pull request adds a step to the CI workflow that waits for all pods to transition to the `Running` or `Completed` state after the Helm chart installation. This ensures that the CI workflow checks the status of the pods before proceeding to the next steps.

#### Changes Made:
- **CI Workflow Enhancement:**
  - Added a step to wait for all pods to be in the `Ready` state (Running or Completed) after Helm chart installation.
  - Ensures that the CI workflow waits for pods to be ready before proceeding to the next steps.

#### Benefits:
- **Reliability:** Ensures that the CI workflow only proceeds when all pods are in a stable state, reducing the likelihood of failures due to pods being in a `CrashLoopBackOff` state.
- **Visibility:** Provides visibility into the status of all pods after the Helm chart installation, making it easier to diagnose issues if any pods are not in the desired state.

#### Related Issues:
- #1544

---
Please review the changes and let me know if there are any additional adjustments needed. Thank you!