### PR TITLE
feat: Add monitorsClockTasks and monitorsClockTick

### DIFF
--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -1,0 +1,179 @@
+{{- if .Values.sentry.monitorsClockTasks.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-monitors-clock-tasks
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "sentry.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: monitors-clock-tasks
+{{- if not .Values.sentry.monitorsClockTasks.autoscaling.enabled }}
+  replicas: {{ .Values.sentry.monitorsClockTasks.replicas }}
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include "sentry.config" . | sha256sum }}
+        {{- if .Values.sentry.monitorsClockTasks.annotations }}
+{{ toYaml .Values.sentry.monitorsClockTasks.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: monitors-clock-tasks
+        {{- if .Values.sentry.monitorsClockTasks.podLabels }}
+{{ toYaml .Values.sentry.monitorsClockTasks.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.monitorsClockTasks.affinity }}
+{{ toYaml .Values.sentry.monitorsClockTasks.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTasks.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.monitorsClockTasks.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTasks.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.monitorsClockTasks.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTasks.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.sentry.monitorsClockTasks.topologySpreadConstraints | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTasks.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.monitorsClockTasks.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-monitors-clock-tasks
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "consumer"
+          - "monitors-clock-tasks"
+          - "--consumer-group"
+          - "monitors-clock-tasks"
+          {{- if .Values.sentry.monitorsClockTasks.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.sentry.monitorsClockTasks.autoOffsetReset }}"
+          {{- end }}
+          {{- if .Values.sentry.monitorsClockTasks.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
+          {{- if .Values.sentry.monitorsClockTasks.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.monitorsClockTasks.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.periodSeconds }}
+        {{- end }}
+        env:
+        - name: C_FORCE_ROOT
+          value: "true"
+{{ include "sentry.env" . | indent 8 }}
+{{- if .Values.sentry.monitorsClockTasks.env }}
+{{ toYaml .Values.sentry.monitorsClockTasks.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- if .Values.sentry.monitorsClockTasks.volumeMounts }}
+{{ toYaml .Values.sentry.monitorsClockTasks.volumeMounts | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.sentry.monitorsClockTasks.resources | indent 12 }}
+{{- if .Values.sentry.monitorsClockTasks.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.monitorsClockTasks.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if .Values.sentry.monitorsClockTasks.sidecars }}
+{{ toYaml .Values.sentry.monitorsClockTasks.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-monitors-clock-tasks
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+{{- if .Values.sentry.monitorsClockTasks.volumes }}
+{{ toYaml .Values.sentry.monitorsClockTasks.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+      {{- if .Values.sentry.monitorsClockTasks.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.monitorsClockTasks.priorityClassName }}"
+      {{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -1,0 +1,179 @@
+{{- if .Values.sentry.monitorsClockTick.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-monitors-clock-tick
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "sentry.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: monitors-clock-tick
+{{- if not .Values.sentry.monitorsClockTick.autoscaling.enabled }}
+  replicas: {{ .Values.sentry.monitorsClockTick.replicas }}
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include "sentry.config" . | sha256sum }}
+        {{- if .Values.sentry.monitorsClockTick.annotations }}
+{{ toYaml .Values.sentry.monitorsClockTick.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: monitors-clock-tick
+        {{- if .Values.sentry.monitorsClockTick.podLabels }}
+{{ toYaml .Values.sentry.monitorsClockTick.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.monitorsClockTick.affinity }}
+{{ toYaml .Values.sentry.monitorsClockTick.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTick.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.monitorsClockTick.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTick.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.monitorsClockTick.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTick.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.sentry.monitorsClockTick.topologySpreadConstraints | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.monitorsClockTick.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.monitorsClockTick.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-monitors-clock-tick
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "consumer"
+          - "monitors-clock-tick"
+          - "--consumer-group"
+          - "monitors-clock-tick"
+          {{- if .Values.sentry.monitorsClockTick.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.sentry.monitorsClockTick.autoOffsetReset }}"
+          {{- end }}
+          {{- if .Values.sentry.monitorsClockTick.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
+          {{- if .Values.sentry.monitorsClockTick.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.monitorsClockTick.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.periodSeconds }}
+        {{- end }}
+        env:
+        - name: C_FORCE_ROOT
+          value: "true"
+{{ include "sentry.env" . | indent 8 }}
+{{- if .Values.sentry.monitorsClockTick.env }}
+{{ toYaml .Values.sentry.monitorsClockTick.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- if .Values.sentry.monitorsClockTick.volumeMounts }}
+{{ toYaml .Values.sentry.monitorsClockTick.volumeMounts | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.sentry.monitorsClockTick.resources | indent 12 }}
+{{- if .Values.sentry.monitorsClockTick.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.monitorsClockTick.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if .Values.sentry.monitorsClockTick.sidecars }}
+{{ toYaml .Values.sentry.monitorsClockTick.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-monitors-clock-tick
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+{{- if .Values.sentry.monitorsClockTick.volumes }}
+{{ toYaml .Values.sentry.monitorsClockTick.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+      {{- if .Values.sentry.monitorsClockTick.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.monitorsClockTick.priorityClassName }}"
+      {{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTasks.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-monitors-clock-tasks
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTick.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-monitors-clock-tick
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -651,6 +651,68 @@ sentry:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
+  monitorsClockTasks:
+    enabled: false
+    replicas: 1
+    env: []
+    resources: {}
+    #  requests:
+    #    cpu: 100m
+    #    memory: 250Mi
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    containerSecurityContext: {}
+    # tolerations: []
+    # podLabels: {}
+    # it's better to use prometheus adapter and scale based on
+    # the size of the rabbitmq queue
+    autoscaling:
+      enabled: false
+    sidecars: []
+    topologySpreadConstraints: []
+    volumes: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
+
+  monitorsClockTick:
+    enabled: false
+    replicas: 1
+    env: []
+    resources: {}
+    #  requests:
+    #    cpu: 100m
+    #    memory: 250Mi
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    containerSecurityContext: {}
+    # tolerations: []
+    # podLabels: {}
+    # it's better to use prometheus adapter and scale based on
+    # the size of the rabbitmq queue
+    autoscaling:
+      enabled: false
+    sidecars: []
+    topologySpreadConstraints: []
+    volumes: []
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
+
   billingMetricsConsumer:
     enabled: true
     replicas: 1


### PR DESCRIPTION
This PR introduces new configurations for `monitorsClockTasks` and `monitorsClockTick` in the Sentry Helm chart.

### Related Issues
- #1660

install:
```
helm install -n test --wait sentry . --values values.yaml --timeout=1000s 
coalesce.go:237: warning: skipped value for kafka.config: Not a table.
NAME: sentry
LAST DEPLOYED: Fri Jan 31 10:02:20 2025
NAMESPACE: test
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
* When running upgrades, make sure to give back the `system.secretKey` value.

kubectl -n test get configmap sentry-sentry -o json | grep -m1 -Po '(?<=system.secret-key: )[^\\]*'
```

pods:
```
k get pod -n test
NAME                                                              READY   STATUS    RESTARTS      AGE
sentry-billing-metrics-consumer-68547ddc4-wg2cz                   1/1     Running   0             10m
sentry-clickhouse-0                                               1/1     Running   0             29m
sentry-cron-779498d85f-ph977                                      1/1     Running   1 (28m ago)   29m
sentry-generic-metrics-consumer-745f8c6946-zkv7z                  1/1     Running   0             10m
sentry-ingest-consumer-attachments-5d9d54c97b-sz4ql               1/1     Running   0             10m
sentry-ingest-consumer-events-6d85975b7c-7bhjh                    1/1     Running   0             10m
sentry-ingest-consumer-transactions-84bc4f5b57-27fmp              1/1     Running   0             10m
sentry-ingest-monitors-58cbc67c5b-lw9w4                           1/1     Running   0             10m
sentry-ingest-occurrences-86954868f6-xlmv8                        1/1     Running   0             10m
sentry-ingest-replay-recordings-56f6d8b67b-lkln2                  1/1     Running   0             10m
sentry-issue-occurrence-consumer-5f955bd8d8-c5cvx                 1/1     Running   0             10m
sentry-kafka-controller-0                                         1/1     Running   0             29m
sentry-kafka-controller-1                                         1/1     Running   0             29m
sentry-kafka-controller-2                                         1/1     Running   0             29m
sentry-metrics-consumer-5dc874bbc4-cmpml                          1/1     Running   0             10m
sentry-monitors-clock-tasks-6b8c564b64-kcxbl                      1/1     Running   0             10m
sentry-monitors-clock-tick-64f89c5f8d-9ct4b                       1/1     Running   0             10m
sentry-nginx-78665d4559-jwtch                                     1/1     Running   0             29m
sentry-post-process-forward-errors-7c5f58666f-hlh6x               1/1     Running   0             10m
sentry-post-process-forward-issue-platform-74c6b9bb9d-7jlqw       1/1     Running   0             10m
sentry-post-process-forward-transactions-7d97677bfb-rjqzj         1/1     Running   0             10m
sentry-rabbitmq-0                                                 1/1     Running   0             29m
sentry-relay-5c9b6d85dc-n7sz5                                     1/1     Running   0             10m
sentry-sentry-postgresql-0                                        1/1     Running   0             29m
sentry-sentry-redis-master-0                                      1/1     Running   0             29m
sentry-sentry-redis-replicas-0                                    1/1     Running   0             29m
sentry-snuba-api-7cb8b475d7-hf2mr                                 1/1     Running   0             29m
sentry-snuba-consumer-7df945cd6b-9vt8s                            1/1     Running   0             10m
sentry-snuba-generic-metrics-counters-consumer-97bc96f78-xn97q    1/1     Running   0             10m
sentry-snuba-generic-metrics-distributions-consumer-7545d42xxdj   1/1     Running   0             10m
sentry-snuba-generic-metrics-sets-consumer-d55c68f78-zrfgq        1/1     Running   0             10m
sentry-snuba-group-attributes-consumer-5584547564-w954x           1/1     Running   0             10m
sentry-snuba-metrics-consumer-9f7949df9-mk4ht                     1/1     Running   0             10m
sentry-snuba-outcomes-billing-consumer-dd5cc49c-8dhlt             1/1     Running   0             10m
sentry-snuba-outcomes-consumer-64875df5dc-w42jq                   1/1     Running   0             10m
sentry-snuba-replacer-68dc4fd4b5-ljfm4                            1/1     Running   0             10m
sentry-snuba-replays-consumer-867576f857-5pgm8                    1/1     Running   0             10m
sentry-snuba-spans-consumer-fb8c78bd4-qnrdh                       1/1     Running   0             10m
sentry-snuba-subscription-consumer-events-656d7cf65b-bstb6        1/1     Running   0             10m
sentry-snuba-subscription-consumer-metrics-94f9bccdc-vlbjt        1/1     Running   0             10m
sentry-snuba-subscription-consumer-transactions-5456f7bd76fmz4t   1/1     Running   0             10m
sentry-snuba-transactions-consumer-7f6b5b57cd-jthv6               1/1     Running   0             10m
sentry-subscription-consumer-events-6678c858cd-rbhbg              1/1     Running   0             10m
sentry-subscription-consumer-generic-metrics-56b55f945f-487fn     1/1     Running   0             10m
sentry-subscription-consumer-metrics-847ffb877f-n6n92             1/1     Running   0             10m
sentry-subscription-consumer-transactions-56d48c5f86-m5pvj        1/1     Running   0             10m
sentry-web-56d6b57967-kthbc                                       1/1     Running   0             29m
sentry-worker-6bfc5fb544-lw628                                    1/1     Running   1 (28m ago)   29m
sentry-zookeeper-clickhouse-0                                     1/1     Running   0             29m
```