### PR TITLE
feat: add maxBatchTimeMs, maxPollIntervalMs for ingestConsumerAttachments

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -107,6 +107,10 @@ spec:
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerAttachments.logLevel }}"
           {{- end }}
+          {{- if .Values.sentry.ingestConsumerAttachments.maxPollIntervalMs }}
+          - "--max-poll-interval-ms"
+          - "{{ .Values.sentry.ingestConsumerAttachments.maxPollIntervalMs }}"
+          {{- end }}
           - "--"
           {{- if .Values.sentry.ingestConsumerAttachments.concurrency }}
           - "--processes"
@@ -115,6 +119,10 @@ spec:
           {{- if .Values.sentry.ingestConsumerAttachments.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestConsumerAttachments.maxBatchTimeMs }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchTimeMs }}"
           {{- end }}
         {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
         livenessProbe:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -363,6 +363,8 @@ sentry:
     enabled: true
     replicas: 1
     # concurrency: 4
+    # maxBatchTimeMs: 20000
+    # maxPollIntervalMs: 30000
     env: []
     resources: {}
     #  requests:


### PR DESCRIPTION
I have a restricted environment where, due to hardware limitations, we are running into timeouts. Configuring these values timeouts through `values.yaml` will resolve this issue.

We have been bypassing this by running consumer manually when the error happens with the following command:

```
sentry run consumer ingest-attachments \
--consumer-group ingest-consumer 
--log-level DEBUG \
--max-poll-interval-ms 90000 \
-- --max-batch-size 1 \
--max-batch-time-ms 80000 \
--reprocess-only-stuck-events
```

Setting higher timeout values from start would prevent even this issue happening.
