### PR TITLE
Added nameOverride for nginx to correctly read nginx ConfigMap

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1855,6 +1855,7 @@ openai: {}
 nginx:
   enabled: true  # true, if Safari compatibility is needed
   containerPort: 8080
+  nameOverride: sentry-nginx
   existingServerBlockConfigmap: '{{ template "sentry.fullname" . }}'
   resources: {}
   replicaCount: 1


### PR DESCRIPTION
nginx section in values.yaml was missing nameOverride which was used in referencing for ConfigMap in existingServerBlockConfigmap. When using default values.yaml deploying Chart failed as ConfigMap couldn't be found.
For example using release name "myrelease" there was created "myrelease-sentry-nginx" ConfigMap and nginx pod was looking for "myrelease" configMap