### PR TITLE
docs: Add upgrade instructions for 25.x.x to 26.x.x version of the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ helm install my-sentry sentry/sentry --wait --timeout=1000s
 
 For now the full list of values is not documented but you can get inspired by the values.yaml specific to each directory.
 
+## Upgrading from 25.x.x Version of This Chart to 26.x.x
+
+Before upgrading to version 26.0.0, you need to update to version 25.20.0.
+
 ## Upgrading from 23.x.x Version of This Chart to 24.x.x/25.x.x
 
 Make sure to revert the changes on Clickhouse replica counts if the change doesn't suit you.


### PR DESCRIPTION
### Summary

This pull request adds upgrade instructions for transitioning from version 25.x.x to 26.x.x of the Helm chart. The instructions are included in the `README.md` file to ensure users are aware of the necessary steps before performing the upgrade.

---
Thank you for considering this pull request.