### PR TITLE
feat: change kafka to redpanda

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 29.3.14
+- name: redpanda
+  repository: https://charts.redpanda.com
+  version: 5.10.2
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
   version: 3.14.1
@@ -23,5 +26,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:2b19e9605468921ff96afb9f393ffe09d3121e5b91f32789e025851f0b66ff63
-generated: "2025-01-17T18:17:43.022337376+06:00"
+digest: sha256:4dec91142eae48683df30b2e28d775b40dbfbd2f6a5870c88ac921b59f0ac5ce
+generated: "2025-05-14T22:42:24.544964974+02:00"

--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: redpanda
   repository: https://charts.redpanda.com
-  version: 5.10.2
+  version: 25.1.1-beta3
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
   version: 3.14.1
@@ -26,5 +26,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:4dec91142eae48683df30b2e28d775b40dbfbd2f6a5870c88ac921b59f0ac5ce
-generated: "2025-05-14T22:42:24.544964974+02:00"
+digest: sha256:25fbcc82efd808299562f918c8d62c3aa117fdb6db73acc1901afe65f8c2f2cb
+generated: "2025-05-22T18:58:36.059686591+02:00"

--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: redpanda
   repository: https://charts.redpanda.com
-  version: 25.1.1-beta3
+  version: 5.9.23
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
   version: 3.14.1
@@ -26,5 +26,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:25fbcc82efd808299562f918c8d62c3aa117fdb6db73acc1901afe65f8c2f2cb
-generated: "2025-05-22T18:58:36.059686591+02:00"
+digest: sha256:b1ffac97e8807f10c6632d050164355cb18c132f484f1ec9ee190e718dbd84be
+generated: "2025-05-27T23:04:20.600779955+02:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -17,6 +17,10 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 29.3.14
     condition: kafka.enabled
+  - name: redpanda
+    repository: https://charts.redpanda.com
+    version: 5.10.2
+    condition: redpanda.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
     version: 3.14.1

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: redpanda
     repository: https://charts.redpanda.com
-    version: 5.10.2
+    version: 25.1.1-beta3
     condition: redpanda.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     condition: kafka.enabled
   - name: redpanda
     repository: https://charts.redpanda.com
-    version: 25.1.1-beta3
+    version: 5.9.23
     condition: redpanda.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -443,7 +443,7 @@ True
 Set Kafka Confluent host
 */}}
 {{- define "sentry.kafka.host" -}}
-{{- if .Values.kafka.enabled -}}
+{{- if or (.Values.kafka.enabled) (.Values.redpanda.enabled) -}}
 {{- template "sentry.kafka.fullname" . -}}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
 {{ required "A valid .Values.externalKafka.host is required" .Values.externalKafka.host }}
@@ -454,7 +454,10 @@ Set Kafka Confluent host
 Set Kafka Confluent port
 */}}
 {{- define "sentry.kafka.port" -}}
-{{- if and (.Values.kafka.enabled) (.Values.kafka.service.ports.client) -}}
+{{- if or
+     (and .Values.kafka.enabled .Values.kafka.service.ports.client)
+     .Values.redpanda.enabled
+-}}
 {{- .Values.kafka.service.ports.client }}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
 {{ required "A valid .Values.externalKafka.port is required" .Values.externalKafka.port }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -454,10 +454,9 @@ Set Kafka Confluent host
 Set Kafka Confluent port
 */}}
 {{- define "sentry.kafka.port" -}}
-{{- if or
-     (and .Values.kafka.enabled .Values.kafka.service.ports.client)
-     .Values.redpanda.enabled
--}}
+{{- if .Values.redpanda.enabled -}}
+{{- .Values.redpanda.kafka.port }}
+{{- else if and .Values.kafka.enabled .Values.kafka.service.ports.client -}}
 {{- .Values.kafka.service.ports.client }}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
 {{ required "A valid .Values.externalKafka.port is required" .Values.externalKafka.port }}
@@ -468,7 +467,9 @@ Set Kafka Confluent port
 Set Kafka Confluent Controller port
 */}}
 {{- define "sentry.kafka.controller_port" -}}
