### PR TITLE
feat(clickhouse): remove explicit imageVersion, inherit from chart

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1915,7 +1915,6 @@ clickhouse:
   enabled: true
   clickhouse:
     replicas: "1"
-    imageVersion: "21.8.13.6"
     configmap:
       remote_servers:
         internal_replication: true


### PR DESCRIPTION
#### Description
This pull request addresses the removal of the explicit `imageVersion` for ClickHouse from the `values.yaml` file. By doing so, the `imageVersion` will now be inherited from the chart's default settings, simplifying the configuration and reducing redundancy.

#### Changes Made
- Removed the `imageVersion` field from the `clickhouse` section in `values.yaml`.

---
Please review the changes and let me know if there are any additional adjustments needed. Thank you!