### PR TITLE
Add serviceaccount for hooks in sentry chart

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 26.14.1
+version: 26.14.2
 appVersion: 25.2.0
 dependencies:
   - name: memcached

--- a/charts/sentry/templates/hooks/hooks-serviceaccount.yaml
+++ b/charts/sentry/templates/hooks/hooks-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.hooks.enabled .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-hooks
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -43,6 +43,9 @@ spec:
 {{ toYaml .Values.hooks.dbCheck.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-hooks
+      {{- end }}
       {{- if .Values.hooks.dbCheck.affinity }}
       affinity:
 {{ toYaml .Values.hooks.dbCheck.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -39,6 +39,9 @@ spec:
 {{ toYaml .Values.hooks.dbInit.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-hooks
+      {{- end }}
       {{- if .Values.hooks.dbInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.dbInit.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -41,6 +41,9 @@ spec:
 {{ toYaml .Values.hooks.snubaInit.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-hooks
+      {{- end }}
       {{- if .Values.hooks.snubaInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.snubaInit.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -41,6 +41,9 @@ spec:
 {{ toYaml .Values.hooks.snubaMigrate.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-hooks
+      {{- end }}
       {{- if .Values.hooks.snubaInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.snubaInit.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -34,6 +34,9 @@ spec:
 {{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-hooks
+      {{- end }}
       {{- if .Values.hooks.dbInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.dbInit.affinity | indent 8 }}


### PR DESCRIPTION
Add a serviceaccount for the helm hooks in the sentry chart. 

Our clusters do not allow use of the default serviceaccounts, so we would love to get this implemented :)