-{{- if and (.Values.kafka.enabled) (.Values.kafka.service.ports.controller ) -}}
+{{- if .Values.redpanda.enabled -}}
+{{- .Values.redpanda.kafka.port }}
+{{- else if and (.Values.kafka.enabled) (.Values.kafka.service.ports.controller ) -}}
 {{- .Values.kafka.service.ports.controller }}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
 {{ required "A valid .Values.externalKafka.port is required" .Values.externalKafka.port }}
@@ -479,7 +480,7 @@ Set Kafka Confluent Controller port
 Set Kafka bootstrap servers string
 */}}
 {{- define "sentry.kafka.bootstrap_servers_string" -}}
-{{- if or (.Values.kafka.enabled) (not (.Values.externalKafka.cluster)) -}}
+{{- if or (.Values.kafka.enabled) (.Values.redpanda.enabled) (not (.Values.externalKafka.cluster)) -}}
 {{ printf "%s:%s" (include "sentry.kafka.host" .) (include "sentry.kafka.port" .) }}
 {{- else -}}
 {{- range $index, $elem := .Values.externalKafka.cluster -}}
@@ -499,7 +500,11 @@ SASL auth setings for Kafka:
 Set Kafka security protocol
 */}}
 {{- define "sentry.kafka.security_protocol" -}}
-{{- if .Values.kafka.enabled -}}
+{{- if .Values.redpanda.enabled -}}
+{{- if and .Values.redpanda.auth.sasl.enabled -}}
+{{ default "plaintext" .Values.redpanda.listeners.kafka.authenticationMethod }}
+{{- end -}}
+{{- else if .Values.kafka.enabled -}}
 {{ default "plaintext" .Values.kafka.listeners.client.protocol }}
 {{- else -}}
 {{ default "plaintext" .Values.externalKafka.security.protocol }}
@@ -512,7 +517,9 @@ Set Kafka sasl mechanism
 {{- define "sentry.kafka.sasl_mechanism" -}}
 {{- $CheckProtocol := include "sentry.kafka.security_protocol" . -}}
 {{- if (regexMatch "^SASL_" $CheckProtocol) -}}
-{{- if .Values.kafka.enabled -}}
+{{- if .Values.redpanda.enabled -}}
+{{ default "None" .Values.redpanda.auth.sasl.mechanism }}
+{{- else if .Values.kafka.enabled -}}
 {{ default "None" (split "," .Values.kafka.sasl.enabledMechanisms)._0 }}
 {{- else -}}
 {{ default "None" .Values.externalKafka.sasl.mechanism }}
@@ -528,7 +535,9 @@ Set Kafka sasl username
 {{- define "sentry.kafka.sasl_username" -}}
 {{- $CheckProtocol := include "sentry.kafka.security_protocol" . -}}
 {{- if (regexMatch "^SASL_" $CheckProtocol) -}}
-{{- if .Values.kafka.enabled -}}
+{{- if .Values.redpanda.enabled -}}
+{{ default "None" (first (default tuple .Values.redpanda.auth.sasl.users).name)  }}
+{{- else if .Values.kafka.enabled -}}
 {{ default "None" (first (default tuple .Values.kafka.sasl.client.users)) }}
 {{- else -}}
 {{ default "None" .Values.externalKafka.sasl.username }}
@@ -544,7 +553,9 @@ Set Kafka sasl password
 {{- define "sentry.kafka.sasl_password" -}}
 {{- $CheckProtocol := include "sentry.kafka.security_protocol" . -}}
 {{- if (regexMatch "^SASL_" $CheckProtocol) -}}
-{{- if .Values.kafka.enabled -}}
+{{- if .Values.redpanda.enabled -}}
+{{ default "None" (first (default tuple .Values.redpanda.auth.sasl.users).password) }}
+{{- else if .Values.kafka.enabled -}}
 {{ default "None" (first (default tuple .Values.kafka.sasl.client.passwords)) }}
 {{- else -}}
 {{ default "None" .Values.externalKafka.sasl.password }}
@@ -558,6 +569,8 @@ Set Kafka sasl password
 Set Senty compression.type for Kafka
 */}}
 {{- define "sentry.kafka.compression_type" -}}
+{{- if .Values.redpanda.enabled -}}
+{{ default "" .Values.sentry.kafka.compression.type }}
 {{- if .Values.kafka.enabled -}}
 {{ default "" .Values.sentry.kafka.compression.type }}
 {{- else -}}
