### PR TITLE
ci: add conventional commits check workflow

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -1,0 +1,24 @@
+name: Conventional Commits Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  check-conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Commit Conventions
+        uses: webiny/action-conventional-commits@v1.3.0
+
+      - name: Check Semantic Pull Request title
+        uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to enforce conventional commit standards and semantic pull request titles.

Workflow addition:

[.github/workflows/conventional-commits-check.yaml](diffhunk://#diff-e31458f7c7241b1ecd6c7718ca7883bb2654734685c1b1e660b1a6b56d790f4eR1-R18): Introduces a workflow named Conventional Commits Check that runs on pull requests targeting the main branch.
This workflow verifies commit message conventions using [webiny/action-conventional-commits@v1.3.0](https://github.com/webiny/action-conventional-commits) and enforces semantic pull request checks with [amannn/action-semantic-pull-request@v5.5.3](https://github.com/amannn/action-semantic-pull-request).

This PR aims to prevent errors like [this one](https://github.com/sentry-kubernetes/charts/pull/1769#issuecomment-2969634878) in the future.

Examples of workflow runs:

Action failed ❌ with PR title "Add conventional commits check workflow": [View run](https://github.com/sentry-kubernetes/charts/actions/runs/15631679461/job/44037301419?pr=1783#step:4:7)

Action succeeded ✅ with PR title "ci: add conventional commits check workflow": [View run](https://github.com/sentry-kubernetes/charts/actions/runs/15631784271/job/44037638300#step:4:1)