### PR TITLE
Fix zhenyatsk clickhouse-tls pr

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -413,6 +413,33 @@ Set ClickHouse cluster name
 {{- end -}}
 
 {{/*
+Set ClickHouse secure setting
+*/}}
+{{- define "sentry.clickhouse.secure" -}}
+{{- if and (.Values.externalClickhouse.enabled) (.Values.externalClickhouse.secure) -}}
+True
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set ClickHouse ca_certs setting
+*/}}
+{{- define "sentry.clickhouse.ca_certs" -}}
+{{- if and (.Values.externalClickhouse.enabled) (.Values.externalClickhouse.ca_certs) -}}
+{{ .Values.externalClickhouse.ca_certs }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set ClickHouse verify ca setting
+*/}}
+{{- define "sentry.clickhouse.verify" -}}
+{{- if and (.Values.externalClickhouse.enabled) (.Values.externalClickhouse.verify) -}}
+True
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set Kafka Confluent host
 */}}
 {{- define "sentry.kafka.host" -}}

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -36,6 +36,9 @@ settings.py: |
     {
       "host": env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }}),
       "port": int({{ include "sentry.clickhouse.port" . }}),
+      "secure": env("CLICKHOUSE_SECURE", False),
+      "ca_certs": env("CLICKHOUSE_CA_CERTS", None),
+      "verify": env("CLICKHOUSE_VERIFY", False),
       "user":  env("CLICKHOUSE_USER", "default"),
       "password": env("CLICKHOUSE_PASSWORD", ""),
       "max_connections": int(os.environ.get("CLICKHOUSE_MAX_CONNECTIONS", 100)),

--- a/charts/sentry/templates/snuba/secret-snuba-env.yaml
+++ b/charts/sentry/templates/snuba/secret-snuba-env.yaml
@@ -15,3 +15,12 @@ data:
 {{- if not .Values.externalClickhouse.existingSecret }}
   CLICKHOUSE_PASSWORD: {{ include "sentry.clickhouse.password" . | b64enc | quote }}
 {{- end }}
+{{- if not .Values.externalClickhouse.secure }}
+  CLICKHOUSE_SECURE: {{ include "sentry.clickhouse.secure" . | b64enc | quote }}
+{{- end }}
+{{- if not .Values.externalClickhouse.ca_certs }}
+  CLICKHOUSE_CA_CERTS: {{ include "sentry.clickhouse.ca_certs" . | b64enc | quote }}
+{{- end }}
+{{- if not .Values.externalClickhouse.verify }}
+  CLICKHOUSE_VERIFY: {{ include "sentry.clickhouse.verify" . | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
Summary
Added support for configuring secure ClickHouse connections in the Helm chart.

Changes

- charts/sentry/templates/snuba/_helper-snuba.tpl
Added corresponding environment variables for Snuba.

- charts/sentry/templates/snuba/secret-snuba-env.yaml
Populated the above variables using Helm values if not set explicitly.

- charts/sentry/templates/_helper.tpl
Added helper templates to set:

    1. CLICKHOUSE_SECURE
    2. CLICKHOUSE_CA_CERTS
    3. CLICKHOUSE_VERIFY



Purpose
These changes allow users to securely connect to an external ClickHouse instance by enabling TLS settings and providing custom CA certificates.