### PR TITLE
feat(snuba): add uptime consumer deployment configuration

### DIFF
--- a/charts/sentry/templates/sentry/subscription-consumer/results/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results/deployment-sentry-uptime-results.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.sentry.subscriptionConsumerResultsEapItems.enabled }}
+{{- if .Values.sentry.uptimeResults.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "sentry.fullname" . }}-subscription-consumer-results-eap-items
+  name: {{ template "sentry.fullname" . }}-uptime-results-consumer
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -24,53 +24,53 @@ spec:
         app: sentry
         release: "{{ .Release.Name }}"
         role: sentry-subscription-consumer-eap-spans
-  replicas: {{ .Values.sentry.subscriptionConsumerResultsEapItems.replicas }}
+  replicas: {{ .Values.sentry.uptimeResults.replicas }}
   template:
     metadata:
       annotations:
         checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
         checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
         checksum/config.yaml: {{ include "sentry.config" . | sha256sum }}
-        {{- if .Values.sentry.subscriptionConsumerResultsEapItems.annotations }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.annotations | indent 8 }}
+        {{- if .Values.sentry.uptimeResults.annotations }}
+{{ toYaml .Values.sentry.uptimeResults.annotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
         role: sentry-subscription-consumer-eap-spans
-        {{- if .Values.sentry.subscriptionConsumerResultsEapItems.podLabels }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.podLabels | indent 8 }}
+        {{- if .Values.sentry.uptimeResults.podLabels }}
+{{ toYaml .Values.sentry.uptimeResults.podLabels | indent 8 }}
         {{- end }}
     spec:
       affinity:
-      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.affinity }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.affinity | indent 8 }}
+      {{- if .Values.sentry.uptimeResults.affinity }}
+{{ toYaml .Values.sentry.uptimeResults.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.nodeSelector }}
+      {{- if .Values.sentry.uptimeResults.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.nodeSelector | indent 8 }}
+{{ toYaml .Values.sentry.uptimeResults.nodeSelector | indent 8 }}
       {{- else if .Values.global.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.tolerations }}
+      {{- if .Values.sentry.uptimeResults.tolerations }}
       tolerations:
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.tolerations | indent 8 }}
+{{ toYaml .Values.sentry.uptimeResults.tolerations | indent 8 }}
       {{- else if .Values.global.tolerations }}
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.topologySpreadConstraints }}
+      {{- if .Values.sentry.uptimeResults.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.topologySpreadConstraints | indent 8 }}
+{{ toYaml .Values.sentry.uptimeResults.topologySpreadConstraints | indent 8 }}
       {{- end }}
       {{- if .Values.images.sentry.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
       {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.securityContext }}
+      {{- if .Values.sentry.uptimeResults.securityContext }}
       securityContext:
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.securityContext | indent 8 }}
+{{ toYaml .Values.sentry.uptimeResults.securityContext | indent 8 }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-subscription-consumer-eap-spans
@@ -80,33 +80,33 @@ spec:
         args:
           - "run"
           - "consumer"
-          - "subscription-results-eap-items"
-          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.autoOffsetReset }}
+          - "uptime-results"
+          {{- if .Values.sentry.uptimeResults.autoOffsetReset }}
           - "--auto-offset-reset"
-          - "{{ .Values.sentry.subscriptionConsumerResultsEapItems.autoOffsetReset }}"
+          - "{{ .Values.sentry.uptimeResults.autoOffsetReset }}"
           {{- end }}
-          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.noStrictOffsetReset }}
+          {{- if .Values.sentry.uptimeResults.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
           - "--consumer-group"
-          - "subscription-results-eap-items"
-          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.enabled }}
+          - "uptime-results"
+          {{- if .Values.sentry.uptimeResults.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
-        {{- if .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.enabled }}
+        {{- if .Values.sentry.uptimeResults.livenessProbe.enabled }}
         livenessProbe:
           exec:
             command:
               - rm
               - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.periodSeconds }}
+          initialDelaySeconds: {{ .Values.sentry.uptimeResults.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentry.uptimeResults.livenessProbe.periodSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}
-{{- if .Values.sentry.subscriptionConsumerResultsEapItems.env }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.env | indent 8 }}
+{{- if .Values.sentry.uptimeResults.env }}
+{{ toYaml .Values.sentry.uptimeResults.env | indent 8 }}
 {{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
@@ -118,23 +118,23 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
-{{- if .Values.sentry.subscriptionConsumerResultsEapItems.volumeMounts }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.volumeMounts | indent 8 }}
+{{- if .Values.sentry.uptimeResults.volumeMounts }}
+{{ toYaml .Values.sentry.uptimeResults.volumeMounts | indent 8 }}
 {{- end }}
         resources:
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.resources | indent 12 }}
-{{- if .Values.sentry.subscriptionConsumerResultsEapItems.containerSecurityContext }}
+{{ toYaml .Values.sentry.uptimeResults.resources | indent 12 }}
+{{- if .Values.sentry.uptimeResults.containerSecurityContext }}
         securityContext:
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.containerSecurityContext | indent 12 }}
+{{ toYaml .Values.sentry.uptimeResults.containerSecurityContext | indent 12 }}
 {{- end }}
