### PR TITLE
feat(sentry): add sasl auth for kafka and manage settings of connections to kafka

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -68,7 +68,14 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | externalClickhouse.singleNode | bool | `true` |  |
 | externalClickhouse.tcpPort | int | `9000` |  |
 | externalClickhouse.username | string | `"default"` |  |
-| externalKafka.port | int | `9092` |  |
+| externalKafka.host | string | `"kafka-confluent"` | Hostname or IP address of external Kafka |
+| externalKafka.port | int | `9092` | Port for external Kafka |
+| externalKafka.compression.type | string | `""` | Compression type for Kafka messages ('gzip', 'snappy', 'lz4', 'zstd') |
+| externalKafka.message.max.bytes | int | `50000000` | Maximum message size for Kafka |
+| externalKafka.sasl.mechanism | string | `"None"` | SASL mechanism for Kafka (PLAIN, SCRAM-256, SCRAM-512) |
+| externalKafka.sasl.username | string | `"None"` | SASL username for Kafka |
+| externalKafka.sasl.password | string | `"None"` | SASL password for Kafka |
+| externalKafka.security.protocol | string | `"plaintext"` | Security protocol for Kafka (PLAINTEXT, SASL_PLAINTEXT, SASL_SSL, SSL) |
 | externalPostgresql.connMaxAge | int | `0` |  |
 | externalPostgresql.database | string | `"sentry"` |  |
 | externalPostgresql.existingSecretKeys | object | `{}` |  |
@@ -142,7 +149,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | kafka.controller.replicaCount | int | `3` |  |
 | kafka.enabled | bool | `true` |  |
 | kafka.kraft.enabled | bool | `true` |  |
-| kafka.listeners.client.protocol | string | `"PLAINTEXT"` |  |
+| kafka.listeners.client.protocol | string | `"PLAINTEXT"` | Security protocol for the Kafka client listener (PLAINTEXT, SASL_PLAINTEXT, SASL_SSL, SSL) |
 | kafka.listeners.controller.protocol | string | `"PLAINTEXT"` |  |
 | kafka.listeners.external.protocol | string | `"PLAINTEXT"` |  |
 | kafka.listeners.interbroker.protocol | string | `"PLAINTEXT"` |  |
@@ -228,6 +235,9 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | kafka.provisioning.topics[7].name | string | `"outcomes"` |  |
 | kafka.provisioning.topics[8].name | string | `"outcomes-billing"` |  |
 | kafka.provisioning.topics[9].name | string | `"ingest-sessions"` |  |
+| kafka.sasl.client.users | list | `[]` | List of usernames for client communications when SASL is enabled, first user will be used if enabled |
+| kafka.sasl.client.passwords | list | `[]` | List of passwords for client communications when SASL is enabled, must match the number of client.users, first password will be used if enabled |
+| kafka.sasl.enabledMechanisms | string | `"PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"` | Comma-separated list of allowed SASL mechanisms when SASL listeners are configured |
 | kafka.zookeeper.enabled | bool | `false` |  |
 | mail.backend | string | `"dummy"` |  |
 | mail.from | string | `""` |  |
@@ -543,6 +553,9 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.ingestReplayRecordings.sidecars | list | `[]` |  |
 | sentry.ingestReplayRecordings.topologySpreadConstraints | list | `[]` |  |
 | sentry.ingestReplayRecordings.volumes | list | `[]` |  |
+| sentry.kafka.message.max.bytes | int | `50000000` | Maximum message size for Kafka |
+| sentry.kafka.compression.type | string | `""` | Compression type for Kafka messages |
+| sentry.kafka.socket.timeout.ms | int | `1000` | Socket timeout for Kafka connections |
 | sentry.metricsConsumer.affinity | object | `{}` |  |
 | sentry.metricsConsumer.autoscaling.enabled | bool | `false` |  |
 | sentry.metricsConsumer.autoscaling.maxReplicas | int | `3` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -458,6 +458,104 @@ Set Kafka bootstrap servers string
 {{- end -}}
 {{- end -}}
 
