### PR TITLE
docs: add comment about setting accessMode for Replays

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1806,7 +1806,7 @@ openai: {}
 #   existingSecretKey: ""   # by default "api-token"
 
 nginx:
-  enabled: true # true, if Safari compatibility is needed
+  enabled: true  # true, if Safari compatibility is needed
   containerPort: 8080
   existingServerBlockConfigmap: '{{ template "sentry.fullname" . }}'
   resources: {}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1884,7 +1884,7 @@ filestore:
       ##   GKE, AWS & OpenStack)
       ##
       # storageClass: "-"
-      accessMode: ReadWriteOnce
+      accessMode: ReadWriteOnce  # Set ReadWriteMany for work Replays
       size: 10Gi
 
       ## Whether to mount the persistent volume to the Sentry worker and


### PR DESCRIPTION
### Description
This pull request adds a comment to the `values.yaml` file in the Sentry Helm chart, suggesting that the `accessMode` should be set to `ReadWriteMany` if the Replays functionality is required. This comment serves as a reminder for users who might need to enable this feature.

### Related Issues
- #1440