-{{- if .Values.sentry.subscriptionConsumerResultsEapItems.sidecars }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.sidecars | indent 6 }}
+{{- if .Values.sentry.uptimeResults.sidecars }}
+{{ toYaml .Values.sentry.uptimeResults.sidecars | indent 6 }}
 {{- end }}
 {{- if .Values.global.sidecars }}
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-results-eap-items
+      serviceAccountName: {{ .Values.serviceAccount.name }}-uptime-results
       {{- end }}
       volumes:
       - name: config
@@ -157,13 +157,13 @@ spec:
         secret:
           secretName: {{ .Values.filestore.gcs.secretName }}
       {{ end }}
-{{- if .Values.sentry.subscriptionConsumerResultsEapItems.volumes }}
-{{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.volumes | indent 6 }}
+{{- if .Values.sentry.uptimeResults.volumes }}
+{{ toYaml .Values.sentry.uptimeResults.volumes | indent 6 }}
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.sentry.subscriptionConsumerResultsEapItems.priorityClassName }}
-      priorityClassName: "{{ .Values.sentry.subscriptionConsumerResultsEapItems.priorityClassName }}"
+      {{- if .Values.sentry.uptimeResults.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.uptimeResults.priorityClassName }}"
       {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/results/serviceaccount-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results/serviceaccount-sentry-uptime-results.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerResultsEapItems.enabled }}