+{{/*
+SASL auth setings for Kafka:
+* https://github.com/getsentry/snuba/blob/24.7.1/snuba/settings/__init__.py#L219-L229
+* https://github.com/getsentry/sentry/blob/24.7.1/src/sentry/utils/kafka_config.py#L9-L34
+* https://github.com/getsentry/sentry/blob/24.7.1/src/sentry/conf/server.py#L2827-L2836
+*/}}
+
+{{/*
+Set Kafka security protocol
+*/}}
+{{- define "sentry.kafka.security_protocol" -}}
+{{- if .Values.kafka.enabled -}}
+{{ default "plaintext" .Values.kafka.listeners.client.protocol }}
+{{- else -}}
+{{ default "plaintext" .Values.externalKafka.security.protocol }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set Kafka sasl mechanism
+*/}}
+{{- define "sentry.kafka.sasl_mechanism" -}}
+{{- $CheckProtocol := include "sentry.kafka.security_protocol" . -}}
+{{- if (regexMatch "^SASL_" $CheckProtocol) -}}
+{{- if .Values.kafka.enabled -}}
+{{ default "None" (split "," .Values.kafka.sasl.enabledMechanisms)._0 }}
+{{- else -}}
+{{ default "None" .Values.externalKafka.sasl.mechanism }}
+{{- end -}}
+{{- else -}}
+{{ "None" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set Kafka sasl username
+*/}}
+{{- define "sentry.kafka.sasl_username" -}}
+{{- $CheckProtocol := include "sentry.kafka.security_protocol" . -}}
+{{- if (regexMatch "^SASL_" $CheckProtocol) -}}
+{{- if .Values.kafka.enabled -}}
+{{ default "None" (first (default tuple .Values.kafka.sasl.client.users)) }}
+{{- else -}}
+{{ default "None" .Values.externalKafka.sasl.username }}
+{{- end -}}
+{{- else -}}
+{{ "None" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set Kafka sasl password
+*/}}
+{{- define "sentry.kafka.sasl_password" -}}
+{{- $CheckProtocol := include "sentry.kafka.security_protocol" . -}}
+{{- if (regexMatch "^SASL_" $CheckProtocol) -}}
+{{- if .Values.kafka.enabled -}}
+{{ default "None" (first (default tuple .Values.kafka.sasl.client.passwords)) }}
+{{- else -}}
+{{ default "None" .Values.externalKafka.sasl.password }}
+{{- end -}}
+{{- else -}}
+{{ "None" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set Senty compression.type for Kafka
+*/}}
+{{- define "sentry.kafka.compression_type" -}}
+{{- if .Values.kafka.enabled -}}
+{{ default "" .Values.sentry.kafka.compression.type }}
+{{- else -}}
+{{ default "" .Values.externalKafka.compression.type }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set Senty message.max.bytes for Kafka
+*/}}
+{{- define "sentry.kafka.message_max_bytes" -}}
+{{- if .Values.kafka.enabled -}}
+{{ default 50000000 .Values.sentry.kafka.message.max.bytes | int64 }}
+{{- else -}}
+{{ default 50000000 .Values.externalKafka.message.max.bytes | int64 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set Senty socket.timeout for Kafka
+*/}}
+{{- define "sentry.kafka.socket_timeout_ms" -}}
+{{- if .Values.kafka.enabled -}}
+{{ default 1000 .Values.sentry.kafka.socket.timeout.ms | int64 }}
+{{- else -}}
+{{ default 1000 .Values.externalKafka.socket.timeout.ms | int64 }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Set RabbitMQ host
@@ -478,6 +576,23 @@ Common Snuba environment variables
   value: /etc/snuba/settings.py
 - name: DEFAULT_BROKERS
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
+{{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
+{{- if not (eq "None" $sentryKafkaSaslMechanism) }}
+- name: KAFKA_SASL_MECHANISM
+  value: {{ $sentryKafkaSaslMechanism | quote}}
+{{- end }}
+{{- $sentryKafkaSaslUsername := include "sentry.kafka.sasl_username" . -}}
+{{- if not (eq "None" $sentryKafkaSaslUsername) }}
+- name: KAFKA_SASL_USERNAME
+  value: {{ $sentryKafkaSaslUsername | quote }}
+{{- end }}
+{{- $sentryKafkaSaslPassword := include "sentry.kafka.sasl_password" . -}}
+{{- if not (eq "None" $sentryKafkaSaslPassword) }}
+- name: KAFKA_SASL_PASSWORD
+  value: {{ $sentryKafkaSaslPassword | quote }}
+{{- end }}
+- name: KAFKA_SECURITY_PROTOCOL
+  value: {{ include "sentry.kafka.security_protocol" . | quote }}
 {{- if and (.Values.redis.enabled) (.Values.redis.auth.enabled) }}
 {{- if .Values.redis.auth.password }}
 - name: REDIS_PASSWORD

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -63,6 +63,26 @@ config.yml: |-
       - name: "api.version.request.timeout.ms"
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
+      {{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
+      {{- if not (eq "None" $sentryKafkaSaslMechanism) }}
+      - name: "sasl.mechanism"
+        value: {{ $sentryKafkaSaslMechanism | quote }}
+      {{- end }}
+      {{- $sentryKafkaSaslUsername := include "sentry.kafka.sasl_username" . -}}
+      {{- if not (eq "None" $sentryKafkaSaslUsername) }}
+      - name: "sasl.username"
+        value: {{ $sentryKafkaSaslUsername | quote }}
+      {{- end }}
+      {{- $sentryKafkaSaslPassword := include "sentry.kafka.sasl_password" . -}}
+      {{- if not (eq "None" $sentryKafkaSaslPassword) }}
+      - name: "sasl.password"
+        value: {{ $sentryKafkaSaslPassword | quote }}
+      {{- end }}
+      {{- $sentryKafkaSecurityProtocol := include "sentry.kafka.security_protocol" . -}}
+      {{- if not (eq "plaintext" $sentryKafkaSecurityProtocol) }}
+      - name: security.protocol
+        value: {{ $sentryKafkaSecurityProtocol | quote }}
+      {{- end }}
   {{- if .Values.relay.processing.additionalKafkaConfig }}
   {{ toYaml .Values.relay.processing.additionalKafkaConfig | nindent 6 }}
   {{- end }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -222,9 +222,31 @@ sentry.conf.py: |-
   SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 
   DEFAULT_KAFKA_OPTIONS = {
-      "bootstrap.servers": {{ (include "sentry.kafka.bootstrap_servers_string" .) | quote }},
-      "message.max.bytes": 50000000,
-      "socket.timeout.ms": 1000,
+      "common": {
+          "bootstrap.servers": {{ (include "sentry.kafka.bootstrap_servers_string" .) | quote }},
+          "message.max.bytes": {{ include "sentry.kafka.message_max_bytes" . }},
+      {{- $sentryKafkaCompressionType := include "sentry.kafka.compression_type" . -}}
+      {{- if $sentryKafkaCompressionType }}
+          "compression.type": {{ $sentryKafkaCompressionType | quote }},
+      {{- end }}
+          "socket.timeout.ms": {{ include "sentry.kafka.socket_timeout_ms" . }},
+      {{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
+      {{- if not (eq "None" $sentryKafkaSaslMechanism) }}
+          "sasl.mechanism": {{ $sentryKafkaSaslMechanism | quote }},
+      {{- end }}
+      {{- $sentryKafkaSaslUsername := include "sentry.kafka.sasl_username" . -}}
+      {{- if not (eq "None" $sentryKafkaSaslUsername) }}
+          "sasl.username": {{ $sentryKafkaSaslUsername | quote }},
+      {{- end }}
+      {{- $sentryKafkaSaslPassword := include "sentry.kafka.sasl_password" . -}}
+      {{- if not (eq "None" $sentryKafkaSaslPassword) }}
+          "sasl.password": {{ $sentryKafkaSaslPassword | quote }},
+      {{- end }}
+      {{- $sentryKafkaSecurityProtocol := include "sentry.kafka.security_protocol" . -}}
+      {{- if not (eq "plaintext" $sentryKafkaSecurityProtocol) }}
+          "security.protocol": {{ $sentryKafkaSecurityProtocol | quote }},
+      {{- end }}
+      }
   }
 
   SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -152,8 +152,8 @@ relay:
     #  apiVersionRequestTimeoutMs:
 
     # additionalKafkaConfig:
-    #  - name: security.protocol
-    #    value: "SSL"
+    #  - name: compression.type
+    #    value: "lz4"
 
 # enable and reference the volume
 geodata:
@@ -932,6 +932,17 @@ sentry:
     volumes: []
     # volumeMounts: []
     serviceAccount: {}
+
+  # Sentry settings of connections to Kafka
+  kafka:
+    message:
+      max:
+        bytes: 50000000
+    compression:
+      type:  # 'gzip', 'snappy', 'lz4', 'zstd'
+    socket:
+      timeout:
+        ms: 1000
 
 snuba:
   api:
@@ -2135,6 +2146,23 @@ kafka:
   #     create: false
   #     name: zookeeper
 
+  # sasl:
+  #  ## Credentials for client communications.
+  #  ## @param sasl.client.users ist of usernames for client communications when SASL is enabled
+  #  ## @param sasl.client.passwords list of passwords for client communications when SASL is enabled, must match the number of client.users
+  #  ## First user and password will be used if enabled
+  #   client:
+  #     users:
+  #       - sentry
+  #     passwords:
+  #       - password
+  #   ## @param sasl.enabledMechanisms Comma-separated list of allowed SASL mechanisms when SASL listeners are configured. Allowed types: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`
+  #   enabledMechanisms: PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
+  # listeners:
+  #   ## @param listeners.client.protocol Security protocol for the Kafka client listener. Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'
+  #   client:
+  #     protocol: SASL_PLAINTEXT
+
 ## This value is only used when kafka.enabled is set to false
 ##
 externalKafka:
@@ -2142,6 +2170,20 @@ externalKafka:
   ##
   # host: "kafka-confluent"
   port: 9092
+  compression:
+    type:  # 'gzip', 'snappy', 'lz4', 'zstd'
+  message:
+    max:
+      bytes: 50000000
+  sasl:
+    mechanism: None  # PLAIN,SCRAM-256,SCRAM-512
+    username: None
+    password: None
+  security:
+    protocol: plaintext  # 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'
+  socket:
+    timeout:
+      ms: 1000
 
 sourcemaps:
   enabled: false


### PR DESCRIPTION
These changes allow configuring SASL authentication for Kafka in Sentry for both external Kafka installations and internal ones deployed from the Bitnami chart. They also enable control over other connection parameters between Sentry and other Sentry applications to Kafka.

Useful links:

- https://github.com/getsentry/snuba/blob/24.7.1/snuba/settings/__init__.py#L219-L229
- https://github.com/getsentry/sentry/blob/24.7.1/src/sentry/utils/kafka_config.py#L9-L34
- https://github.com/getsentry/sentry/blob/24.7.1/src/sentry/conf/server.py#L2827-L2836


Example values.yaml for testing with the Bitnami Kafka chart:
```yaml
sentry:
...
  kafka:
    message:
      max:
        bytes: 50000000
    compression:
      type: lz4
    socket:
      timeout:
        ms: 1000
        
...
kafka:
...
  sasl:
    client:
      users:
         - sentry
      passwords:
         - p@ssw0rd
    enabledMechanisms: PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
 listeners:
   client:
     protocol: SASL_PLAINTEXT
...
,,,


```

Example values.yaml for testing with external Kafka:
```yaml
externalKafka:
  ## Hostname or ip address of external kafka
  ##
  host: "kafka-confluent.example.com"
  port: 9092
  compression:
     type: lz4'
  message:
    max:
      bytes: 50000000
  sasl:
    mechanism: PLAIN
    username: sentry
    password: p@ssw0rd
  security:
    protocol: SASL_PLAINTEXT
  socket:
    timeout:
      ms: 1000

```