### PR TITLE
fix: fix typo in value of argument '--consumer-group' for snuba-eap-items-span-consumer

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-span-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-span-consumer.yaml
@@ -88,7 +88,7 @@ spec:
           - "--storage"
           - "eap_items"
           - "--consumer-group"
-          - "snuba-eap-items-span-consumers "
+          - "snuba-eap-items-span-consumers"
           {{- if .Values.snuba.eapItemsSpanConsumer.autoOffsetReset }}
           - "--auto-offset-reset"
           - "{{ .Values.snuba.eapItemsSpanConsumer.autoOffsetReset }}"


### PR DESCRIPTION
There is an extra space in the template