### PR TITLE
feat: enhance worker deployments with additional packages and CA certificates

### DIFF
--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -79,8 +79,8 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
           - |
-            {{- if .Values.sentry.workerEvents.installAdditionalPackages }}
-            pip install django-multidb-router sentry-nodestore-elastic https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+            {{- if .Values.sentry.worker.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
             # Copy certificates from secret to /usr/local/share/ca-certificates/
             mkdir -p /usr/local/share/ca-certificates/

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -76,10 +76,20 @@ spec:
       - name: {{ .Chart.Name }}-worker
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "worker"
+          - |
+            {{- if .Values.sentry.workerEvents.installAdditionalPackages }}
+            pip install django-multidb-router sentry-nodestore-elastic https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+            {{- end }}
+            # Copy certificates from secret to /usr/local/share/ca-certificates/
+            mkdir -p /usr/local/share/ca-certificates/
+            cp /etc/ssl/certs/* /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            sentry run worker
           - "-Q"
           - {{ .Values.sentry.workerEvents.queues }}
           {{- if .Values.sentry.workerEvents.concurrency }}
@@ -122,6 +132,11 @@ spec:
 {{- if .Values.sentry.workerEvents.volumeMounts }}
 {{ toYaml .Values.sentry.workerEvents.volumeMounts | indent 8 }}
 {{- end }}
+        {{- if .Values.sentry.worker.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
   {{- if .Values.sentry.workerEvents.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.workerEvents.livenessProbe.periodSeconds }}
@@ -178,5 +193,11 @@ spec:
       {{- end }}
 {{- if .Values.sentry.workerEvents.volumes }}
 {{ toYaml .Values.sentry.workerEvents.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.worker.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.worker.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -82,9 +82,7 @@ spec:
             {{- if .Values.sentry.worker.installAdditionalPackages }}
             pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
-            # Copy certificates from secret to /usr/local/share/ca-certificates/
             mkdir -p /usr/local/share/ca-certificates/
-            cp /etc/ssl/certs/* /usr/local/share/ca-certificates/
             for c in $(ls -1 /usr/local/share/ca-certificates/); do
                 cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
             done

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -79,8 +79,8 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
           - |
-            {{- if .Values.sentry.workerTransactions.installAdditionalPackages }}
-            pip install django-multidb-router sentry-nodestore-elastic https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+            {{- if .Values.sentry.worker.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
             # Copy certificates from secret to /usr/local/share/ca-certificates/
             mkdir -p /usr/local/share/ca-certificates/

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -76,10 +76,20 @@ spec:
       - name: {{ .Chart.Name }}-worker
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "worker"
+          - |
+            {{- if .Values.sentry.workerTransactions.installAdditionalPackages }}
+            pip install django-multidb-router sentry-nodestore-elastic https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+            {{- end }}
+            # Copy certificates from secret to /usr/local/share/ca-certificates/
+            mkdir -p /usr/local/share/ca-certificates/
+            cp /etc/ssl/certs/* /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            sentry run worker
           - "-Q"
           - {{ .Values.sentry.workerTransactions.queues }}
           {{- if .Values.sentry.workerTransactions.concurrency }}
@@ -122,6 +132,11 @@ spec:
 {{- if .Values.sentry.workerTransactions.volumeMounts }}
 {{ toYaml .Values.sentry.workerTransactions.volumeMounts | indent 8 }}
 {{- end }}
+        {{- if .Values.sentry.worker.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
   {{- if .Values.sentry.workerTransactions.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.workerTransactions.livenessProbe.periodSeconds }}
@@ -178,5 +193,11 @@ spec:
       {{- end }}
 {{- if .Values.sentry.workerTransactions.volumes }}
 {{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.worker.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.worker.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -82,9 +82,7 @@ spec:
             {{- if .Values.sentry.worker.installAdditionalPackages }}
             pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
-            # Copy certificates from secret to /usr/local/share/ca-certificates/
             mkdir -p /usr/local/share/ca-certificates/
-            cp /etc/ssl/certs/* /usr/local/share/ca-certificates/
             for c in $(ls -1 /usr/local/share/ca-certificates/); do
                 cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
             done

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -80,7 +80,7 @@ spec:
         args:
           - |
             {{- if .Values.sentry.worker.installAdditionalPackages }}
-            pip install django-multidb-router sentry-nodestore-elastic https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+            pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
             # Copy certificates from secret to /usr/local/share/ca-certificates/
             mkdir -p /usr/local/share/ca-certificates/

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -82,9 +82,7 @@ spec:
             {{- if .Values.sentry.worker.installAdditionalPackages }}
             pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
-            # Copy certificates from secret to /usr/local/share/ca-certificates/
             mkdir -p /usr/local/share/ca-certificates/
-            cp /etc/ssl/certs/* /usr/local/share/ca-certificates/
             for c in $(ls -1 /usr/local/share/ca-certificates/); do
                 cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
             done

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -76,10 +76,20 @@ spec:
       - name: {{ .Chart.Name }}-worker
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "worker"
+          - |
+            {{- if .Values.sentry.worker.installAdditionalPackages }}
+            pip install django-multidb-router sentry-nodestore-elastic https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+            {{- end }}
+            # Copy certificates from secret to /usr/local/share/ca-certificates/
+            mkdir -p /usr/local/share/ca-certificates/
+            cp /etc/ssl/certs/* /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            sentry run worker
           {{- if .Values.sentry.worker.excludeQueues }}
           - "--exclude-queues"
           - "{{ .Values.sentry.worker.excludeQueues }}"
@@ -129,6 +139,11 @@ spec:
 {{- if .Values.sentry.worker.volumeMounts }}
 {{ toYaml .Values.sentry.worker.volumeMounts | indent 8 }}
 {{- end }}
+        {{- if .Values.sentry.worker.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
   {{- if .Values.sentry.worker.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.worker.livenessProbe.periodSeconds }}
@@ -191,5 +206,11 @@ spec:
       {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.worker.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.worker.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -250,8 +250,11 @@ sentry:
 
   worker:
     enabled: true
-    installAdditionalPackages: true
-    caCertificatesSecret: my-ca-certificates
+    # installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates
     # annotations: {}
     replicas: 1
     # concurrency: 4
@@ -292,7 +295,12 @@ sentry:
   # allows to dedicate some workers to specific queues
   workerEvents:
     ## If the number of exceptions increases, it is recommended to enable workerEvents
-    enabled: false
+    enabled: true
+    #  installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates
     # annotations: {}
     queues: "events.save_event,post_process_errors"
     ## When increasing the number of exceptions and enabling workerEvents, it is recommended to increase the number of their replicas
@@ -329,7 +337,12 @@ sentry:
 
   # allows to dedicate some workers to specific queues
   workerTransactions:
-    enabled: false
+    enabled: true
+    #  installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates
     # annotations: {}
     queues: "events.save_event_transaction,post_process_transactions"
     replicas: 1

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -250,6 +250,8 @@ sentry:
 
   worker:
     enabled: true
+    installAdditionalPackages: true
+    caCertificatesSecret: my-ca-certificates
     # annotations: {}
     replicas: 1
     # concurrency: 4

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -296,7 +296,7 @@ sentry:
   # allows to dedicate some workers to specific queues
   workerEvents:
     ## If the number of exceptions increases, it is recommended to enable workerEvents
-    enabled: true
+    enabled: false
     #  installAdditionalPackages:
     #   - django-multidb-router
     #   - sentry-nodestore-elastic
@@ -339,7 +339,7 @@ sentry:
 
   # allows to dedicate some workers to specific queues
   workerTransactions:
-    enabled: true
+    enabled: false
     #  installAdditionalPackages:
     #   - django-multidb-router
     #   - sentry-nodestore-elastic

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -254,6 +254,7 @@ sentry:
     #   - django-multidb-router
     #   - sentry-nodestore-elastic
     #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # kubectl create secret generic ca-certificates --from-file=you-certificates.crt=you-certificates.crt
     # caCertificatesSecret: ca-certificates
     # annotations: {}
     replicas: 1
@@ -300,6 +301,7 @@ sentry:
     #   - django-multidb-router
     #   - sentry-nodestore-elastic
     #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # kubectl create secret generic ca-certificates --from-file=you-certificates.crt=you-certificates.crt
     # caCertificatesSecret: ca-certificates
     # annotations: {}
     queues: "events.save_event,post_process_errors"
@@ -342,6 +344,7 @@ sentry:
     #   - django-multidb-router
     #   - sentry-nodestore-elastic
     #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # kubectl create secret generic ca-certificates --from-file=you-certificates.crt=you-certificates.crt
     # caCertificatesSecret: ca-certificates
     # annotations: {}
     queues: "events.save_event_transaction,post_process_transactions"


### PR DESCRIPTION
This pull request introduces several enhancements to the Sentry worker deployments:

1. **Additional Package Installation**: 
   - Workers now have the capability to install additional Python packages during startup. This is controlled by the `installAdditionalPackages` flag in the `values.yaml` file.
   - The following packages are installed if the flag is disabled:
     - `django-multidb-router`
     - `sentry-nodestore-elastic`
     - `sentry-s3-nodestore` (from a specific release)

2. **CA Certificates Management**:
   - Workers can now manage custom CA certificates by mounting a secret containing the certificates to `/usr/local/share/ca-certificates/`.
   - The certificates are then copied to the appropriate location and updated using `update-ca-certificates`.
   - This feature is controlled by the `caCertificatesSecret` field in the `values.yaml` file.

### Changes

- **Deployment Templates**:
  - Modified the `command` and `args` sections in the worker deployment templates to include a bash script that handles the installation of additional packages and CA certificates.
  - Added volume mounts and volume definitions for the CA certificates secret.

- **Values Configuration**:
  - Introduced new configuration options in the `values.yaml` file:
    - `sentry.worker.installAdditionalPackages`: Boolean flag to enable/disable the installation of additional packages.
    - `sentry.worker.caCertificatesSecret`: Name of the secret containing custom CA certificates.


### Check pip packages

```
pip list | grep -E 'django|nodestore'
django-crispy-forms                1.14.0
django_csp                         3.8
django-multidb-router              0.10
django-pg-zero-downtime-migrations 0.13
djangorestframework                3.15.2
sentry-nodestore-elastic           1.0.1
sentry-s3-nodestore                1.0.3
```

### Check certificates
```
import os
import ssl
import certifi
import re
from cryptography import x509
from cryptography.hazmat.backends import default_backend

def list_certificates():
    # Get the path to the cacert.pem file
    cacert_path = certifi.where()

    # Open the file containing the certificates
    with open(cacert_path, 'r') as f:
        pem_data = f.read()

    # Use a regular expression to extract certificates
    certificate_pattern = re.compile(r'-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE-----', re.DOTALL)
    certificates = certificate_pattern.findall(pem_data)

    # Display information about each certificate
    for i, cert_pem in enumerate(certificates):
        try:
            # Load and parse the certificate
            cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
            subject = cert.subject
            issuer = cert.issuer
            not_valid_before = cert.not_valid_before
            not_valid_after = cert.not_valid_after

            # Print certificate information
            print(f"Certificate #{i + 1}:")
            print(f"  Subject: {subject}")
            print(f"  Issuer: {issuer}")
            print(f"  Valid from: {not_valid_before}")
            print(f"  Valid until: {not_valid_after}")
            print()
        except Exception as e:
            # Print error message if there's an issue with the certificate
            print(f"Error processing certificate #{i + 1}: {e}")

# Example usage
list_certificates()
```