### PR TITLE
ci(lint): auto cancel

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,6 +2,10 @@ name: Lint and Test Charts
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a concurrency group to the GitHub Actions workflow for linting and testing charts. This ensures that only one workflow run per branch is active at a time, canceling any in-progress runs when a new one is triggered.

* [`.github/workflows/lint-test.yaml`](diffhunk://#diff-8ee75a42ccdffb28e750aba529bb689756d1773f5b5052e1ffea9486cf5fb2b7R5-R8): Added a `concurrency` key to group runs by workflow name and branch reference, with the `cancel-in-progress` option set to `true`.