### PR TITLE
feat: add global nodeSelector fallback for all deployments

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -50,6 +50,9 @@ spec:
       {{- if .Values.hooks.dbCheck.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.hooks.dbCheck.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.hooks.dbCheck.tolerations }}
       tolerations:

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -46,6 +46,9 @@ spec:
       {{- if .Values.hooks.dbInit.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.hooks.dbInit.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.hooks.dbInit.tolerations }}
       tolerations:

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.hooks.snubaInit.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.hooks.snubaInit.tolerations }}
       tolerations:

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.hooks.snubaInit.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.hooks.snubaInit.tolerations }}
       tolerations:

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -41,6 +41,9 @@ spec:
       {{- if .Values.hooks.dbInit.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.hooks.dbInit.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.hooks.dbInit.tolerations }}

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.relay.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.relay.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.relay.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -42,6 +42,9 @@ spec:
             {{- if .Values.sentry.cleanup.nodeSelector }}
           nodeSelector:
 {{ toYaml .Values.sentry.cleanup.nodeSelector | indent 12 }}
+            {{- else if .Values.global.nodeSelector }}
+          nodeSelector:
+{{ toYaml .Values.sentry.cleanup.nodeSelector | indent 12 }}
             {{- end }}
             {{- if .Values.sentry.cleanup.tolerations }}
           tolerations:

--- a/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
+++ b/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
@@ -40,6 +40,9 @@ spec:
       {{- if .Values.sentry.cron.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.cron.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.cron.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestConsumerAttachments.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestConsumerAttachments.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerAttachments.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestConsumerEvents.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestConsumerEvents.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerEvents.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestMonitors.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestMonitors.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestMonitors.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestOccurrences.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestOccurrences.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestOccurrences.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestProfiles.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestProfiles.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestProfiles.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestReplayRecordings.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestReplayRecordings.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestReplayRecordings.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.ingestConsumerTransactions.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.ingestConsumerTransactions.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerTransactions.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.billingMetricsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.billingMetricsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.billingMetricsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -40,6 +40,9 @@ spec:
       {{- if .Values.metrics.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.metrics.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.metrics.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.metricsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.metricsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.metricsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.genericMetricsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.genericMetricsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.genericMetricsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.postProcessForwardErrors.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.postProcessForwardErrors.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardErrors.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.postProcessForwardIssuePlatform.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.postProcessForwardIssuePlatform.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardIssuePlatform.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.postProcessForwardTransactions.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.postProcessForwardTransactions.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardTransactions.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerEvents.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerEvents.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerGenericMetrics.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerGenericMetrics.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerMetrics.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerMetrics.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerMetrics.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerTransactions.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerTransactions.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.vroom.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.vroom.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.vroom.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -44,6 +44,9 @@ spec:
       {{- if .Values.sentry.web.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.web.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.web.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -42,6 +42,9 @@ spec:
       {{- if .Values.sentry.workerEvents.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.workerEvents.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.workerEvents.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -42,6 +42,9 @@ spec:
       {{- if .Values.sentry.workerTransactions.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.workerTransactions.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.workerTransactions.tolerations }}
       tolerations:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -42,6 +42,9 @@ spec:
       {{- if .Values.sentry.worker.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sentry.worker.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.worker.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -41,6 +41,9 @@ spec:
       {{- if .Values.snuba.api.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.api.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.api.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.consumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.consumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.consumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.genericMetricsCountersConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.genericMetricsCountersConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsCountersConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.genericMetricsDistributionConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.genericMetricsDistributionConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsDistributionConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.genericMetricsSetsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.genericMetricsSetsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsSetsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.groupAttributesConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.groupAttributesConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.groupAttributesConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.issueOccurrenceConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.issueOccurrenceConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.issueOccurrenceConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.metricsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.metricsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.metricsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.outcomesBillingConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.outcomesBillingConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.outcomesBillingConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.outcomesConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.outcomesConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.outcomesConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.profilingFunctionsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.profilingFunctionsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.profilingFunctionsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.profilingProfilesConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.profilingProfilesConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.profilingProfilesConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.replacer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.replacer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.replacer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.replaysConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.replaysConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.replaysConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.spansConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.spansConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.spansConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.subscriptionConsumerEvents.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerEvents.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.subscriptionConsumerMetrics.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.subscriptionConsumerMetrics.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerMetrics.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.subscriptionConsumerTransactions.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerTransactions.tolerations }}
       tolerations:

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.transactionsConsumer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.snuba.transactionsConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.transactionsConsumer.tolerations }}
       tolerations:

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -41,6 +41,9 @@ spec:
       {{- if .Values.symbolicator.api.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.symbolicator.api.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.symbolicator.api.tolerations }}
       tolerations:

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -42,6 +42,9 @@ spec:
       {{- if .Values.symbolicator.api.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.symbolicator.api.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.symbolicator.api.tolerations }}
       tolerations:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3,6 +3,8 @@ prefix:
 # Set this to true to support IPV6 networks
 ipv6: false
 
+global:
+  nodeSelector: {}
 
 user:
   create: true


### PR DESCRIPTION
#### Description

This pull request introduces a fallback mechanism for `nodeSelector` configurations across all deployments in the Sentry Helm chart. If a specific `nodeSelector` is not defined for a particular deployment, the global `nodeSelector` from `.Values.global.nodeSelector` will be used instead.

---
Please review the changes and provide feedback. If everything looks good, feel free to merge this pull request.

Thank you!