### PR TITLE
feat: add Kafka topics from upstream projects (Sentry and Snuba) for version 24.9.0

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2100,7 +2100,9 @@ kafka:
         config:
           "message.timestamp.type": LogAppendTime
       - name: outcomes
+      - name: outcomes-dlq
       - name: outcomes-billing
+      - name: outcomes-billing-dlq
       - name: ingest-sessions
       - name: snuba-sessions-commit-log
         config:
@@ -2117,6 +2119,7 @@ kafka:
       - name: scheduled-subscriptions-generic-metrics-sets
       - name: scheduled-subscriptions-generic-metrics-distributions
       - name: scheduled-subscriptions-generic-metrics-counters
+      - name: scheduled-subscriptions-generic-metrics-gauges
       - name: events-subscription-results
       - name: transactions-subscription-results
       - name: sessions-subscription-results
@@ -2148,6 +2151,10 @@ kafka:
         config:
           "cleanup.policy": "compact,delete"
           "min.compaction.lag.ms": "3600000"
+      - name: snuba-generic-metrics-gauges-commit-log
+        config:
+          "cleanup.policy": "compact,delete"
+          "min.compaction.lag.ms": "3600000"
       - name: generic-events
         config:
           "message.timestamp.type": LogAppendTime
@@ -2167,20 +2174,32 @@ kafka:
       - name: snuba-dead-letter-querylog
       - name: snuba-dead-letter-group-attributes
       - name: ingest-attachments
+      - name: ingest-attachments-dlq
       - name: ingest-transactions
+      - name: ingest-transactions-dlq
+      - name: ingest-events-dlq
       - name: ingest-events
         ## If the number of exceptions increases, it is recommended to increase the number of partitions for ingest-events
         # partitions: 1
       - name: ingest-replay-recordings
       - name: ingest-metrics
+      - name: ingest-metrics-dlq
       - name: ingest-performance-metrics
       - name: ingest-feedback-events
+      - name: ingest-feedback-events-dlq
       - name: ingest-monitors
+      - name: monitors-clock-tasks
+      - name: monitors-clock-tick
       - name: profiles
       - name: ingest-occurrences
       - name: snuba-spans
       - name: shared-resources-usage
       - name: snuba-metrics-summaries
+      - name: snuba-profile-chunks
+      - name: buffered-segments
+      - name: buffered-segments-dlq
+      - name: uptime-configs
+      - name: uptime-results
   listeners:
     client:
       protocol: "PLAINTEXT"


### PR DESCRIPTION
This pull request introduces new Kafka topics and updates existing ones based on upstream commits from Sentry and Snuba version 24.9.0. 

Topic from files:
https://github.com/getsentry/snuba/blob/24.9.0/snuba/utils/streams/topics.py
https://github.com/getsentry/sentry/blob/24.9.0/src/sentry/conf/server.py

The following changes have been made:

- **New Topics Added:**
  - `outcomes-dlq`
  - `outcomes-billing-dlq`
  - `scheduled-subscriptions-generic-metrics-gauges`
  - `snuba-generic-metrics-gauges-commit-log`
  - `ingest-attachments-dlq`
  - `ingest-feedback-events`
  - `ingest-feedback-events-dlq`
  - `ingest-generic-metrics-dlq`
  - `ingest-transactions-dlq`
  - `ingest-events-dlq`
  - `ingest-metrics-dlq`
  - `monitors-clock-tasks`
  - `monitors-clock-tick`
  - `snuba-profile-chunks`
  - `buffered-segments`
  - `buffered-segments-dlq`
  - `uptime-configs`
  - `uptime-results`

**Upstream Commits:**
- https://github.com/getsentry/snuba/commit/219fd2ccb3b725f629171709e690d745524424cd
- https://github.com/getsentry/snuba/commit/83f3d5a50d2ca59cf13b9a56075a2ed4e3923b3d
- https://github.com/getsentry/sentry/commit/ff45ba469b923df325f86a29612efd1f50dc0fa1
- https://github.com/getsentry/sentry/commit/27d14dbbd733cdfe26a7baa252de51bec57db8f6
- https://github.com/getsentry/sentry/commit/7fcded83ffde5414433e0edf9291d22b6afcb03b
- https://github.com/getsentry/sentry/commit/d11d5854aedcb3688d1c2ecbfd2a4156a4f9ab7b
- https://github.com/getsentry/sentry/commit/21831a3a2935e295dfdcf40f800c77119fd90886
- https://github.com/getsentry/sentry/commit/b85278de324b3b2514d07cce3ce55bfd19a6cba9
- https://github.com/getsentry/sentry/commit/2c12dad0607d6d7f8c557f39af3cd5c554a4716e
- https://github.com/getsentry/sentry/commit/d0505f013fd406258ce986a444967b32351d0ae1
- https://github.com/getsentry/sentry/commit/46c6c18bdf39c63435fd6c219e3333e56c8565a4
