### PR TITLE
feat: disable Sentry anonymous usage statistics

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -152,6 +152,8 @@ sentry.conf.py: |-
   # General #
   ###########
 
+  # Disable sends anonymous usage statistics
+  SENTRY_BEACON = False
 
   secret_key = env('SENTRY_SECRET_KEY')
   if not secret_key:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1806,7 +1806,7 @@ openai: {}
 #   existingSecretKey: ""   # by default "api-token"
 
 nginx:
-  enabled: true # true, if Safari compatibility is needed
+  enabled: true  # true, if Safari compatibility is needed
   containerPort: 8080
   existingServerBlockConfigmap: '{{ template "sentry.fullname" . }}'
   resources: {}


### PR DESCRIPTION
This PR introduces a feature to disable Sentry's anonymous usage statistics. By setting `SENTRY_BEACON` to `False`, we ensure that no anonymous data is sent to Sentry, enhancing privacy and compliance with data usage policies.

### Changes:
- Added `SENTRY_BEACON = False` to the `sentry.conf.py` configuration file.

![image](https://github.com/user-attachments/assets/200e8d9d-bf79-4b66-bbd9-cd327687c806)
and
![image](https://github.com/user-attachments/assets/196c6b87-88cd-46cc-bbe0-1f3452499cd6)

links:

https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L1510

https://forum.sentry.io/t/how-to-upgrade-docker-install-stuck-on-beacon-modal/2546

https://develop.sentry.dev/self-hosted/

https://github.com/getsentry/sentry/blob/master/src/sentry/tasks/beacon.py#L48

Please review and provide feedback.