### PR TITLE
feat(clickhouse): update ClickHouse version to 23.3.19.32

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "22.8.15.23"
+appVersion: "23.3.19.32"
 description: ClickHouse is an open source column-oriented database management
   system capable of real time generation of analytical data reports using SQL
   queries


### PR DESCRIPTION
## Description
@Mokto  This pull request updates the ClickHouse version in the Helm chart to 23.3.19.32. The new version aligns with with the upgrade script located at [install/upgrade-clickhouse.sh](https://github.com/getsentry/self-hosted/blob/master/install/upgrade-clickhouse.sh).

## Changes
Updated the appVersion in the Chart.yaml file from 22.8.15.23 to 23.3.19.32.

Update plan:
sentry  clickhouse
24.7.1  21.8.13.6
24.8.0  23.3.19.32
24.9.0  23.3.19.32

## Related Issues
- #1474

## Related Pull Requests:
- #1540


i tested sentry 24.8.0 and clickhouse chart version 3.12.0 with 22.8.15.23
sentry-snuba-migrate-pkpmh snuba-migrate snuba.clickhouse.errors.ClickhouseError: DB::Exception: Codec DoubleDelta does not accept any arguments. Stack trace:

i tested sentry 24.8.0 and clickhouse version 23.3.19.32 - no errors