### PR TITLE
fix(vroom): add persistent storage configuration

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -683,7 +683,7 @@ Set external Clickhouse password from existingSecret
 - name: SENTRY_KAFKA_BROKERS_OCCURRENCES
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
 - name: SENTRY_BUCKET_PROFILES
-  value: file://localhost//var/lib/sentry-profiles
+  value: "file:///var/vroom/sentry-profiles"
 - name: SENTRY_SNUBA_HOST
   value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" . }}
 {{- end -}}

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -85,11 +85,14 @@ spec:
         env:
         - name: VROOM_PORT
           value: '{{ template "vroom.port" }}'
+{{- include "vroom.env" . | nindent 8 }}
 {{- if .Values.vroom.env }}
 {{ toYaml .Values.vroom.env | indent 8 }}
 {{- end }}
-{{- if .Values.vroom.volumeMounts }}
         volumeMounts:
+        - name: vroom-storage
+          mountPath: /var/vroom/sentry-profiles
+{{- if .Values.vroom.volumeMounts }}
 {{ toYaml .Values.vroom.volumeMounts | indent 10 }}
 {{- end }}
         livenessProbe:
@@ -127,14 +130,20 @@ spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-vroom
       {{- end }}
-{{- if or .Values.vroom.volumes .Values.global.volumes }}
       volumes:
+      {{- if .Values.vroom.persistence.enabled }}
+      - name: vroom-storage
+        persistentVolumeClaim:
+          claimName: sentry-vroom-pvc
+      {{- else }}
+      - name: vroom-storage
+        emptyDir: {}
+      {{- end }}
 {{- if .Values.vroom.volumes }}
 {{ toYaml .Values.vroom.volumes | indent 6 }}
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
-{{- end }}
 {{- end }}
       {{- if .Values.vroom.priorityClassName }}
       priorityClassName: "{{ .Values.vroom.priorityClassName }}"

--- a/charts/sentry/templates/sentry/vroom/pvc-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/pvc-vroom.yaml
@@ -1,0 +1,28 @@
+{{- if has "feature-complete" .Values.profiles }}
+{{- if .Values.sentry.features.enableProfiling }}
+{{- if .Values.vroom.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sentry-vroom-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: vroom
+spec:
+  accessModes:
+{{- range .Values.vroom.persistence.accessModes }}
+    - {{ . | quote }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.vroom.persistence.size | quote }}
+  {{- if .Values.vroom.persistence.storageClassName }}
+  storageClassName: {{ .Values.vroom.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -97,6 +97,12 @@ vroom:
     annotations: {}
   # tolerations: []
   # podLabels: {}
+  persistence:
+    enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
+    accessModes:
+      - ReadWriteOnce
+    # storageClassName: standard
+    size: "10Gi"
 
   autoscaling:
     enabled: false


### PR DESCRIPTION
This pull request introduces changes to improve the configuration and deployment of the `vroom` component in the Sentry Helm chart. The updates focus on enabling persistent storage for profiling data, adjusting environment variables, and refining deployment templates. Below are the most significant changes grouped by theme:

### Persistent Storage for Profiling Data:
* Added a PersistentVolumeClaim (PVC) definition for `vroom` when profiling is enabled and persistence is configured. This allows storage for profiling data to be backed by a persistent volume. (`charts/sentry/templates/sentry/vroom/pvc-vroom.yaml`, [charts/sentry/templates/sentry/vroom/pvc-vroom.yamlR1-R28](diffhunk://#diff-b76eec27d59baa4933af6bfc31f4c5cbfd9f180b1f10fd5cd2d605b92f29ca60R1-R28))
* Updated the `vroom` deployment to conditionally include a persistent volume or `emptyDir` based on the persistence configuration. (`charts/sentry/templates/sentry/vroom/deployment-vroom.yaml`, [charts/sentry/templates/sentry/vroom/deployment-vroom.yamlL130-L137](diffhunk://#diff-a12159af3e526a565fb39ab0b59ba342804e8e5a7996f1a43adc7117f725f81aL130-L137))
* Introduced new persistence-related settings in `values.yaml`, including options to enable persistence, specify access modes, storage class, and size. (`charts/sentry/values.yaml`, [charts/sentry/values.yamlR100-R105](diffhunk://#diff-65cdeb87e3ade9495c0f750360f2b92df5010a2bcb0ae4f587f1339dbc4fc0a8R100-R105))

### Environment and Volume Configuration:
* Updated the `SENTRY_BUCKET_PROFILES` environment variable to use a new path (`/var/vroom/sentry-profiles`) for profiling data storage. (`charts/sentry/templates/_helper.tpl`, [charts/sentry/templates/_helper.tplL686-R686](diffhunk://#diff-1327e24804f05c729b65b01af5f5a8cd1c8496a44ed336e3339c20c4fd805dbaL686-R686))
* Added a volume mount for `vroom-storage` in the `vroom` deployment to ensure the new profiling data path is properly mounted. (`charts/sentry/templates/sentry/vroom/deployment-vroom.yaml`, [charts/sentry/templates/sentry/vroom/deployment-vroom.yamlR88-R95](diffhunk://#diff-a12159af3e526a565fb39ab0b59ba342804e8e5a7996f1a43adc7117f725f81aR88-R95))