### PR TITLE
feat(metrics): add `imagePullSecrets` option to the metrics deployment

### DIFF
--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -61,6 +61,10 @@ spec:
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
+      {{- if .Values.metrics.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.metrics.image.imagePullSecrets | indent 8 }}
+      {{- end }}
       {{- if .Values.metrics.securityContext }}
       securityContext:
 {{ toYaml .Values.metrics.securityContext | indent 8 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2531,6 +2531,7 @@ metrics:
     repository: prom/statsd-exporter
     tag: v0.17.0
     pullPolicy: IfNotPresent
+    imagePullSecrets: []
 
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:


### PR DESCRIPTION
This option was missing for this image