### PR TITLE
fix(sentry): set `SENTRY_SELF_HOSTED_ERRORS_ONLY` when needed

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -170,6 +170,10 @@ sentry.conf.py: |-
 
   SENTRY_OPTIONS["system.event-retention-days"] = int(env('SENTRY_EVENT_RETENTION_DAYS') or {{ .Values.sentry.cleanup.days | quote }})
 
+  {{- if has "errors-only" .Values.profiles }}
+  SENTRY_SELF_HOSTED_ERRORS_ONLY = True
+  {{- end }}
+
   #########
   # Redis #
   #########


### PR DESCRIPTION
Following https://github.com/sentry-kubernetes/charts/pull/1810.
When Sentry is deployed in errors-only mode, an additional setting `SENTRY_SELF_HOSTED_ERRORS_ONLY` needs to be set to `True`.
For reference: [the setting in Sentry self-hosted](https://github.com/getsentry/self-hosted/blob/3e9e1ec367c7c45d6eb794e8763009ea83f16eac/sentry/sentry.conf.example.py#L96).