### PR TITLE
feat: Add errors-only mode from original self-hosted compose

### DIFF
--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.ingestFeedback.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -177,4 +178,5 @@ spec:
       {{- if .Values.sentry.ingestFeedback.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestFeedback.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.ingestMonitors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.ingestMonitors.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -182,4 +183,5 @@ spec:
       {{- if .Values.sentry.ingestMonitors.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestMonitors.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.monitorsClockTasks.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -176,4 +177,5 @@ spec:
       {{- if .Values.sentry.monitorsClockTasks.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.monitorsClockTasks.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.monitorsClockTick.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -176,4 +177,5 @@ spec:
       {{- if .Values.sentry.monitorsClockTick.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.monitorsClockTick.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-ingest-monitors.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.ingestMonitors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTasks.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTick.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.ingestOccurrences.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -177,4 +178,5 @@ spec:
       {{- if .Values.sentry.ingestOccurrences.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestOccurrences.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/occurrences/serviceaccount-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/serviceaccount-sentry-ingest-occurrences.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.ingestOccurrences.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.features.enableProfiling }}
 apiVersion: apps/v1
 kind: Deployment
@@ -177,4 +178,5 @@ spec:
       {{- if .Values.sentry.ingestProfiles.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestProfiles.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/profiles/serviceaccount-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/serviceaccount-sentry-ingest-profiles.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableProfiling }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.ingestReplayRecordings.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -177,4 +178,5 @@ spec:
       {{- if .Values.sentry.ingestReplayRecordings.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestReplayRecordings.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/serviceaccount-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/serviceaccount-sentry-ingest-replay-recordings.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.ingestReplayRecordings.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.ingestConsumerTransactions.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -198,4 +199,5 @@ spec:
       {{- if .Values.sentry.ingestConsumerTransactions.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.ingestConsumerTransactions.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.sentry.ingestConsumerTransactions.enabled .Values.sentry.ingestConsumerTransactions.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
@@ -30,4 +31,5 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/transactions/serviceaccount-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/serviceaccount-sentry-ingest-consumer-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerTransactions.enabled  }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.billingMetricsConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,4 +179,5 @@ spec:
       {{- if .Values.sentry.billingMetricsConsumer.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.billingMetricsConsumer.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/billing/serviceaccount-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/serviceaccount-sentry-billing-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.billingMetricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.metricsConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -188,4 +189,5 @@ spec:
       {{- if .Values.sentry.metricsConsumer.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.metricsConsumer.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.genericMetricsConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -188,4 +189,5 @@ spec:
       {{- if .Values.sentry.genericMetricsConsumer.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.genericMetricsConsumer.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/generic/serviceaccount-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/serviceaccount-sentry-generic-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.genericMetricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/serviceaccount-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/serviceaccount-sentry-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.metricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.postProcessForwardIssuePlatform.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -179,4 +180,5 @@ spec:
       {{- if .Values.sentry.postProcessForwardIssuePlatform.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.postProcessForwardIssuePlatform.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/serviceaccount-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/serviceaccount-sentry-post-process-forwarder-issue-platform.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardIssuePlatform.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.postProcessForwardTransactions.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -183,4 +184,5 @@ spec:
       {{- if .Values.sentry.postProcessForwardTransactions.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.postProcessForwardTransactions.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/serviceaccount-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/serviceaccount-sentry-post-process-forwarder-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardTransactions.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.processSegments.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -173,4 +174,5 @@ spec:
       {{- if .Values.sentry.processSegments.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.processSegments.priorityClassName }}"
       {{- end }}
-{{- end }} 
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/process/segments/serviceaccount-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/serviceaccount-sentry-process-segments.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.processSegments.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- end }} 
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.processSpans.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -173,4 +174,5 @@ spec:
       {{- if .Values.sentry.processSpans.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.processSpans.priorityClassName }}"
       {{- end }}
-{{- end }} 
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/process/spans/serviceaccount-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/serviceaccount-sentry-process-spans.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.processSpans.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- end }} 
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.subscriptionConsumerGenericMetrics.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -184,4 +185,5 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerGenericMetrics.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.subscriptionConsumerGenericMetrics.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/serviceaccount-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/serviceaccount-sentry-subscription-consumer-generic-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerGenericMetrics.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.subscriptionConsumerMetrics.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -184,4 +185,5 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerMetrics.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.subscriptionConsumerMetrics.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/serviceaccount-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/serviceaccount-sentry-subscription-consumer-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerMetrics.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.subscriptionConsumerTransactions.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -166,4 +167,5 @@ spec:
       {{- if .Values.sentry.subscriptionConsumerTransactions.priorityClassName }}
       priorityClassName: "{{ .Values.sentry.subscriptionConsumerTransactions.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/serviceaccount-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/serviceaccount-sentry-subscription-consumer-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerTransactions.enabled}}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.features.enableProfiling }}
 apiVersion: apps/v1
 kind: Deployment
@@ -138,4 +139,5 @@ spec:
       {{- if .Values.vroom.priorityClassName }}
       priorityClassName: "{{ .Values.vroom.priorityClassName }}"
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.vroom.autoscaling.enabled }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
@@ -30,4 +31,5 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/vroom/service-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/service-vroom.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.features.enableProfiling }}
 apiVersion: v1
 kind: Service
@@ -25,4 +26,5 @@ spec:
   selector:
     app: {{ template "sentry.fullname" . }}
     role: vroom
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/vroom/serviceaccount-sentry-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/serviceaccount-sentry-vroom.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableProfiling }}
 apiVersion: v1
 kind: ServiceAccount
@@ -7,4 +8,5 @@ metadata:
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.genericMetricsCountersConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.genericMetricsDistributionConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.genericMetricsGaugesConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.genericMetricsSetsConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.issueOccurrenceConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.metricsConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.features.enableProfiling }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.features.enableProfiling }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.sentry.features.enableProfiling }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.replaysConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.spansConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.subscriptionConsumerMetrics.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -146,5 +147,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.subscriptionConsumerTransactions.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -145,5 +146,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -1,3 +1,4 @@
+{{- if has "feature-complete" .Values.profiles }}
 {{- if .Values.snuba.transactionsConsumer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -178,5 +179,6 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -13,6 +13,13 @@ global:
   sidecars: []
   volumes: []
 
+# Profiles correspond to COMPOSE_PROFILES in the original self-hosted docker-compose.yml.
+# https://github.com/getsentry/self-hosted/blob/master/docker-compose.yml
+# When set to errors-only, the chart only deploys components related to processing errors.
+# For more, read https://develop.sentry.dev/self-hosted/experimental/errors-only/.
+profiles:
+  - feature-complete
+
 user:
   create: true
   email: admin@sentry.local


### PR DESCRIPTION
This pull request adds "errors-only" mode as first addressed in #1372.

I've looked up [the original docker compose](https://github.com/getsentry/self-hosted/blob/master/docker-compose.yml) file, and wrapped components which had `profiles: [feature-complete]` with if statements that check for active profiles.
While adding if statements, I've noticed some components are missing in this chart that are present in the original docker-compose.yml file - I've not addressed these in this PR.

This mimics the original docker compose behavior, so this should be easy to maintain.
However, I also noticed that `sentry.features` values is also present in the values.yaml file which seems to control the ConfigMap contents but not enable/disable the deployments themselves.
Perhaps a future task would be to "merge" these values toggle functions, so the chart users can choose which features to enable and deploy only the minimal components.

However, for now I've stuck with a simple approach of mimicking the compose profiles behavior for easier maintenance.
Please feel free to add corrections in this branch or discuss how we should implement "errors-only" mode in this chart.

Thanks!

closes #1372 (although already closed as stale)