### PR TITLE
docs: Add Comment for Nginx Configuration Regarding Safari Compatibility

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1806,7 +1806,7 @@ openai: {}
 #   existingSecretKey: ""   # by default "api-token"
 
 nginx:
-  enabled: true
+  enabled: true # true, if Safari compatibility is needed
   containerPort: 8080
   existingServerBlockConfigmap: '{{ template "sentry.fullname" . }}'
   resources: {}


### PR DESCRIPTION
This pull request adds a comment to the `nginx.enabled` field in the `values.yaml` file, clarifying that the Nginx service should be enabled (`enabled: true`) if Safari compatibility is required. This change is purely documentation-focused, aiming to provide better context for users configuring the Sentry deployment.