### PR TITLE
fix: external redis functionality

### DIFF
--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -99,7 +99,7 @@ spec:
                   name: {{ .Values.externalRedis.existingSecret }}
                   key: {{ default "redis-password" .Values.externalRedis.existingSecretKey }}
             - name: RELAY_REDIS_URL
-              value: {{ $redisProto }}://$(HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}
+              value: {{ $redisProto }}://:$(HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}
           {{- end }}
 {{- if .Values.relay.init.env }}
 {{ toYaml .Values.relay.init.env | indent 12 }}
@@ -141,7 +141,7 @@ spec:
               name: {{ .Values.externalRedis.existingSecret }}
               key: {{ default "redis-password" .Values.externalRedis.existingSecretKey }}
         - name: RELAY_REDIS_URL
-          value: {{ $redisProto }}://$(HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}
+          value: {{ $redisProto }}://:$(HELM_CHARTS_RELAY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}
         {{- end }}
 {{- if .Values.relay.env }}
 {{ toYaml .Values.relay.env | indent 8 }}


### PR DESCRIPTION
This PR extends on to the feature by #1492 

We are using external redis from aws elasticache in non cluster mode. 

```
externalRedis:
  host: master.uat-XXXXXX.amazonaws.com
  existingSecret: sentry
  existingSecretKey: redis-password
  ssl: true

redis:
  enabled: false
``` 

With above config we were facing this issue on sentry relay

```
2024-10-14T04:00:01.703356Z ERROR relay_server::services::processor: error processing envelope tags.project_key=834fe1715ec71e6042077d96dbde5ca4 error=failed to apply quotas error.sources=[failed to communicate with redis, failed to communicate with redis, NOAUTH: Authentication required.]
``` 


As per this [issue]( https://github.com/getsentry/relay/issues/1722), we have to provide username:password format and if not, we should precede the password with the colon which was unintentionally missed out for relay service. Please note we did have the colon [here](https://github.com/sentry-kubernetes/charts/pull/1492/files#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaR652-R660) in the same PR.
