### PR TITLE
fix(clickhouse): add missing configOverride in statefulset-clickhouse-replica

### DIFF
--- a/charts/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/charts/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -166,6 +166,10 @@ spec:
           - key: users.xml
             path: users.xml
       {{- end }}
+      {{- if .Values.clickhouse.configmap.configOverride }}
+          - key: override.xml
+            path: override.xml
+      {{- end }}
 {{- if .Values.clickhouse.volumes }}
 {{ toYaml .Values.clickhouse.volumes | indent 6 }}
 {{- end }}


### PR DESCRIPTION
The configOverride section was missing in the ClickHouse statefulset for replicas.