### PR TITLE
feat: Introduce global tolerations across all components

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -57,6 +57,9 @@ spec:
       {{- if .Values.hooks.dbCheck.tolerations }}
       tolerations:
 {{ toYaml .Values.hooks.dbCheck.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.hooks.dbCheck.image.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -53,6 +53,9 @@ spec:
       {{- if .Values.hooks.dbInit.tolerations }}
       tolerations:
 {{ toYaml .Values.hooks.dbInit.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.images.sentry.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.hooks.snubaInit.tolerations }}
       tolerations:
 {{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.images.snuba.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.hooks.snubaInit.tolerations }}
       tolerations:
 {{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       restartPolicy: Never
       {{- if .Values.images.snuba.imagePullSecrets }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.hooks.dbInit.tolerations }}
       tolerations:
 {{ toYaml .Values.hooks.dbInit.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.images.sentry.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -63,6 +63,9 @@ spec:
       {{- if .Values.relay.tolerations }}
       tolerations:
 {{ toYaml .Values.relay.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.relay.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -49,6 +49,9 @@ spec:
             {{- if .Values.sentry.cleanup.tolerations }}
           tolerations:
 {{ toYaml .Values.sentry.cleanup.tolerations | indent 12 }}
+            {{- else if .Values.global.tolerations }}
+          tolerations:
+{{ toYaml .Values.global.tolerations | indent 12 }}
             {{- end }}
             {{- if .Values.dnsPolicy }}
           dnsPolicy: {{ .Values.dnsPolicy | quote }}

--- a/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
+++ b/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
@@ -47,6 +47,9 @@ spec:
       {{- if .Values.sentry.cron.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.cron.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.cron.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestConsumerAttachments.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestConsumerAttachments.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerAttachments.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestConsumerEvents.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestConsumerEvents.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestMonitors.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestMonitors.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestMonitors.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestOccurrences.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestOccurrences.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestOccurrences.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestProfiles.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestProfiles.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestProfiles.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestReplayRecordings.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestReplayRecordings.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestReplayRecordings.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.ingestConsumerTransactions.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.ingestConsumerTransactions.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.ingestConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.sentry.billingMetricsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.billingMetricsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.billingMetricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -47,6 +47,9 @@ spec:
       {{- if .Values.metrics.tolerations }}
       tolerations:
 {{ toYaml .Values.metrics.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.metrics.schedulerName }}
       schedulerName: "{{ .Values.metrics.schedulerName }}"

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.metricsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.metricsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.metricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.genericMetricsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.genericMetricsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.genericMetricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.postProcessForwardErrors.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.postProcessForwardErrors.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardErrors.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.postProcessForwardIssuePlatform.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.postProcessForwardIssuePlatform.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardIssuePlatform.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.postProcessForwardTransactions.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.postProcessForwardTransactions.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.postProcessForwardTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerEvents.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerGenericMetrics.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerGenericMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerMetrics.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.subscriptionConsumerMetrics.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -56,6 +56,9 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerTransactions.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.subscriptionConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.vroom.tolerations }}
       tolerations:
 {{ toYaml .Values.vroom.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.vroom.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -51,6 +51,9 @@ spec:
       {{- if .Values.sentry.web.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.web.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.web.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.workerEvents.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.workerEvents.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.workerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.workerTransactions.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.workerTransactions.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.workerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.sentry.worker.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.worker.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.sentry.worker.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.snuba.api.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.api.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.api.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.consumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.consumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.consumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.genericMetricsCountersConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.genericMetricsCountersConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsCountersConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.genericMetricsDistributionConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.genericMetricsDistributionConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsDistributionConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.genericMetricsSetsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.genericMetricsSetsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.genericMetricsSetsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.groupAttributesConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.groupAttributesConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.groupAttributesConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.issueOccurrenceConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.issueOccurrenceConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.issueOccurrenceConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.metricsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.metricsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.metricsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.outcomesBillingConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.outcomesBillingConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.outcomesBillingConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.outcomesConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.outcomesConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.outcomesConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.profilingFunctionsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.profilingFunctionsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.profilingFunctionsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.profilingProfilesConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.profilingProfilesConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.profilingProfilesConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.replacer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.replacer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.replacer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.replaysConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.replaysConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.replaysConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.spansConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.spansConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.spansConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.subscriptionConsumerEvents.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.subscriptionConsumerMetrics.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.subscriptionConsumerMetrics.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.subscriptionConsumerTransactions.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.subscriptionConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.snuba.transactionsConsumer.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.transactionsConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.snuba.transactionsConsumer.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.symbolicator.api.tolerations }}
       tolerations:
 {{ toYaml .Values.symbolicator.api.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.symbolicator.api.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.symbolicator.api.tolerations }}
       tolerations:
 {{ toYaml .Values.symbolicator.api.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.symbolicator.api.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -5,6 +5,7 @@ ipv6: false
 
 global:
   nodeSelector: {}
+  tolerations: []
 
 user:
   create: true


### PR DESCRIPTION
### Description
This pull request introduces a global tolerations fallback mechanism across all deployments in the Sentry Helm chart. This enhancement allows users to define tolerations at a global level, which will be applied to all deployments if specific tolerations are not explicitly defined at the deployment level.

### Changes Made
- Added a global `tolerations` field in the `values.yaml` file.
- Updated all deployment templates to include a fallback to the global tolerations if specific tolerations are not provided.
- Ensured that the global tolerations are applied consistently across all Kubernetes resources, including jobs, deployments, and stateful sets.

---
Please review the changes and provide feedback. If everything looks good, feel free to merge this pull request.
Thank you!