### PR TITLE
chore: remove duplicated topic snuba-profile-chunks

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2351,7 +2351,6 @@ kafka:
         config:
           "message.timestamp.type": LogAppendTime
       - name: profiles-call-tree
-      - name: snuba-profile-chunks
       - name: ingest-replay-events
         config:
           "message.timestamp.type": LogAppendTime


### PR DESCRIPTION
remove duplicated topic `snuba-profile-chunks` from `kafka.provisioning.topics` config