### PR TITLE
Support to access External Clickhouse over Secured Ports (or ClickHouse Cloud provided DBs)

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -362,6 +362,17 @@ Set ClickHouse HTTP port
 {{- end -}}
 
 {{/*
+Set ClickHouse secure (To connect with secured ClickHouse DBs over ports - 9440, 8443 etc)
+*/}}
+{{- define "sentry.clickhouse.secure" -}}
+{{- if .Values.externalClickhouse.secure -}}
+{{ printf "True" }}
+{{- else -}}
+{{- printf "False" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set ClickHouse Database
 */}}
 {{- define "sentry.clickhouse.database" -}}

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -41,6 +41,7 @@ settings.py: |
       "max_connections": int(os.environ.get("CLICKHOUSE_MAX_CONNECTIONS", 100)),
       "database": env("CLICKHOUSE_DATABASE", "default"),
       "http_port": {{ include "sentry.clickhouse.http_port" . }},
+      "secure": {{ include "sentry.clickhouse.secure" . }},
       "storage_sets": {
           "cdc",
           "discover",


### PR DESCRIPTION
Currently using this chart, we can only connect to ClickHouse over insecure ports like - 9000, 8123 etc

But after these changes, we can connect to ClickHouse over secured ports lik - 9440, 8443 etc, as well. This will allow people to connect sentry to ClickHouse Cloud DBs.