### PR TITLE
fix: Use correct syntax for envFrom in web and worker

### DIFF
--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -102,7 +102,7 @@ spec:
 {{- if .Values.sentry.web.existingSecretEnv }}
         envFrom:
           - secretRef:
-            name: "{{.Values.sentry.web.existingSecretEnv}}"
+              name: {{.Values.sentry.web.existingSecretEnv}}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -100,7 +100,7 @@ spec:
 {{- if .Values.sentry.worker.existingSecretEnv }}
         envFrom:
         - secretRef:
-          name: "{{.Values.sentry.worker.existingSecretEnv}}"
+            name: {{.Values.sentry.worker.existingSecretEnv}}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -184,7 +184,7 @@ sentry:
     strategyType: RollingUpdate
     replicas: 1
     env: []
-    existingSecretEnv: []
+    existingSecretEnv: ""
     probeFailureThreshold: 5
     probeInitialDelaySeconds: 10
     probePeriodSeconds: 10
@@ -243,7 +243,7 @@ sentry:
     replicas: 1
     # concurrency: 4
     env: []
-    existingSecretEnv: []
+    existingSecretEnv: ""
     resources: {}
     #  requests:
     #    cpu: 1000m


### PR DESCRIPTION
I believe there were some syntax mistakes in https://github.com/sentry-kubernetes/charts/pull/1509 (see my comments there). This PR should fix these.