### PR TITLE
fix: missing flags required for Queues and Queries instrumentation

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -514,6 +514,8 @@ sentry.conf.py: |-
 
               {{- if .Values.sentry.features.enableSpan }}
               "projects:span-metrics-extraction",
+              "projects:span-metrics-extraction-addons",
+              "organizations:indexed-spans-extraction",
               "organizations:starfish-browser-resource-module-image-view",
               "organizations:starfish-browser-resource-module-ui",
               "organizations:starfish-browser-webvitals",


### PR DESCRIPTION
Those 2 flags are in the official compose deployment: https://github.com/getsentry/self-hosted/blob/master/sentry/sentry.conf.example.py#L263

Only after enabling them, data started showing in Queues instrumentation and the query details in Queries. 

![image](https://github.com/user-attachments/assets/76094398-f173-4f19-b29f-74faed1197c2)
