### PR TITLE
fix(nginx): _assets should rewrite to _static/sentry/dist

### DIFF
--- a/charts/sentry/templates/configmap-nginx.yaml
+++ b/charts/sentry/templates/configmap-nginx.yaml
@@ -53,6 +53,11 @@ data:
         proxy_pass http://sentry;
       }
 
+      location /_assets/ {
+        proxy_pass http://sentry/_static/dist/sentry/;
+        proxy_hide_header Content-Disposition;
+      }
+
       location /_static/ {
         proxy_pass http://sentry;
         proxy_hide_header Content-Disposition;


### PR DESCRIPTION
Hello!

I have encountered into this issue https://github.com/getsentry/self-hosted/issues/3479 when using the latest sentry chart (26.14.1), and I have noticed that an nginx config port from https://github.com/getsentry/self-hosted/pull/3483 was missing.

This is reproducible, for example, when using GitHub auth.

<img width="1411" alt="スクリーンショット 2025-02-28 18 56 11" src="https://github.com/user-attachments/assets/04c04a08-11d7-4863-a86c-966139c4203c" />

<img width="1702" alt="スクリーンショット 2025-02-28 18 57 25" src="https://github.com/user-attachments/assets/4c3ca411-88f7-4b09-ad6c-7ac505a55d2b" />

I have tested that this change works by setting `nginx.extraLocationSnippet` to the following value in the current latest version of the chart:
```
nginx:
  extraLocationSnippet: |
    location /_assets/ {
      proxy_pass http://sentry/_static/dist/sentry/;
      proxy_hide_header Content-Disposition;
    }
```

Resources under `/_assets` no longer redirects to an invalid URL with trailing slash, and it correctly returns a JavaScript asset.

<img width="1705" alt="スクリーンショット 2025-02-28 18 58 29" src="https://github.com/user-attachments/assets/24f1e386-2522-4b6d-b5cf-0021ee93a4b1" />

Unfortunately though, after integrating this fix, I have encountered another problem which prevents me from using this GitHub auth (https://github.com/getsentry/self-hosted/issues/3540), and the fix only seems to be shipped in sentry 25.2.0 while the latest chart is dependent on 25.1.0 (by default).
But that's out of scope for this PR's fix.

Thanks!