### PR TITLE
Add Symbolicator Cleanup and Increase dbInit Memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
+**.tgz
 

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -125,6 +125,35 @@ spec:
         securityContext:
 {{ toYaml .Values.symbolicator.api.containerSecurityContext | indent 12 }}
 {{- end }}
+{{- if .Values.symbolicator.api.cleaner.enabled }}
+      - name: {{ .Chart.Name }}-symbolicator-cleaner
+        image: "{{ template "symbolicator.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.symbolicator.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            while true; do
+              symbolicator cleanup -c /etc/symbolicator/config.yml;
+              sleep {{ .Values.symbolicator.api.cleaner.sleepInterval }};
+            done
+        env:
+        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+        {{ end }}
+        volumeMounts:
+        - mountPath: /etc/symbolicator
+          name: config
+          readOnly: true
+        - mountPath: /data
+          name: symbolicator-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- end }}
 {{- if .Values.symbolicator.api.sidecars }}
 {{ toYaml .Values.symbolicator.api.sidecars | indent 6 }}
 {{- end }}

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -126,6 +126,30 @@ spec:
         securityContext:
 {{ toYaml .Values.symbolicator.api.containerSecurityContext | indent 12 }}
 {{- end }}
+      {{- if .Values.symbolicator.api.cleaner.enabled }}
+      - name: {{ .Chart.Name }}-symbolicator-cleaner
+        image: "{{ template "symbolicator.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.symbolicator.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            while true; do
+              symbolicator cleanup -c /etc/symbolicator/config.yml;
+              sleep {{ .Values.symbolicator.api.cleaner.sleepInterval }};
+            done
+        volumeMounts:
+        - mountPath: /etc/symbolicator
+          name: config
+          readOnly: true
+        - mountPath: /data
+          name: symbolicator-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+      {{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
       {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1786,7 +1786,7 @@ hooks:
     podAnnotations: {}
     resources:
       limits:
-        memory: 2048Mi
+        memory: 2560Mi
       requests:
         cpu: 300m
         memory: 2048Mi
@@ -1853,7 +1853,7 @@ symbolicator:
     cleaner:
       enabled: true
       sleepInterval: 120
-    usedeployment: false  # Set true to use Deployment, false for StatefulSet
+    usedeployment: true  # Set true to use Deployment, false for StatefulSet
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
       accessModes: ["ReadWriteOnce"]

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1848,8 +1848,11 @@ mail:
   from: ""
 
 symbolicator:
-  enabled: false
+  enabled: true
   api:
+    cleaner:
+      enabled: true
+      sleepInterval: 120
     usedeployment: true  # Set true to use Deployment, false for StatefulSet
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1851,7 +1851,7 @@ symbolicator:
   enabled: false
   api:
     cleaner:
-      enabled: false
+      enabled: true
       sleepInterval: 3600
     usedeployment: true  # Set true to use Deployment, false for StatefulSet
     persistence:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1848,11 +1848,11 @@ mail:
   from: ""
 
 symbolicator:
-  enabled: true
+  enabled: false
   api:
     cleaner:
-      enabled: true
-      sleepInterval: 120
+      enabled: false
+      sleepInterval: 3600
     usedeployment: true  # Set true to use Deployment, false for StatefulSet
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1853,7 +1853,7 @@ symbolicator:
     cleaner:
       enabled: true
       sleepInterval: 120
-    usedeployment: true  # Set true to use Deployment, false for StatefulSet
+    usedeployment: false  # Set true to use Deployment, false for StatefulSet
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
       accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
## Summary

This PR introduces automatic cleanup functionality for Symbolicator and addresses memory issues with database initialization.

## Changes Made

### Symbolicator Cleanup Enhancement
- **Added automatic cleanup container**: Implemented a sidecar container that runs `symbolicator cleanup` command periodically
- **Configurable cleanup interval**: Added `sleepInterval` parameter (default: 3600 seconds) to control cleanup frequency
- **Deployment flexibility**: Cleanup container is available for both Deployment and StatefulSet configurations
- **Optional feature**: Cleanup functionality can be enabled/disabled via `symbolicator.api.cleaner.enabled` flag
- **Proper volume mounting**: Cleanup container has access to configuration and data volumes, including GCS credentials when needed

### Memory Optimization
- **Increased dbInit memory limit**: Bumped memory limit from 2048Mi to 2560Mi to prevent OOM crashes during database initialization

### Configuration Updates
- **Added .gitignore entry**: Excluded `**.tgz` files from version control
