### PR TITLE
Add missing block in ingest-consumer-transactions

### DIFF
--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -189,6 +189,9 @@ spec:
 {{- if .Values.sentry.ingestConsumerTransactions.volumes }}
 {{ toYaml .Values.sentry.ingestConsumerTransactions.volumes | indent 6 }}
 {{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
       {{- if .Values.sentry.ingestConsumerTransactions.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestConsumerTransactions.priorityClassName }}"
       {{- end }}


### PR DESCRIPTION
Missing block in ingest-consumer-transactions `.Values.global.volumes`