### PR TITLE
feat: Update appVersion to 24.12.2 and add new Kafka topics

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry
 description: A Helm chart for Kubernetes
 type: application
 version: 26.11.2
-appVersion: 24.11.2
+appVersion: 24.12.2
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2171,6 +2171,7 @@ kafka:
       - name: ingest-attachments-dlq
       - name: ingest-transactions
       - name: ingest-transactions-dlq
+      - name: ingest-transactions-backlog
       - name: ingest-events-dlq
       - name: ingest-events
         ## If the number of exceptions increases, it is recommended to increase the number of partitions for ingest-events
@@ -2199,6 +2200,7 @@ kafka:
       - name: buffered-segments-dlq
       - name: uptime-configs
       - name: uptime-results
+      - name: snuba-uptime-results
       - name: task-worker
   listeners:
     client:


### PR DESCRIPTION
### Pull Request Description:
This pull request updates the `appVersion` to `24.12.2` and introduces new Kafka topics based on the latest changes from Sentry and Snuba. The following changes have been made:

- **Updated `appVersion` to 24.12.2** in `Chart.yaml`.
- **New Kafka Topics Added:**
  - `ingest-transactions-backlog`
  - `snuba-uptime-results`

Topic from files:
https://github.com/getsentry/snuba/blob/24.12.2/snuba/utils/streams/topics.py
https://github.com/getsentry/sentry/blob/24.12.2/src/sentry/conf/server.py

Thank you for your time and review!