### PR TITLE
Add configuration for noStrictOffsetReset

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -105,6 +105,9 @@ spec:
           {{- if .Values.snuba.replacer.queuedMinMessages }}
           - "--queued-min-messages"
           - "{{ .Values.snuba.replacer.queuedMinMessages }}"
+          {{- if .Values.snuba.replacer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1115,6 +1115,7 @@ snuba:
     # queuedMinMessages: ""
     # volumes: []
     # volumeMounts: []
+    # noStrictOffsetReset: false
 
   metricsConsumer:
     enabled: true


### PR DESCRIPTION
Introduce a new configuration option `noStrictOffsetReset` in the Snuba replacer deployment template and values file. This allows users to optionally disable strict offset reset behavior by setting `noStrictOffsetReset` to true in the `values.yaml` file. This change provides more flexibility in handling offset resets, which can be useful in certain deployment scenarios where strict offset management is not required or desired.