### PR TITLE
docs: Add clarifying comments for secret management and external service configurations

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -460,9 +460,9 @@ Set Kafka bootstrap servers string
 
 {{/*
 SASL auth setings for Kafka:
-* https://github.com/getsentry/snuba/blob/24.9.0/snuba/settings/__init__.py#L220-L230
-* https://github.com/getsentry/sentry/blob/24.9.0/src/sentry/utils/kafka_config.py#L9-L34
-* https://github.com/getsentry/sentry/blob/24.9.0/src/sentry/conf/server.py#L2844-L2853
+* https://github.com/getsentry/snuba/blob/24.11.2/snuba/settings/__init__.py#L220-L230
+* https://github.com/getsentry/sentry/blob/24.11.2/src/sentry/utils/kafka_config.py#L9-L34
+* https://github.com/getsentry/sentry/blob/24.11.2/src/sentry/conf/server.py#L2844-L2853
 */}}
 
 {{/*
@@ -593,6 +593,10 @@ Common Snuba environment variables
 {{- end }}
 - name: KAFKA_SECURITY_PROTOCOL
   value: {{ include "sentry.kafka.security_protocol" . | quote }}
+
+{{/*
+Set external Redis password from existingSecret
+*/}}
 {{- if and (.Values.redis.enabled) (.Values.redis.auth.enabled) }}
 {{- if .Values.redis.auth.password }}
 - name: REDIS_PASSWORD
@@ -614,6 +618,10 @@ Common Snuba environment variables
       name: {{ .Values.externalRedis.existingSecret }}
       key: {{ default "redis-password" .Values.externalRedis.existingSecretKey }}
 {{- end }}
+
+{{/*
+Set external Clickhouse password from existingSecret
+*/}}
 {{- if .Values.externalClickhouse.existingSecret }}
 - name: CLICKHOUSE_PASSWORD
   valueFrom:
@@ -667,6 +675,10 @@ Common Sentry environment variables
       name: {{ template "sentry.fullname" . }}-sentry-secret
       key: "key"
 {{- end }}
+
+{{/*
+Set external Postgresql password from existingSecret
+*/}}
 {{- if .Values.postgresql.enabled }}
 - name: POSTGRES_PASSWORD
   valueFrom:
@@ -683,6 +695,10 @@ Common Sentry environment variables
       name: {{ .Values.externalPostgresql.existingSecret }}
       key: {{ or .Values.externalPostgresql.existingSecretKeys.password .Values.externalPostgresql.existingSecretKey "postgresql-password" }}
 {{- end }}
+
+{{/*
+Set external Postgresql user from existingSecret
+*/}}
 {{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.username }}
 - name: POSTGRES_USER
   valueFrom:
@@ -693,6 +709,10 @@ Common Sentry environment variables
 - name: POSTGRES_USER
   value: {{ include "sentry.postgresql.username" . | quote }}
 {{- end }}
+
+{{/*
+Set external Postgresql name from existingSecret
+*/}}
 {{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.database }}
 - name: POSTGRES_NAME
   valueFrom:
@@ -703,6 +723,10 @@ Common Sentry environment variables
 - name: POSTGRES_NAME
   value: {{ include "sentry.postgresql.database" . | quote }}
 {{- end }}
+
+{{/*
+Set external Postgresql host from existingSecret
+*/}}
 {{- if .Values.pgbouncer.enabled }}
 - name: POSTGRES_HOST
   value: {{ template "sentry.fullname" . }}-pgbouncer
@@ -718,6 +742,10 @@ Common Sentry environment variables
   value: {{ include "sentry.postgresql.host" . | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Set external Postgresql port from existingSecret
+*/}}
 {{- if .Values.pgbouncer.enabled }}
 - name: POSTGRES_PORT
   value: "5432"
@@ -733,6 +761,10 @@ Common Sentry environment variables
   value: {{ include "sentry.postgresql.port" . | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Set S3
+*/}}
 {{- if and (eq .Values.filestore.backend "s3") .Values.filestore.s3.existingSecret }}
 - name: S3_ACCESS_KEY_ID
   valueFrom:
