### PR TITLE
fix(clickhouse-chart): correct placement of internal_replication

### DIFF
--- a/charts/clickhouse/templates/configmap-config.yaml
+++ b/charts/clickhouse/templates/configmap-config.yaml
@@ -38,8 +38,8 @@ data:
             <{{ include "clickhouse.fullname" . }}>
             {{- range untilStep 0 (int .Values.clickhouse.replicas) 1 }}
                 <shard>
+                    <internal_replication>{{ $.Values.clickhouse.configmap.remote_servers.internal_replication | default "false" }}</internal_replication>
                     <replica>
-                        <internal_replication>{{ $.Values.clickhouse.configmap.remote_servers.internal_replication | default "false" }}</internal_replication>
                         <host>{{ include "clickhouse.fullname" $ }}-{{ . }}.{{ include "clickhouse.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}</host>
                         <port>{{ $.Values.clickhouse.tcp_port}}</port>
                       {{- if $.Values.clickhouse.configmap.remote_servers.replica.user }}

--- a/charts/clickhouse/templates/configmap-metrika.yaml
+++ b/charts/clickhouse/templates/configmap-metrika.yaml
@@ -37,8 +37,8 @@ data:
             <{{ include "clickhouse.fullname" . }}>
             {{- range untilStep 0 (int .Values.clickhouse.replicas) 1 }}
                 <shard>
+                    <internal_replication>{{ $.Values.clickhouse.configmap.remote_servers.internal_replication | default "false" }}</internal_replication>
                     <replica>
-                        <internal_replication>{{ $.Values.clickhouse.configmap.remote_servers.internal_replication | default "false" }}</internal_replication>
                         <host>{{ include "clickhouse.fullname" $ }}-{{ . }}.{{ include "clickhouse.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}</host>
                         <port>{{ $.Values.clickhouse.tcp_port}}</port>
                       {{- if $.Values.clickhouse.configmap.remote_servers.replica.user }}


### PR DESCRIPTION
This PR addresses a configuration issue in the ClickHouse chart where the internal_replication setting was incorrectly placed inside the "replica" tag. The correct placement for internal_replication is inside the "shard" tag, as per the expected configuration schema.