### PR TITLE
feat(clickhouse): update ClickHouse chart to 3.12.0

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
-  version: 3.11.0
+  version: 3.12.0
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.4.11
@@ -23,5 +23,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.2
-digest: sha256:f4ac160ca9a62db5ff6bf36b9dbb0e2ef8b274e05cace579aaaced04e4df4986
-generated: "2024-10-14T10:39:44.230529676Z"
+digest: sha256:ce18fe5b992a59cb62ed3438a55d1c225cb26e342a65f09a102ae05d5cec1722
+generated: "2024-10-16T16:29:12.454761534+06:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
-    version: 3.11.0
+    version: 3.12.0
     condition: clickhouse.enabled
   - name: zookeeper
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
## Description
This pull request updates the ClickHouse Helm chart to 3.12.0. The new version aligns with with the upgrade script located at [install/upgrade-clickhouse.sh](https://github.com/getsentry/self-hosted/blob/master/install/upgrade-clickhouse.sh).

## Changes
Updated the clickhouse version in the Chart.yaml file from 3.11.0 to 3.12.0.

I think the upgrade plan will be like this:
sentry clickhouse
24.7.1 21.8.13.6
24.7.1 22.8.15.23
24.7.1 23.3.19.32
24.8.0 23.3.19.32
24.9.0 23.3.19.32

## Related Issues
- #1474

## Related Pull Requests:
- #1540
- #1552