### PR TITLE
feat: update Sentry chart to appVersion 24.10.0

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
-  version: 3.13.0
+  version: 3.14.0
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.4.11
@@ -23,5 +23,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:df4a8d1128f8b3319c8c10a5a8202a691fe95fb28f92b193dcafcdbf0c6636eb
-generated: "2024-11-11T00:18:02.524127944Z"
+digest: sha256:7cf8aeed33089ff05f42054b5a49310f9d38d01eab349cc27f8c0df57eb91d9d
+generated: "2025-01-03T12:42:03.873408284+06:00"

--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
-  version: 3.14.0
+  version: 3.13.0
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.4.11
@@ -23,5 +23,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:7cf8aeed33089ff05f42054b5a49310f9d38d01eab349cc27f8c0df57eb91d9d
-generated: "2025-01-03T12:42:03.873408284+06:00"
+digest: sha256:df4a8d1128f8b3319c8c10a5a8202a691fe95fb28f92b193dcafcdbf0c6636eb
+generated: "2024-11-11T00:18:02.524127944Z"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry
 description: A Helm chart for Kubernetes
 type: application
 version: 26.9.1
-appVersion: 24.9.0
+appVersion: 24.10.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
-    version: 3.13.0
+    version: 3.14.0
     condition: clickhouse.enabled
   - name: zookeeper
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
-    version: 3.14.0
+    version: 3.13.0
     condition: clickhouse.enabled
   - name: zookeeper
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2193,6 +2193,10 @@ kafka:
       - name: profiles
       - name: ingest-occurrences
       - name: snuba-spans
+      - name: snuba-eap-spans-commit-log
+      - name: scheduled-subscriptions-eap-spans
+      - name: eap-spans-subscription-results
+      - name: snuba-eap-mutations
       - name: shared-resources-usage
       - name: snuba-metrics-summaries
       - name: snuba-profile-chunks


### PR DESCRIPTION
This PR updates the Sentry Helm chart to use the latest appVersion `24.10.0`. 

The changes include:
- Updated `appVersion` from `24.9.0` to `24.10.0`.

- Added new Kafka topics required for the new Snuba version:
  - `snuba-eap-spans-commit-log`
  - `scheduled-subscriptions-eap-spans`
  - `eap-spans-subscription-results`
  - `snuba-eap-mutations`

These changes are based on the comparison between Snuba versions `24.9.0` and `24.10.0` (see [diff](https://github.com/getsentry/snuba/compare/24.9.0...24.10.0)).

Please review and merge this PR to ensure compatibility with the latest Sentry and Snuba releases.