@@ -745,6 +777,10 @@ Common Sentry environment variables
       name: {{ .Values.filestore.s3.existingSecret }}
       key: {{ default "s3-secret-access-key" .Values.filestore.s3.secretAccessKeyRef }}
 {{- end }}
+
+{{/*
+Set redis password
+*/}}
 {{- if .Values.redis.enabled }}
 {{- if .Values.redis.password }}
 - name: REDIS_PASSWORD
@@ -766,6 +802,8 @@ Common Sentry environment variables
       name: {{ .Values.externalRedis.existingSecret }}
       key: {{ default "redis-password" .Values.externalRedis.existingSecretKey }}
 {{- end }}
+
+
 {{- if and (.Values.redis.enabled) (.Values.redis.auth.existingSecret) }}
 - name: HELM_CHARTS_SENTRY_REDIS_PASSWORD_CONTROLLED
   valueFrom:
@@ -783,10 +821,18 @@ Common Sentry environment variables
 - name: BROKER_URL
   value: "{{ $redisProto }}://:$(HELM_CHARTS_SENTRY_REDIS_PASSWORD_CONTROLLED)@{{ $redisHost }}:{{ $redisPort }}/{{ $redisDb }}"
 {{- end }}
+
+{{/*
+Set google application
+*/}}
 {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
 {{- end }}
+
+{{/*
+Set sentry email password
+*/}}
 {{- if .Values.mail.password }}
 - name: SENTRY_EMAIL_PASSWORD
   value: {{ .Values.mail.password | quote }}
@@ -797,6 +843,10 @@ Common Sentry environment variables
       name: {{ .Values.mail.existingSecret }}
       key: {{ default "mail-password" .Values.mail.existingSecretKey }}
 {{- end }}
+
+{{/*
+Set slack
+*/}}
 {{- if .Values.slack.existingSecret }}
 - name: SLACK_CLIENT_ID
   valueFrom:
@@ -814,6 +864,10 @@ Common Sentry environment variables
       name: {{ .Values.slack.existingSecret }}
       key: {{ default "signing-secret" .Values.slack.existingSecretSigningSecret }}
 {{- end }}
+
+{{/*
+Set discord
+*/}}
 {{- if .Values.discord.existingSecret }}
 - name: DISCORD_APPLICATION_ID
   valueFrom:
@@ -836,6 +890,10 @@ Common Sentry environment variables
       name: {{ .Values.discord.existingSecret }}
       key: {{ default "bot-token" .Values.discord.existingSecretBotToken }}
 {{- end }}
+
+{{/*
+Set github app
+*/}}
 {{- if and .Values.github.existingSecret }}
 - name: GITHUB_APP_PRIVATE_KEY
   valueFrom:
@@ -858,6 +916,10 @@ Common Sentry environment variables
       name: {{ .Values.github.existingSecret }}
       key: {{ default "client-secret" .Values.github.existingSecretClientSecretKey }}
 {{- end }}
+
+{{/*
+Set google auth
+*/}}
 {{- if .Values.google.existingSecret }}
 - name: GOOGLE_AUTH_CLIENT_ID
   valueFrom:
@@ -870,6 +932,10 @@ Common Sentry environment variables
       name: {{ .Values.google.existingSecret }}
       key: {{ default "client-secret" .Values.google.existingSecretClientSecretKey }}
 {{- end }}
+
+{{/*
+Set openai api
+*/}}
 {{- if .Values.openai.existingSecret }}
 - name: OPENAI_API_KEY
   valueFrom:


### PR DESCRIPTION
Added comments to _helper.tpl for:

- Secret management (Redis, Clickhouse, Postgresql, S3, GCS, Slack, Discord, GitHub, Google, OpenAI).
- Environment variable configuration (e.g., `REDIS_PASSWORD`, `CLICKHOUSE_PASSWORD`, `POSTGRES_PASSWORD`).
- File storage setup (S3, GCS).
- Email, Slack, and Discord integrations.
- GitHub and Google authentication.
- OpenAI API key management.