### PR TITLE
feat(clickhouse): update ClickHouse version to 22.8.15.23

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "21.8.13.6"
+appVersion: "22.8.15.23"
 description: ClickHouse is an open source column-oriented database management
   system capable of real time generation of analytical data reports using SQL
   queries


### PR DESCRIPTION
## Description
This pull request updates the ClickHouse version in the Helm chart to 22.8.15.23. The new version aligns with with the upgrade script located at [install/upgrade-clickhouse.sh](https://github.com/getsentry/self-hosted/blob/master/install/upgrade-clickhouse.sh).

## Changes
Updated the appVersion in the Chart.yaml file from 21.8.13.6 to 22.8.15.23.

Update plan:
sentry  clickhouse
24.7.1  21.8.13.6
24.8.0  22.8.15.23
24.9.0  23.3.19.32

## Related Issues
- #1474

## Related Pull Requests:
- #1540