### PR TITLE
feat(sentry): enable feature complete configuration

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -392,6 +392,10 @@ sentry.conf.py: |-
   # Features #
   ############
 
+  # Enable feature complete
+  {{- if .Values.sentry.featureComplete }}
+  COMPOSE_PROFILES = "feature-complete"
+  {{- end }}
 
   SENTRY_FEATURES = {
     "auth:register": {{ .Values.auth.register | ternary "True" "False" }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -238,6 +238,9 @@ sentry:
     volumeMounts: []
     # workers: 3
 
+  # Enable feature complete see https://github.com/getsentry/self-hosted/blob/master/.env#L5
+  featureComplete: true
+
   features:
     orgSubdomains: false
     vstsLimitedScopes: true


### PR DESCRIPTION
This pull request introduces a new feature toggle for enabling the "feature complete" mode in Sentry's self-hosted configuration. The changes include updates to the Helm chart templates and values to support this feature.

### New Feature Toggle for "Feature Complete" Mode:

* **Template Update**: Added a conditional block in `charts/sentry/templates/sentry/_helper-sentry.tpl` to set the `COMPOSE_PROFILES` environment variable to "feature-complete" when the `featureComplete` value is enabled.
* **Values Update**: Introduced a new `featureComplete` field in `charts/sentry/values.yaml` to toggle the "feature complete" mode, with a default value of `true`. This is accompanied by a comment referencing the relevant configuration in the Sentry self-hosted repository.