### PR TITLE
Add comments for scheduler-executor-type consumers

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1333,7 +1333,7 @@ snuba:
     # queuedMinMessages: ""
     # noStrictOffsetReset: false
 
-  subscriptionConsumerEapSpans:
+  subscriptionConsumerEapSpans: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []
@@ -1354,7 +1354,7 @@ snuba:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
-  subscriptionConsumerEvents:
+  subscriptionConsumerEvents: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []
@@ -1459,7 +1459,7 @@ snuba:
     # queuedMinMessages: ""
     # noStrictOffsetReset: false
 
-  subscriptionConsumerMetrics:
+  subscriptionConsumerMetrics: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []
@@ -1482,7 +1482,7 @@ snuba:
     # volumes: []
     # volumeMounts: []
 
-  subscriptionConsumerTransactions:
+  subscriptionConsumerTransactions: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1333,7 +1333,7 @@ snuba:
     # queuedMinMessages: ""
     # noStrictOffsetReset: false
 
-  subscriptionConsumerEapSpans:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerEapSpans:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
     replicas: 1
     env: []
@@ -1354,7 +1354,7 @@ snuba:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
-  subscriptionConsumerEvents:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerEvents:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
     replicas: 1
     env: []
@@ -1459,7 +1459,7 @@ snuba:
     # queuedMinMessages: ""
     # noStrictOffsetReset: false
 
-  subscriptionConsumerMetrics:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerMetrics:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
     replicas: 1
     env: []
@@ -1482,7 +1482,7 @@ snuba:
     # volumes: []
     # volumeMounts: []
 
-  subscriptionConsumerTransactions:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerTransactions:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
     replicas: 1
     env: []

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1333,7 +1333,7 @@ snuba:
     # queuedMinMessages: ""
     # noStrictOffsetReset: false
 
-  subscriptionConsumerEapSpans: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerEapSpans:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []
@@ -1354,7 +1354,7 @@ snuba:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
-  subscriptionConsumerEvents: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerEvents:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []
@@ -1459,7 +1459,7 @@ snuba:
     # queuedMinMessages: ""
     # noStrictOffsetReset: false
 
-  subscriptionConsumerMetrics: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerMetrics:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []
@@ -1482,7 +1482,7 @@ snuba:
     # volumes: []
     # volumeMounts: []
 
-  subscriptionConsumerTransactions: # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
+  subscriptionConsumerTransactions:  # if you run scheduler-executor-type consumers, all topics ending with -commit-log should have 1 partition and only 1 consumer replica.
     enabled: true
     replicas: 1
     env: []


### PR DESCRIPTION
This pull request updates the Sentry Helm chart's values.yaml file by adding explanatory comments to all subscription consumer sections (EapSpans, Events, Metrics, Transactions). The new comments clarify that, when using scheduler-executor-type consumers, all topics ending with -commit-log should have only 1 partition and 1 consumer replica for correct operation. These comments aim to provide better guidance for configuring Snuba consumers and to help prevent misconfiguration issues related to topic partitioning and consumer replica counts.

No functional changes were introduced; this is purely a documentation update within the configuration file.

https://github.com/getsentry/snuba/issues/5855#issuecomment-2113149084