### PR TITLE
feat: add custom labels for ingress

### DIFF
--- a/charts/sentry/templates/ingress.yaml
+++ b/charts/sentry/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
  annotations:
    {{- range $key, $value := .Values.ingress.annotations }}
      {{ $key }}: {{ $value | quote }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1895,6 +1895,8 @@ ingress:
   # If you are using AWS ALB Ingress controller, switch to true if you want activate the http to https redirection.
   alb:
     httpRedirect: false
+  # Add custom labels for ingress resource
+  # labels:
   # annotations:
   #   If you are using nginx ingress controller, please use at least those 2 annotations
   #   kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
**Changes**:
  - [x] add ability to define custom labels for ingress resource

**Proposal**:
I use external DNS operator for manage DNS records.
 To allow external-dns manage DNS record for specific ingress resource we must create are custom label on ingress resource. 