### PR TITLE
feat(sentry): upgrade version

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -3,7 +3,7 @@ name: sentry
 description: A Helm chart for Kubernetes
 type: application
 version: 26.22.0
-appVersion: 25.5.1
+appVersion: 25.7.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -1,0 +1,169 @@
+{{- if .Values.sentry.subscriptionConsumerResultsEapItems.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-subscription-consumer-results-eap-items
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+        role: sentry-subscription-consumer-eap-spans
+  replicas: {{ .Values.sentry.subscriptionConsumerResultsEapItems.replicas }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include "sentry.config" . | sha256sum }}
+        {{- if .Values.sentry.subscriptionConsumerResultsEapItems.annotations }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+        role: sentry-subscription-consumer-eap-spans
+        {{- if .Values.sentry.subscriptionConsumerResultsEapItems.podLabels }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.affinity }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.topologySpreadConstraints | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-subscription-consumer-eap-spans
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "consumer"
+          - "subscription-results-eap-items"
+          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.sentry.subscriptionConsumerResultsEapItems.autoOffsetReset }}"
+          {{- end }}
+          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
+          - "--consumer-group"
+          - "subscription-results-eap-items"
+          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.enabled }}
+          - "--healthcheck-file-path"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.periodSeconds }}
+        {{- end }}
+        env:
+{{ include "sentry.env" . | indent 8 }}
+{{- if .Values.sentry.subscriptionConsumerResultsEapItems.env }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- if .Values.sentry.subscriptionConsumerResultsEapItems.volumeMounts }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.volumeMounts | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.resources | indent 12 }}
+{{- if .Values.sentry.subscriptionConsumerResultsEapItems.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if .Values.sentry.subscriptionConsumerResultsEapItems.sidecars }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-results-eap-items
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+{{- if .Values.sentry.subscriptionConsumerResultsEapItems.volumes }}
+{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.subscriptionConsumerResultsEapItems.priorityClassName }}"
+      {{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/serviceaccount-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/serviceaccount-sentry-subscription-results-eap-items.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerResultsEapItems.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-subscription-consumer-results-eap-items
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1363,6 +1363,27 @@ snuba:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
+  subscriptionConsumerResultsEapItems:
+    enabled: true
+    replicas: 1
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    topologySpreadConstraints: []
+    containerSecurityContext: {}
+    # tolerations: []
+    # podLabels: {}
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
+    # volumes: []
+    # volumeMounts: []
+    # autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
+
   subscriptionConsumerEvents:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
     replicas: 1

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -866,6 +866,27 @@ sentry:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
+  subscriptionConsumerResultsEapItems:
+    enabled: true
+    replicas: 1
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    topologySpreadConstraints: []
+    containerSecurityContext: {}
+    # tolerations: []
+    # podLabels: {}
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
+    # volumes: []
+    # volumeMounts: []
+    # autoOffsetReset: "earliest"
+    # noStrictOffsetReset: false
+
   subscriptionConsumerEvents:
     enabled: true
     replicas: 1
@@ -1343,27 +1364,6 @@ snuba:
     # noStrictOffsetReset: false
 
   subscriptionConsumerEapSpans:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
-    enabled: true
-    replicas: 1
-    env: []
-    resources: {}
-    affinity: {}
-    nodeSelector: {}
-    securityContext: {}
-    topologySpreadConstraints: []
-    containerSecurityContext: {}
-    # tolerations: []
-    # podLabels: {}
-    livenessProbe:
-      enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-    # volumes: []
-    # volumeMounts: []
-    # autoOffsetReset: "earliest"
-    # noStrictOffsetReset: false
-
-  subscriptionConsumerResultsEapItems:
     enabled: true
     replicas: 1
     env: []


### PR DESCRIPTION
This pull request introduces updates to the Sentry Helm chart, including a version bump and the addition of new Kubernetes resources for managing the `subscription-consumer-results-eap-items` component. The changes focus on improving deployment flexibility and adding support for a new consumer.

### Version Updates:
* Updated the `appVersion` in `charts/sentry/Chart.yaml` from `25.5.1` to `25.7.0`, reflecting the latest application release.

### New Kubernetes Resources for `subscription-consumer-results-eap-items`:
* **Deployment**: Added a new deployment template to manage the `subscription-consumer-results-eap-items` consumer. This includes support for custom annotations, labels, affinity, tolerations, security contexts, and resource configurations.
* **ServiceAccount**: Introduced a dedicated ServiceAccount for the `subscription-consumer-results-eap-items` consumer, with optional annotations and token automount configuration.