### PR TITLE
Refactor Sentry web configuration from hardcoded to values.yaml

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -366,7 +366,7 @@ sentry.conf.py: |-
       'thunder-lock': {{ .Values.config.web.thunderLock | ternary "True" "False" }},
       'log-x-forwarded-for': {{ .Values.config.web.logXForwardedFor | ternary "True" "False" }},
       'buffer-size': {{ .Values.config.web.bufferSize }},
-      'limit-post': {{ .Values.config.web.limitPost }},
+      'limit-post': {{ .Values.config.web.limitPost | int }},
       'disable-logging': {{ .Values.config.web.disableLogging | ternary "True" "False" }},
       'reload-on-rss': {{ .Values.config.web.reloadOnRss }},
       'ignore-sigpipe': {{ .Values.config.web.ignoreSignpipe | ternary "True" "False" }},

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -351,16 +351,16 @@ sentry.conf.py: |-
       # This is needed to prevent https://git.io/fj7Lw
       "uwsgi-socket": None,
       # Keep this between 15s-75s as that's what Relay supports
-      "http-keepalive": {{ .Values.config.web.httpKeepalive }},
+      "http-keepalive": {{ .Values.config.web.httpKeepalive | int }},
       "http-chunked-input": {{ .Values.config.web.httpChunkedInput | ternary "True" "False" }},
       # the number of web workers
-      'workers': {{ .Values.config.web.workers }},
+      'workers': {{ .Values.config.web.workers | int }},
       # Turn off memory reporting
       "memory-report": {{ .Values.config.web.memoryReport | ternary "True" "False" }},
       # Some stuff so uwsgi will cycle workers sensibly
-      'max-requests': {{ .Values.config.web.maxRequests }},
-      'max-requests-delta': {{ .Values.config.web.maxRequestsDelta }},
-      'max-worker-lifetime': {{ .Values.config.web.maxWorkerLifetime }},
+      'max-requests': {{ .Values.config.web.maxRequests | int }},
+      'max-requests-delta': {{ .Values.config.web.maxRequestsDelta | int }},
+      'max-worker-lifetime': {{ .Values.config.web.maxWorkerLifetime | int }},
       # Duplicate options from sentry default just so we don't get
       # bit by sentry changing a default value that we depend on.
       'thunder-lock': {{ .Values.config.web.thunderLock | ternary "True" "False" }},

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -352,26 +352,26 @@ sentry.conf.py: |-
       "uwsgi-socket": None,
       # Keep this between 15s-75s as that's what Relay supports
       "http-keepalive": {{ .Values.config.web.httpKeepalive }},
-      "http-chunked-input": True,
+      "http-chunked-input": {{ .Values.config.web.httpChunkedInput | ternary "True" "False" }},
       # the number of web workers
       'workers': {{ .Values.config.web.workers }},
       # Turn off memory reporting
-      "memory-report": {{ .Values.config.web.memoryReport }},
+      "memory-report": {{ .Values.config.web.memoryReport | ternary "True" "False" }},
       # Some stuff so uwsgi will cycle workers sensibly
       'max-requests': {{ .Values.config.web.maxRequests }},
       'max-requests-delta': {{ .Values.config.web.maxRequestsDelta }},
       'max-worker-lifetime': {{ .Values.config.web.maxWorkerLifetime }},
       # Duplicate options from sentry default just so we don't get
       # bit by sentry changing a default value that we depend on.
-      'thunder-lock': {{ .Values.config.web.thunderLock }},
-      'log-x-forwarded-for': {{ .Values.config.web.logXForwardedFor }},
+      'thunder-lock': {{ .Values.config.web.thunderLock | ternary "True" "False" }},
+      'log-x-forwarded-for': {{ .Values.config.web.logXForwardedFor | ternary "True" "False" }},
       'buffer-size': {{ .Values.config.web.bufferSize }},
       'limit-post': {{ .Values.config.web.limitPost }},
-      'disable-logging': {{ .Values.config.web.disableLogging }},
+      'disable-logging': {{ .Values.config.web.disableLogging | ternary "True" "False" }},
       'reload-on-rss': {{ .Values.config.web.reloadOnRss }},
-      'ignore-sigpipe': {{ .Values.config.web.ignoreSignpipe }},
-      'ignore-write-errors': {{ .Values.config.web.ignoreWriteErrors }},
-      'disable-write-exception': {{ .Values.config.web.disableWriteException }},
+      'ignore-sigpipe': {{ .Values.config.web.ignoreSignpipe | ternary "True" "False" }},
+      'ignore-write-errors': {{ .Values.config.web.ignoreWriteErrors | ternary "True" "False" }},
+      'disable-write-exception': {{ .Values.config.web.disableWriteException | ternary "True" "False" }},
   }
 
   ###########

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -365,10 +365,10 @@ sentry.conf.py: |-
       # bit by sentry changing a default value that we depend on.
       'thunder-lock': {{ .Values.config.web.thunderLock | ternary "True" "False" }},
       'log-x-forwarded-for': {{ .Values.config.web.logXForwardedFor | ternary "True" "False" }},
