### PR TITLE
feat(rabbitmq): updated configuration to support Prometheus

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2292,7 +2292,6 @@ rabbitmq:
     username: guest
     password: guest
   nameOverride: ""
-
   pdb:
     create: true
   persistence:
@@ -2302,7 +2301,6 @@ rabbitmq:
     # enabled: true
     # type: relative
     # value: 0.4
-
   extraSecrets:
     load-definition:
       load_definition.json: |
@@ -2348,6 +2346,13 @@ rabbitmq:
   # serviceAccount:
   #   create: false
   #   name: rabbitmq
+  metrics:
+    enabled: false
+    serviceMonitor:
+      enabled: false
+      path: "/metrics/per-object" # https://www.rabbitmq.com/docs/prometheus
+      labels:
+        release: "prometheus-operator" # helm release of kube-prometheus-stack
 
 memcached:
   memoryLimit: "2048"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2350,9 +2350,9 @@ rabbitmq:
     enabled: false
     serviceMonitor:
       enabled: false
-      path: "/metrics/per-object" # https://www.rabbitmq.com/docs/prometheus
+      path: "/metrics/per-object"  # https://www.rabbitmq.com/docs/prometheus
       labels:
-        release: "prometheus-operator" # helm release of kube-prometheus-stack
+        release: "prometheus-operator"  # helm release of kube-prometheus-stack
 
 memcached:
   memoryLimit: "2048"


### PR DESCRIPTION
### Description
This pull request introduces the addition of RabbitMQ metrics configuration in the `values.yaml` file, although the metrics are disabled by default. Additionally, it removes empty lines from the configuration for better readability.

### Changes Made
- **RabbitMQ Configuration**:
  - Added `metrics` section with `enabled`, `serviceMonitor`, `path`, and `labels` configurations.
  - Disabled metrics collection by default (`metrics.enabled: false`).
  - Removed empty lines in the configuration.

---
Please review the changes and provide feedback. If everything looks good, feel free to merge this pull request.

Thank you!