### PR TITLE
Define default for startupProbe.initialDelaySeconds

### DIFF
--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -144,6 +144,7 @@ clickhouse:
 
   startupProbe:
     enabled: true
+    initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 5
     failureThreshold: 60


### PR DESCRIPTION
The https://github.com/sentry-kubernetes/charts/blob/develop/charts/clickhouse/README.md specifies a default value for `clickhouse.startupProbe.initialDelaySeconds`, but https://github.com/sentry-kubernetes/charts/blob/develop/charts/clickhouse/values.yaml#L145-L150 doesn't.