### PR TITLE
ci(cc): add comments

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -19,6 +19,31 @@ jobs:
         uses: webiny/action-conventional-commits@v1.3.0
 
       - name: Check Semantic Pull Request title
-        uses: amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This pull request updates the pull request title linting workflow in `.github/workflows/conventional-commits-check.yaml` to improve error handling and user feedback. The most important changes include updating the version of the `action-semantic-pull-request` action, adding a sticky comment for linting errors, and ensuring comments are deleted when issues are resolved.

### Workflow improvements:
* Updated `amannn/action-semantic-pull-request` from version `v5.5.3` to `v5` and added an `id` (`lint_pr_title`) for referencing its outputs.
* Integrated `marocchino/sticky-pull-request-comment@v2` to post a sticky comment with details of the pull request title linting error when the linting step fails.
* Added logic to delete the sticky comment when the pull request title issue is resolved, ensuring no lingering error messages.