### PR TITLE
chore(deps): upgrade app version

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -3,6 +3,7 @@ name: sentry
 description: A Helm chart for Kubernetes
 type: application
 version: 27.0.0
+# renovate image=docker.io/getsentry/sentry
 appVersion: 25.7.0
 dependencies:
   - name: memcached

--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,33 @@
 {
-  "extends": ["config:recommended", ":rebaseStalePrs", "docker:disable"],
+  "extends": [
+    "config:recommended",
+    ":rebaseStalePrs",
+    "docker:disable",
+    "customManagers:helmChartYamlAppVersions"
+  ],
   "enabled": true,
   "prConcurrentLimit": 30,
-  "enabledManagers": ["helmv3", "github-actions"],
+  "enabledManagers": [
+    "helmv3",
+    "github-actions"
+  ],
   "schedule": [
     "before 5am on Monday"
   ],
   "packageRules": [
     {
-      "updateTypes": ["patch", "minor"],
+      "updateTypes": [
+        "patch",
+        "minor"
+      ],
       "schedule": [
         "before 5am on Monday"
       ]
     },
     {
-      "updateTypes": ["major"],
+      "updateTypes": [
+        "major"
+      ],
       "schedule": [
         "before 5am on the first day of the month"
       ]


### PR DESCRIPTION
This pull request introduces changes to improve dependency management and configuration for Renovate, as well as updates to the Helm chart metadata. The most significant changes include adding a Renovate-specific image annotation in the Helm chart and extending Renovate's configuration to include custom Helm chart app version management.

### Dependency and configuration improvements:

* [`charts/sentry/Chart.yaml`](diffhunk://#diff-e6369eabde1bc7fdda74820867d9c7520ccf5b9c3222bde88815d9ad894f366cR6): Added a Renovate-specific annotation (`# renovate image=docker.io/getsentry/sentry`) to specify the Docker image for the Sentry Helm chart. This facilitates automated updates of the image version.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L2-R30): Enhanced Renovate's configuration by adding the `customManagers:helmChartYamlAppVersions` preset to manage app versions in Helm chart YAML files. This ensures that app version updates are properly handled.