### PR TITLE
fix clickhouse-chart for correct placement of internal_replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+

--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
-  version: 3.14.0
+  version: 3.14.1
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.4.11
@@ -23,5 +23,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:7cf8aeed33089ff05f42054b5a49310f9d38d01eab349cc27f8c0df57eb91d9d
-generated: "2025-01-06T01:36:52.739851807Z"
+digest: sha256:2b19e9605468921ff96afb9f393ffe09d3121e5b91f32789e025851f0b66ff63
+generated: "2025-01-17T18:17:43.022337376+06:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
-    version: 3.14.0
+    version: 3.14.1
     condition: clickhouse.enabled
   - name: zookeeper
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
Update clickhouse chart to 3.14.1 for fix correct placement of internal_replication
https://github.com/sentry-kubernetes/charts/pull/1633