### PR TITLE
feat: add Kafka topics from upstream projects (Sentry and Snuba) for version 24.9.0

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2060,7 +2060,9 @@ kafka:
         config:
           "message.timestamp.type": LogAppendTime
       - name: outcomes
+      - name: outcomes-dlq
       - name: outcomes-billing
+      - name: outcomes-billing-dlq
       - name: ingest-sessions
       - name: snuba-sessions-commit-log
         config:
@@ -2077,6 +2079,7 @@ kafka:
       - name: scheduled-subscriptions-generic-metrics-sets
       - name: scheduled-subscriptions-generic-metrics-distributions
       - name: scheduled-subscriptions-generic-metrics-counters
+      - name: scheduled-subscriptions-generic-metrics-gauges
       - name: events-subscription-results
       - name: transactions-subscription-results
       - name: sessions-subscription-results
@@ -2108,6 +2111,10 @@ kafka:
         config:
           "cleanup.policy": "compact,delete"
           "min.compaction.lag.ms": "3600000"
+      - name: snuba-generic-metrics-gauges-commit-log
+        config:
+          "cleanup.policy": "compact,delete"
+          "min.compaction.lag.ms": "3600000"
       - name: generic-events
         config:
           "message.timestamp.type": LogAppendTime
@@ -2127,19 +2134,33 @@ kafka:
       - name: snuba-dead-letter-querylog
       - name: snuba-dead-letter-group-attributes
       - name: ingest-attachments
+      - name: ingest-attachments-dlq
+      - name: ingest-feedback-events
+      - name: ingest-feedback-events-dlq
+      - name: ingest-generic-metrics-dlq
       - name: ingest-transactions
+      - name: ingest-transactions-dlq
+      - name: ingest-events-dlq
       - name: ingest-events
         ## If the number of exceptions increases, it is recommended to increase the number of partitions for ingest-events
         # partitions: 1
       - name: ingest-replay-recordings
       - name: ingest-metrics
-      - name: ingest-performance-metrics
+      - name: ingest-metrics-dlq
+      - name: ingest-performance-metrics # ingest-generic-metrics-dlq
       - name: ingest-monitors
+      - name: monitors-clock-tasks
+      - name: monitors-clock-tick
       - name: profiles
       - name: ingest-occurrences
       - name: snuba-spans
       - name: shared-resources-usage
       - name: snuba-metrics-summaries
+      - name: snuba-profile-chunks
+      - name: buffered-segments
+      - name: buffered-segments-dlq
+      - name: uptime-configs
+      - name: uptime-results
   listeners:
     client:
       protocol: "PLAINTEXT"


### PR DESCRIPTION
This pull request introduces new Kafka topics and updates existing ones based on the latest changes from the upstream projects Sentry and Snuba (version 24.9.0). The following changes have been made:

- **New Topics Added:**
  - `outcomes-dlq`
  - `outcomes-billing-dlq`
  - `scheduled-subscriptions-generic-metrics-gauges`
  - `snuba-generic-metrics-gauges-commit-log`
  - `ingest-attachments-dlq`
  - `ingest-feedback-events`
  - `ingest-feedback-events-dlq`
  - `ingest-generic-metrics-dlq`
  - `ingest-transactions-dlq`
  - `ingest-events-dlq`
  - `ingest-metrics-dlq`
  - `monitors-clock-tasks`
  - `monitors-clock-tick`
  - `snuba-profile-chunks`
  - `buffered-segments`
  - `buffered-segments-dlq`
  - `uptime-configs`
  - `uptime-results`

- **Updates to Existing Topics:**
  - Added DLQ support and additional configurations for topics like `ingest-events`, `ingest-transactions`, and others.

These changes are necessary to align with the latest features and improvements in the upstream projects, ensuring compatibility and support for new functionalities.

**Additional Notes:**
- This PR is part of the migration to version 24.9.0 of Sentry and Snuba.
- Please review the changes carefully to ensure no unintended side effects.