### PR TITLE
ci(lint): enhance chart-testing command with Sentry feature flags

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s --set sentry.features.enableProfiling=true --set sentry.features.enableSessionReplay=true --set sentry.features.enableFeedback=true --set sentry.features.enableSpan=true"


### PR DESCRIPTION
This pull request includes a small but important update to the `lint-test.yaml` workflow file. The change enhances the Helm chart-testing command by enabling additional Sentry features during the installation process.

* [`.github/workflows/lint-test.yaml`](diffhunk://#diff-8ee75a42ccdffb28e750aba529bb689756d1773f5b5052e1ffea9486cf5fb2b7L54-R54): Updated the `ct install` command to include Helm arguments that enable the following Sentry features: `enableProfiling`, `enableSessionReplay`, `enableFeedback`, and `enableSpan`.