### PR TITLE
chore(clickhouse): replace external exporter with embedded ClickHouse exporter

### DIFF
--- a/charts/clickhouse/templates/configmap-config.yaml
+++ b/charts/clickhouse/templates/configmap-config.yaml
@@ -89,6 +89,17 @@ data:
         <max_server_memory_usage>{{ .Values.clickhouse.configmap.max_server_memory_usage | default "0" }}</max_server_memory_usage>
         {{- end }}
 
+        {{- if .Values.clickhouse.metrics.enabled }}
+        <prometheus>
+          <endpoint>/metrics</endpoint>
+          <port>{{ .Values.clickhouse.metrics.port }}</port>
+          <metrics>true</metrics>
+          <events>true</events>
+          <asynchronous_metrics>true</asynchronous_metrics>
+          <errors>true</errors>
+        </prometheus>
+        {{- end }}
+
         <query_log>
             <database>system</database>
             <table>query_log</table>

--- a/charts/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/charts/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -74,6 +74,11 @@ spec:
           - -c
           - export SHARD=${HOSTNAME##*-} && /entrypoint.sh
         ports:
+        {{- if .Values.clickhouse.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ .Values.clickhouse.metrics.port }}
+          protocol: TCP
+        {{- end }}
         - name: http-port
           containerPort: {{ .Values.clickhouse.http_port | default "8123" }}
         - name: tcp-port
@@ -121,22 +126,6 @@ spec:
       {{- with .Values.clickhouse.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
-      {{- end }}
-        {{- if .Values.clickhouse.metrics.enabled }}
-      - name: prom-exporter
-        image: "{{ .Values.clickhouse.metrics.image.registry }}/{{ .Values.clickhouse.metrics.image.repository }}:{{ .Values.clickhouse.metrics.image.tag }}"
-        imagePullPolicy: {{ .Values.clickhouse.metrics.image.pullPolicy | quote }}
-        ports:
-          - name: metrics
-            containerPort: {{ .Values.clickhouse.metrics.image.port }}
-            protocol: TCP
-        {{- if .Values.clickhouse.metrics.resources }}
-{{- if .Values.clickhouse.metrics.volumeMounts }}
-        volumeMounts:
-{{ toYaml .Values.clickhouse.metrics.volumeMounts | indent 8 }}
-{{- end }}
-        resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 8 }}
-        {{- end }}
       {{- end }}
     {{- if .Values.clickhouse.nodeSelector }}
       nodeSelector:

--- a/charts/clickhouse/templates/statefulset-clickhouse.yaml
+++ b/charts/clickhouse/templates/statefulset-clickhouse.yaml
@@ -76,6 +76,11 @@ spec:
           - -c
           - export SHARD=${HOSTNAME##*-} && /entrypoint.sh
         ports:
+        {{- if .Values.clickhouse.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ .Values.clickhouse.metrics.port }}
+          protocol: TCP
+        {{- end }}
         - name: http-port
           containerPort: {{ .Values.clickhouse.http_port | default "8123" }}
         - name: tcp-port
@@ -133,22 +138,6 @@ spec:
       {{- with .Values.clickhouse.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
-      {{- end }}
-      {{- if .Values.clickhouse.metrics.enabled }}
-      - name: prom-exporter
-        image: "{{ .Values.clickhouse.metrics.image.registry }}/{{ .Values.clickhouse.metrics.image.repository }}:{{ .Values.clickhouse.metrics.image.tag }}"
-        imagePullPolicy: {{ .Values.clickhouse.metrics.image.pullPolicy | quote }}
-        ports:
-          - name: metrics
-            containerPort: {{ .Values.clickhouse.metrics.image.port }}
-            protocol: TCP
-{{- if .Values.clickhouse.metrics.volumeMounts }}
-        volumeMounts:
-{{ toYaml .Values.clickhouse.metrics.volumeMounts | indent 8 }}
-{{- end }}
-        {{- if .Values.clickhouse.metrics.resources }}
-        resources: {{- toYaml .Values.clickhouse.metrics.resources | nindent 10 }}
-      {{- end }}
       {{- end }}
     {{- if .Values.clickhouse.nodeSelector }}
       nodeSelector:

--- a/charts/clickhouse/templates/svc-clickhouse-metrics.yaml
+++ b/charts/clickhouse/templates/svc-clickhouse-metrics.yaml
@@ -19,7 +19,7 @@ spec:
   loadBalancerIP: {{ .Values.clickhouse.metrics.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - port: {{ .Values.clickhouse.metrics.image.port }}
+    - port: {{ .Values.clickhouse.metrics.port }}
       targetPort: metrics
       name: metrics
   selector:

--- a/charts/clickhouse/templates/svc-clickhouse-replica-metrics.yaml
+++ b/charts/clickhouse/templates/svc-clickhouse-replica-metrics.yaml
@@ -20,7 +20,7 @@ spec:
   loadBalancerIP: {{ .Values.clickhouse.metrics.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - port: {{ .Values.clickhouse.metrics.image.port }}
+    - port: {{ .Values.clickhouse.metrics.port }}
       targetPort: metrics
       name: metrics
   selector:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -63,26 +63,13 @@ clickhouse:
   ## Prometheus Exporter / Metrics
   ##
   metrics:
-    enabled: false
-    image:
-      registry: docker.io
-      repository: f1yegor/clickhouse-exporter
-      tag: latest
-      pullPolicy: IfNotPresent
-      port: 9116
-
-    ## Metrics exporter resource requests and limits
-    # resources: {}
-
-    ## Additional Volumes
-    # volumes: []
-    # volumeMounts: []
+    enabled: true
+    port: 9116
 
     ## Metrics exporter pod Annotation and Labels
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9116"
-    podLabels: {}
 
     ## Enable this if you're using https://github.com/coreos/prometheus-operator
     serviceMonitor:
@@ -102,7 +89,6 @@ clickhouse:
       additionalLabels: {}
       namespace: ""
       rules: []
-
 
     service:
       type: ClusterIP


### PR DESCRIPTION
chore(clickhouse): replace external exporter with embedded ClickHouse exporter

- Removed external Prometheus exporter
- Updated ClickHouse config to use built-in Prometheus exporter (https://clickhouse.com/docs/operations/server-configuration-parameters/settings#prometheus)