-      'buffer-size': {{ .Values.config.web.bufferSize }},
+      'buffer-size': {{ .Values.config.web.bufferSize | int }},
       'limit-post': {{ .Values.config.web.limitPost | int }},
       'disable-logging': {{ .Values.config.web.disableLogging | ternary "True" "False" }},
-      'reload-on-rss': {{ .Values.config.web.reloadOnRss }},
+      'reload-on-rss': {{ .Values.config.web.reloadOnRss | int }},
       'ignore-sigpipe': {{ .Values.config.web.ignoreSignpipe | ternary "True" "False" }},
       'ignore-write-errors': {{ .Values.config.web.ignoreWriteErrors | ternary "True" "False" }},
       'disable-write-exception': {{ .Values.config.web.disableWriteException | ternary "True" "False" }},

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -354,24 +354,24 @@ sentry.conf.py: |-
       "http-keepalive": {{ .Values.config.web.httpKeepalive }},
       "http-chunked-input": True,
       # the number of web workers
-      'workers': 3,
+      'workers': {{ .Values.config.web.workers }},
       # Turn off memory reporting
-      "memory-report": False,
+      "memory-report": {{ .Values.config.web.memoryReport }},
       # Some stuff so uwsgi will cycle workers sensibly
       'max-requests': {{ .Values.config.web.maxRequests }},
       'max-requests-delta': {{ .Values.config.web.maxRequestsDelta }},
       'max-worker-lifetime': {{ .Values.config.web.maxWorkerLifetime }},
       # Duplicate options from sentry default just so we don't get
       # bit by sentry changing a default value that we depend on.
-      'thunder-lock': True,
-      'log-x-forwarded-for': False,
-      'buffer-size': 32768,
-      'limit-post': 209715200,
-      'disable-logging': True,
-      'reload-on-rss': 600,
-      'ignore-sigpipe': True,
-      'ignore-write-errors': True,
-      'disable-write-exception': True,
+      'thunder-lock': {{ .Values.config.web.thunderLock }},
+      'log-x-forwarded-for': {{ .Values.config.web.logXForwardedFor }},
+      'buffer-size': {{ .Values.config.web.bufferSize }},
+      'limit-post': {{ .Values.config.web.limitPost }},
+      'disable-logging': {{ .Values.config.web.disableLogging }},
+      'reload-on-rss': {{ .Values.config.web.reloadOnRss }},
+      'ignore-sigpipe': {{ .Values.config.web.ignoreSignpipe }},
+      'ignore-write-errors': {{ .Values.config.web.ignoreWriteErrors }},
+      'disable-write-exception': {{ .Values.config.web.disableWriteException }},
   }
 
   ###########

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1989,9 +1989,20 @@ config:
     # No YAML relay config given
   web:
     httpKeepalive: 15
+    workers: 3
+    memoryReport: false
     maxRequests: 100000
     maxRequestsDelta: 500
     maxWorkerLifetime: 86400
+    thunderLock: true
+    logXForwardedFor: false
+    bufferSize: 32768
+    limitPost: 209715200
+    disableLogging: true
+    reloadOnRss: 600
+    ignoreSignpipe: true
+    ignoreWriteErrors: true
+    disableWriteException: true
 
 clickhouse:
   enabled: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1989,6 +1989,7 @@ config:
     # No YAML relay config given
   web:
     httpKeepalive: 15
+    httpChunkedInput: true
     workers: 3
     memoryReport: false
     maxRequests: 100000


### PR DESCRIPTION
## Description
This PR moves hardcoded Sentry configuration values from the `_helper-sentry.tpl` template to `values.yaml`. This change follows the Helm best practices by making configuration parameters explicitly definable in values rather than hardcoded in templates.

## Changes
- Added new configuration section `config.web` in `values.yaml` to store all Sentry web server parameters
- Replaced all hardcoded values in `_helper-sentry.tpl` with references to values
- Maintained camelCase naming convention for consistency with existing parameters
- Set default values in `values.yaml` to match previous hardcoded values

## Benefits
- Improved configuration flexibility - users can modify parameters without changing template code
- Better configuration visibility - all available options are documented in values.yaml
- Consistent configuration approach - follows the pattern used for other configurable components
- Simplifies future maintenance by centralizing configuration parameters

---
Please review the changes and provide feedback. If everything looks good, feel free to merge this pull request.
Thank you!

@Mokto 