### PR TITLE
docs:  Added existingSecret comment in Sentry values.yaml

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1828,36 +1828,36 @@ google: {}
 #   clientId: ""
 #   clientSecret: ""
 #   existingSecret: ""
-#   existingSecretClientIdKey: ""     # by default "client-id"
-#   existingSecretClientSecretKey: "" # by default "client-secret"
+#   existingSecretClientIdKey: ""       # by default "client-id"
+#   existingSecretClientSecretKey: ""   # by default "client-secret"
 
 slack: {}
 # slack:
-#   clientId:
-#   clientSecret:
-#   signingSecret:
-#   existingSecret:
-#   existingSecretClientId:           # by default "client-id"
-#   existingSecretClientSecret:       # by default "client-secret"
-#   existingSecretSigningSecret       # by default "signing-secret"
+#   clientId: ""
+#   clientSecret: ""
+#   signingSecret: ""
+#   existingSecret: ""
+#   existingSecretClientId: ""          # by default "client-id"
+#   existingSecretClientSecret: ""      # by default "client-secret"
+#   existingSecretSigningSecret: ""     # by default "signing-secret"
 #   Reference -> https://develop.sentry.dev/integrations/slack/
 
 discord: {}
 # discord:
-#   applicationId:
-#   publicKey:
-#   clientSecret:
-#   botToken:
-#   existingSecret:
-#   existingSecretApplicationIdKey:   #by default "application-id"
-#   existingSecretPublicKeyKey:       #by default ""
-#   existingSecretClientSecretKey:    #by default "client-secret"
-#   existingSecretBotTokenKey:        #by default "bot-token"
+#   applicationId: ""
+#   publicKey: ""
+#   clientSecret: ""
+#   botToken: ""
+#   existingSecret: "xxxxx"
+#   existingSecretApplicationIdKey: ""  # by default "application-id"
+#   existingSecretPublicKeyKey: ""      # by default ""
+#   existingSecretClientSecretKey: ""   # by default "client-secret"
+#   existingSecretBotTokenKey: ""       # by default "bot-token"
 #   Reference -> https://develop.sentry.dev/integrations/discord/
 
 openai: {}
 #   existingSecret: "xxxxx"
-#   existingSecretKey: ""   # by default "api-token"
+#   existingSecretKey: ""               # by default "api-token"
 
 nginx:
   enabled: true  # true, if Safari compatibility is needed

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1827,7 +1827,7 @@ google: {}
 # google:
 #   clientId: ""
 #   clientSecret: ""
-#   existingSecret: ""
+#   existingSecret: "xxxxx"
 #   existingSecretClientIdKey: ""       # by default "client-id"
 #   existingSecretClientSecretKey: ""   # by default "client-secret"
 
@@ -1836,7 +1836,7 @@ slack: {}
 #   clientId: ""
 #   clientSecret: ""
 #   signingSecret: ""
-#   existingSecret: ""
+#   existingSecret: "xxxxx"
 #   existingSecretClientId: ""          # by default "client-id"
 #   existingSecretClientSecret: ""      # by default "client-secret"
 #   existingSecretSigningSecret: ""     # by default "signing-secret"
@@ -1849,10 +1849,10 @@ discord: {}
 #   clientSecret: ""
 #   botToken: ""
 #   existingSecret: "xxxxx"
-#   existingSecretApplicationIdKey: ""  # by default "application-id"
-#   existingSecretPublicKeyKey: ""      # by default ""
-#   existingSecretClientSecretKey: ""   # by default "client-secret"
-#   existingSecretBotTokenKey: ""       # by default "bot-token"
+#   existingSecretApplicationId: ""     # by default "application-id"
+#   existingSecretPublicKey: ""         # by default "public-key"
+#   existingSecretClientSecret: ""      # by default "client-secret"
+#   existingSecretBotToken: ""          # by default "bot-token"
 #   Reference -> https://develop.sentry.dev/integrations/discord/
 
 openai: {}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1828,7 +1828,7 @@ google: {}
 #   clientId: ""
 #   clientSecret: ""
 #   existingSecret: ""
-#   existingSecretClientIdKey: "" # by default "client-id"
+#   existingSecretClientIdKey: ""     # by default "client-id"
 #   existingSecretClientSecretKey: "" # by default "client-secret"
 
 slack: {}
@@ -1837,6 +1837,9 @@ slack: {}
 #   clientSecret:
 #   signingSecret:
 #   existingSecret:
+#   existingSecretClientId:           # by default "client-id"
+#   existingSecretClientSecret:       # by default "client-secret"
+#   existingSecretSigningSecret       # by default "signing-secret"
 #   Reference -> https://develop.sentry.dev/integrations/slack/
 
 discord: {}
@@ -1846,6 +1849,10 @@ discord: {}
 #   clientSecret:
 #   botToken:
 #   existingSecret:
+#   existingSecretApplicationIdKey:   #by default "application-id"
+#   existingSecretPublicKeyKey:       #by default ""
+#   existingSecretClientSecretKey:    #by default "client-secret"
+#   existingSecretBotTokenKey:        #by default "bot-token"
 #   Reference -> https://develop.sentry.dev/integrations/discord/
 
 openai: {}


### PR DESCRIPTION
### Background
When setting up Sentry configuration in values.yaml, I encountered difficulties due to the lack of concrete examples. Since it was unclear whether the configuration was implemented as expected, I had to dive into the source code to understand the correct configuration patterns.

### Proposed Changes
- Added comments and examples for existingSecret configuration in Sentry's values.yaml

