### PR TITLE
feat(clickhouse): update ClickHouse chart to 3.12.0

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
-    version: 3.11.0
+    version: 3.12.0
     condition: clickhouse.enabled
   - name: zookeeper
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
## Description
This pull request updates the ClickHouse Helm chart to 3.12.0. The new version aligns with with the upgrade script located at [install/upgrade-clickhouse.sh](https://github.com/getsentry/self-hosted/blob/master/install/upgrade-clickhouse.sh).

## Changes
Updated the clickhouse version in the Chart.yaml file from 3.11.0 to 3.12.0.

I think the upgrade plan will be like this:
sentry clickhouse
24.7.1 21.8.13.6
24.7.1 22.8.15.23
24.7.1 23.3.19.32
24.8.0 23.3.19.32
24.9.0 23.3.19.32

## Related Issues
- #1474

## Related Pull Requests:
- #1540
- #1552