### PR TITLE
feat: Support `containerSecurityContext` for Symbolicator Cleaner container

### DIFF
--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -153,6 +153,10 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+{{- if .Values.symbolicator.apicleaner.cleaner.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.symbolicator.api.cleaner.containerSecurityContext | indent 12 }}
+{{- end }}
 {{- end }}
 {{- if .Values.symbolicator.api.sidecars }}
 {{ toYaml .Values.symbolicator.api.sidecars | indent 6 }}

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -153,7 +153,7 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
-{{- if .Values.symbolicator.apicleaner.cleaner.containerSecurityContext }}
+{{- if .Values.symbolicator.api.cleaner.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.symbolicator.api.cleaner.containerSecurityContext | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Providing `securityContext` for all containers is required in some environments.