### PR TITLE
fix(snuba): update consumer group name for profiling chunks consumer

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -88,7 +88,7 @@ spec:
           - "--storage"
           - "profile_chunks"
           - "--consumer-group"
-          - "profile_chunks_group"
+          - "snuba-consumers"
           {{- if .Values.snuba.profilingChunksConsumer.autoOffsetReset }}
           - "--auto-offset-reset"
           - "{{ .Values.snuba.profilingChunksConsumer.autoOffsetReset }}"


### PR DESCRIPTION
This pull request includes a small but important change to the `charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml` file. The consumer group for the profiling chunks consumer has been updated to use a more generic name, `snuba-consumers`, instead of the previous `profile_chunks_group`.