@@ -569,7 +582,9 @@ Set Senty compression.type for Kafka
 Set Senty message.max.bytes for Kafka
 */}}
 {{- define "sentry.kafka.message_max_bytes" -}}
-{{- if .Values.kafka.enabled -}}
+{{- if .Values.redpanda.enabled -}}
+{{ default 50000000 .Values.sentry.kafka.message.max.bytes | int64 }}
+{{- else if .Values.kafka.enabled -}}
 {{ default 50000000 .Values.sentry.kafka.message.max.bytes | int64 }}
 {{- else -}}
 {{ default 50000000 .Values.externalKafka.message.max.bytes | int64 }}
@@ -580,7 +595,9 @@ Set Senty message.max.bytes for Kafka
 Set Senty socket.timeout for Kafka
 */}}
 {{- define "sentry.kafka.socket_timeout_ms" -}}
-{{- if .Values.kafka.enabled -}}
+{{- if .Values.redpanda.enabled -}}
+{{ default 1000 .Values.sentry.kafka.socket.timeout.ms | int64 }}
+{{- else if .Values.kafka.enabled -}}
 {{ default 1000 .Values.sentry.kafka.socket.timeout.ms | int64 }}
 {{- else -}}
 {{ default 1000 .Values.externalKafka.socket.timeout.ms | int64 }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -178,7 +178,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sentry.kafka.fullname" -}}
+{{- if .Values.kafka.enabled -}}
 {{- printf "%s-%s" .Release.Name "kafka" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "redpanda" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "sentry.zookeeper.fullname" -}}
@@ -455,7 +459,7 @@ Set Kafka Confluent port
 */}}
 {{- define "sentry.kafka.port" -}}
 {{- if .Values.redpanda.enabled -}}
-{{- .Values.redpanda.kafka.port }}
+{{- default 9092 (dig "kafka" "port" nil .Values.redpanda) }}
 {{- else if and .Values.kafka.enabled .Values.kafka.service.ports.client -}}
 {{- .Values.kafka.service.ports.client }}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
@@ -468,7 +472,7 @@ Set Kafka Confluent Controller port
 */}}
 {{- define "sentry.kafka.controller_port" -}}
 {{- if .Values.redpanda.enabled -}}
-{{- .Values.redpanda.kafka.port }}
+{{- default 9092 (dig "kafka" "port" nil .Values.redpanda) }}
 {{- else if and (.Values.kafka.enabled) (.Values.kafka.service.ports.controller ) -}}
 {{- .Values.kafka.service.ports.controller }}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
@@ -571,7 +575,7 @@ Set Senty compression.type for Kafka
 {{- define "sentry.kafka.compression_type" -}}
 {{- if .Values.redpanda.enabled -}}
 {{ default "" .Values.sentry.kafka.compression.type }}
-{{- if .Values.kafka.enabled -}}
+{{- else if .Values.kafka.enabled -}}
 {{ default "" .Values.sentry.kafka.compression.type }}
 {{- else -}}
 {{ default "" .Values.externalKafka.compression.type }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -459,7 +459,7 @@ Set Kafka Confluent port
 */}}
 {{- define "sentry.kafka.port" -}}
 {{- if .Values.redpanda.enabled -}}
-{{- default 9092 (dig "kafka" "port" nil .Values.redpanda) }}
+{{- .Values.redpanda.listeners.kafka.port }}
 {{- else if and .Values.kafka.enabled .Values.kafka.service.ports.client -}}
 {{- .Values.kafka.service.ports.client }}
 {{- else if and (.Values.externalKafka) (not (.Values.externalKafka.cluster)) -}}
@@ -505,9 +505,7 @@ Set Kafka security protocol
 */}}
 {{- define "sentry.kafka.security_protocol" -}}
 {{- if .Values.redpanda.enabled -}}
-{{- if and .Values.redpanda.auth.sasl.enabled -}}
 {{ default "plaintext" .Values.redpanda.listeners.kafka.authenticationMethod }}
-{{- end -}}
 {{- else if .Values.kafka.enabled -}}
 {{ default "plaintext" .Values.kafka.listeners.client.protocol }}
 {{- else -}}

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -141,7 +141,7 @@ spec:
               done
               echo "Zookeeper is up"
               {{- end }}
