### PR TITLE
fix: remove reference to secret-key from NOTES.txt

### DIFF
--- a/charts/sentry/templates/NOTES.txt
+++ b/charts/sentry/templates/NOTES.txt
@@ -1,7 +1,3 @@
-* When running upgrades, make sure to give back the `system.secretKey` value.
-
-kubectl -n {{ .Release.Namespace }} get configmap {{ template "sentry.fullname" . }}-sentry -o json | grep -m1 -Po '(?<=system.secret-key: )[^\\]*'
-
 {{ if not (.Values.kafka.enabled) }}
 * Sentry use external kafka:
 


### PR DESCRIPTION
`system.secret-key` has been removed in chart version 16