### PR TITLE
feat: add maxTasksPerChild option to Sentry worker deployments

### DIFF
--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -88,6 +88,10 @@ spec:
           - "--logformat"
           - "{{ .Values.sentry.workerEvents.logFormat }}"
           {{- end }}
+          {{- if .Values.sentry.worker.maxTasksPerChild }}
+          - "--max-tasks-per-child"
+          - "{{ .Values.sentry.worker.maxTasksPerChild }}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -88,9 +88,9 @@ spec:
           - "--logformat"
           - "{{ .Values.sentry.workerEvents.logFormat }}"
           {{- end }}
-          {{- if .Values.sentry.worker.maxTasksPerChild }}
+          {{- if .Values.sentry.workerEvents.maxTasksPerChild }}
           - "--max-tasks-per-child"
-          - "{{ .Values.sentry.worker.maxTasksPerChild }}"
+          - "{{ .Values.sentry.workerEvents.maxTasksPerChild }}"
           {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -88,6 +88,10 @@ spec:
           - "--logformat"
           - "{{ .Values.sentry.workerTransactions.logFormat }}"
           {{- end }}
+          {{- if .Values.sentry.worker.maxTasksPerChild }}
+          - "--max-tasks-per-child"
+          - "{{ .Values.sentry.worker.maxTasksPerChild }}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -88,9 +88,9 @@ spec:
           - "--logformat"
           - "{{ .Values.sentry.workerTransactions.logFormat }}"
           {{- end }}
-          {{- if .Values.sentry.worker.maxTasksPerChild }}
+          {{- if .Values.sentry.workerTransactions.maxTasksPerChild }}
           - "--max-tasks-per-child"
-          - "{{ .Values.sentry.worker.maxTasksPerChild }}"
+          - "{{ .Values.sentry.workerTransactions.maxTasksPerChild }}"
           {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -90,6 +90,10 @@ spec:
           - "--logformat"
           - "{{ .Values.sentry.worker.logFormat }}"
           {{- end }}
+          {{- if .Values.sentry.worker.maxTasksPerChild }}
+          - "--max-tasks-per-child"
+          - "{{ .Values.sentry.worker.maxTasksPerChild }}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -255,6 +255,7 @@ sentry:
     # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
     # logFormat: "machine" # human|machine
     # excludeQueues: ""
+    # maxTasksPerChild: 1000
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -292,6 +293,7 @@ sentry:
     # podLabels: {}
     # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
     # logFormat: "machine" # human|machine
+    # maxTasksPerChild: 1000
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -327,6 +329,7 @@ sentry:
     # podLabels: {}
     # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
     # logFormat: "machine" # human|machine
+    # maxTasksPerChild: 1000
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:


### PR DESCRIPTION
#### Description
This pull request introduces a new configuration option, `maxTasksPerChild`, for Sentry worker deployments. This option allows users to specify the maximum number of tasks a worker process can complete before being replaced. This feature is particularly useful for managing memory leaks and resource usage in long-running worker processes.

#### Changes
- **Added `maxTasksPerChild` Option to `values.yaml`:**
  - A new configuration option `maxTasksPerChild` has been added under the `sentry.worker`,`sentry.workerEvents`,`workerTransactions` section in `values.yaml`.
  
- **Updated Deployment Templates:**
  - The following deployment templates have been updated to include the new `maxTasksPerChild` option:
    - `deployment-sentry-worker.yaml`
    - `deployment-sentry-worker-events.yaml`
    - `deployment-sentry-worker-transactions.yaml`

---
Please review the changes and let me know if there are any additional adjustments needed. Thank you!