+{{- if and .Values.serviceAccount.enabled .Values.sentry.uptimeResults.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}-subscription-consumer-results-eap-items
+  name: {{ .Values.serviceAccount.name }}-uptime-results
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-uptime-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-uptime-consumer.yaml
@@ -1,0 +1,184 @@
+{{- if has "feature-complete" .Values.profiles }}
+{{- if .Values.snuba.uptimeConsumer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-snuba-uptime-consumer
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "12"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: snuba-transactions-consumer
+  replicas: {{ .Values.snuba.uptimeConsumer.replicas }}
+  template:
+    metadata:
+      annotations:
+        checksum/snubaSettingsPy: {{ .Values.config.snubaSettingsPy | sha256sum }}
+        checksum/config.yaml: {{ include "sentry.snuba.config" . | sha256sum }}
+        {{- if .Values.snuba.uptimeConsumer.annotations }}
+{{ toYaml .Values.snuba.uptimeConsumer.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: snuba-transactions-consumer
+        {{- if .Values.snuba.uptimeConsumer.podLabels }}
+{{ toYaml .Values.snuba.uptimeConsumer.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.snuba.uptimeConsumer.affinity }}
+{{ toYaml .Values.snuba.uptimeConsumer.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.snuba.uptimeConsumer.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.snuba.uptimeConsumer.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.snuba.uptimeConsumer.tolerations }}
+      tolerations:
+{{ toYaml .Values.snuba.uptimeConsumer.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.snuba.uptimeConsumer.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.snuba.uptimeConsumer.topologySpreadConstraints | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.snuba.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.snuba.uptimeConsumer.securityContext }}
+      securityContext:
+{{ toYaml .Values.snuba.uptimeConsumer.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-snuba
+        image: "{{ template "snuba.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.snuba.pullPolicy }}
+        command:
+          - "snuba"
+          - {{ if .Values.snuba.rustConsumer -}}"rust-consumer"{{- else -}}"consumer"{{- end }}
+          - "--storage"
+          - "transactions"
+          - "--consumer-group"
+          - "transactions_group"
+          {{- if .Values.snuba.uptimeConsumer.autoOffsetReset }}
+          - "--auto-offset-reset"
+          - "{{ .Values.snuba.uptimeConsumer.autoOffsetReset }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.snuba.uptimeConsumer.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.processes }}
+          - "--processes"
+          - "{{ .Values.snuba.uptimeConsumer.processes }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.inputBlockSize }}
+          - "--input-block-size"
+          - "{{ .Values.snuba.uptimeConsumer.inputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.outputBlockSize }}
+          - "--output-block-size"
+          - "{{ .Values.snuba.uptimeConsumer.outputBlockSize }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.snuba.uptimeConsumer.maxBatchTimeMs }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.queuedMaxMessagesKbytes }}
+          - "--queued-max-messages-kbytes"
+          - "{{ .Values.snuba.uptimeConsumer.queuedMaxMessagesKbytes }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.queuedMinMessages }}
+          - "--queued-min-messages"
+          - "{{ .Values.snuba.uptimeConsumer.queuedMinMessages }}"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.noStrictOffsetReset }}
+          - "--no-strict-offset-reset"
+          {{- end }}
+          {{- if .Values.snuba.uptimeConsumer.livenessProbe.enabled }}
+          - "--health-check-file"
+          - "/tmp/health.txt"
+          {{- end }}
+        {{- if .Values.snuba.uptimeConsumer.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - rm
+              - /tmp/health.txt
+          initialDelaySeconds: {{ .Values.snuba.uptimeConsumer.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snuba.uptimeConsumer.livenessProbe.periodSeconds }}
+        {{- end }}
+        ports:
+        - containerPort: {{ template "snuba.port" }}
+        env:
+{{ include "sentry.snuba.env" . | indent 8 }}
+{{- if .Values.snuba.uptimeConsumer.env }}
+{{ toYaml .Values.snuba.uptimeConsumer.env | indent 8 }}
+{{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ template "sentry.fullname" . }}-snuba-env
+        volumeMounts:
+        - mountPath: /etc/snuba
+          name: config
+          readOnly: true
+{{- if .Values.snuba.uptimeConsumer.volumeMounts }}
+{{ toYaml .Values.snuba.uptimeConsumer.volumeMounts | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.snuba.uptimeConsumer.resources | indent 12 }}
+{{- if .Values.snuba.uptimeConsumer.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.snuba.uptimeConsumer.containerSecurityContext | indent 12 }}
+{{- end }}
+{{- if .Values.snuba.uptimeConsumer.sidecars }}
+{{ toYaml .Values.snuba.uptimeConsumer.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "sentry.fullname" . }}-snuba
+{{- if .Values.snuba.uptimeConsumer.volumes }}
+{{ toYaml .Values.snuba.uptimeConsumer.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -873,7 +873,7 @@ sentry:
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
-  subscriptionConsumerResultsEapItems:
+  uptimeResults:
     enabled: true
     replicas: 1
     env: []
@@ -1639,6 +1639,39 @@ snuba:
     #       medium: Memory
 
   transactionsConsumer:
+    enabled: true
+    replicas: 1
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    topologySpreadConstraints: []
+    containerSecurityContext: {}
+    # tolerations: []
+    # podLabels: {}
+    # autoOffsetReset: "earliest"
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 320
+    # maxBatchSize: ""
+    # processes: ""
+    # inputBlockSize: ""
+    # outputBlockSize: ""
+    maxBatchTimeMs: 750
+    # queuedMaxMessagesKbytes: ""
+    # queuedMinMessages: ""
+    # noStrictOffsetReset: false
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+    # volumes:
+    #   - name: dshm
+    #     emptyDir:
+    #       medium: Memory
+
+  uptimeConsumer:
     enabled: true
     replicas: 1
     env: []


### PR DESCRIPTION
This pull request introduces a significant update to the Sentry Helm charts, primarily focusing on renaming and restructuring components related to "subscription-consumer-results-eap-items" and introducing new configurations for "uptime-results" and "uptime-consumer." The changes aim to improve clarity, consistency, and functionality in deployment configurations.

### Renaming and Refactoring Subscription Consumer:
* The file `deployment-sentry-subscription-results-eap-items.yaml` was renamed to `deployment-sentry-uptime-results.yaml`, and all references to `subscriptionConsumerResultsEapItems` were replaced with `uptimeResults` in the deployment configuration. This includes updates to fields such as `replicas`, `annotations`, `podLabels`, `affinity`, `nodeSelector`, `tolerations`, `volumes`, and `securityContext`. [[1]](diffhunk://#diff-38ef4f0603176d78bd2fbaa6eddd455ce744b1964a5472f64f7fec456fb0a477L1-R5) [[2]](diffhunk://#diff-38ef4f0603176d78bd2fbaa6eddd455ce744b1964a5472f64f7fec456fb0a477L27-R73) [[3]](diffhunk://#diff-38ef4f0603176d78bd2fbaa6eddd455ce744b1964a5472f64f7fec456fb0a477L83-R109) [[4]](diffhunk://#diff-38ef4f0603176d78bd2fbaa6eddd455ce744b1964a5472f64f7fec456fb0a477L121-R137) [[5]](diffhunk://#diff-38ef4f0603176d78bd2fbaa6eddd455ce744b1964a5472f64f7fec456fb0a477L160-R167)

* The service account file `serviceaccount-sentry-subscription-results-eap-items.yaml` was renamed to `serviceaccount-sentry-uptime-results.yaml`, with corresponding updates to the service account naming and enabling conditions.

### Addition of Snuba Uptime Consumer:
* A new deployment configuration for the Snuba uptime consumer was added in `deployment-snuba-uptime-consumer.yaml`. This includes support for configurable replicas, environment variables, resource limits, liveness probes, and other deployment settings.

### Updates to Values Configuration:
* In `values.yaml`, the `subscriptionConsumerResultsEapItems` section was replaced with `uptimeResults`, and a new `uptimeConsumer` section was added under the `snuba` configuration. These changes introduce default settings for replicas, liveness probes, and other deployment parameters. [[1]](diffhunk://#diff-65cdeb87e3ade9495c0f750360f2b92df5010a2bcb0ae4f587f1339dbc4fc0a8L876-R876) [[2]](diffhunk://#diff-65cdeb87e3ade9495c0f750360f2b92df5010a2bcb0ae4f587f1339dbc4fc0a8R1674-R1706)