-              {{- if .Values.kafka.kraft.enabled }}
+              {{- if or (.Values.kafka.kraft.enabled) (.Values.kafka.redpanda.enabled) }}
               KAFKA_REPLICAS={{ .Values.kafka.controller.replicaCount | default 3 }}
               echo "Kafka Kraft is enabled, checking if Kraft controllers are up"
               KRAFT_STATUS=0
@@ -162,7 +162,7 @@ spec:
               done
               echo "Kraft controllers are up"
               {{- end }}
-              {{- else if (not (.Values.externalKafka.cluster)) }}
+              {{- else if and (not (.Values.externalKafka.cluster)) (not (.Values.redpanda.enabled)) }}
               KAFKA_HOST={{ .Values.externalKafka.host }}
               if ! nc -z "$KAFKA_HOST" {{ $kafkaPort }}; then
                 KAFKA_STATUS=0

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2203,7 +2203,10 @@ redpanda:
     replicas: 1
   listeners:
     kafka:
-      authenticationMethod: "none"
+      port: 9092
+      tls:
+        enabled: false
+      authenticationMethod: "plaintext"
   console:
     enabled: false
 

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2196,10 +2196,20 @@ zookeeper:
   # persistence:
   #   size: 8Gi
 
+redpanda:
+  enabled: true
+  statefulset:
+    replicas: 3
+  listeners:
+    kafka:
+      authenticationMethod: "none"
+  console:
+    enabled: false
+
 # Settings for Kafka.
 # See https://github.com/bitnami/charts/tree/master/bitnami/kafka
 kafka:
-  enabled: true
+  enabled: false
   provisioning:
     ## Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers.
     # Note that existing topics will remain with replicationFactor: 1 when updated.

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2198,8 +2198,9 @@ zookeeper:
 
 redpanda:
   enabled: true
+  fullnameOverride: "sentry-redpanda"
   statefulset:
-    replicas: 3
+    replicas: 1
   listeners:
     kafka:
       authenticationMethod: "none"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2199,6 +2199,9 @@ zookeeper:
 redpanda:
   enabled: true
   fullnameOverride: "sentry-redpanda"
+  config:
+    cluster:
+      auto_create_topics_enabled: true
   statefulset:
     replicas: 1
   listeners:
@@ -2209,6 +2212,9 @@ redpanda:
       authenticationMethod: "plaintext"
   console:
     enabled: false
+  auth:
+    sasl:
+      enabled: false
 
 # Settings for Kafka.
 # See https://github.com/bitnami/charts/tree/master/bitnami/kafka


### PR DESCRIPTION
This pull request introduces support for Redpanda as an alternative to Kafka in the Sentry Helm chart. The changes include adding Redpanda as a dependency, updating templates to handle Redpanda-specific configurations, and modifying default values to enable Redpanda by default while disabling Kafka. Below is a summary of the most important changes grouped by theme.

### Dependency Management
* Added Redpanda as a dependency in `Chart.yaml`, with its repository and version specified, and a condition to enable it via `redpanda.enabled`.

### Template Updates for Redpanda
* Updated `sentry.kafka.fullname` to use "redpanda" in the name when Redpanda is enabled.
* Modified Kafka-related templates to include support for Redpanda configurations, such as ports, authentication methods, and SASL settings. These changes ensure compatibility with Redpanda's configuration structure. [[1]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL446-R450) [[2]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL457-R463) [[3]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL468-R476) [[4]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL479-R487) [[5]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL499-R509) [[6]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL512-R524) [[7]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL528-R542) [[8]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL544-R560) [[9]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL558-R576) [[10]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL569-R589) [[11]](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL580-R602)

### Job Hook Adjustments
* Updated the `sentry-db-check.job.yaml` hook to account for Redpanda when checking Kafka Kraft controllers and external Kafka clusters. [[1]](diffhunk://#diff-418cfd7f9906396229f663f3040e79558cba718115d407862497f5dec2252b5eL144-R144) [[2]](diffhunk://#diff-418cfd7f9906396229f663f3040e79558cba718115d407862497f5dec2252b5eL165-R165)

### Default Values
* Added a new `redpanda` section in `values.yaml` with default configurations for Redpanda, including cluster settings, listeners, and authentication. Enabled Redpanda by default and disabled Kafka.