### PR TITLE
chore(chart): add some metadata

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -41,3 +41,7 @@ dependencies:
     condition: nginx.enabled
 maintainers:
   - name: sentry-kubernetes
+icon: https://raw.githubusercontent.com/sentry-kubernetes/charts/refs/heads/develop/docs/logo.png
+home: https://github.com/sentry-kubernetes/charts
+sources:
+  - https://github.com/sentry-kubernetes/charts/tree/develop/charts/sentry


### PR DESCRIPTION
This pull request adds metadata to the `charts/sentry/Chart.yaml` file to improve documentation and accessibility for the Sentry Helm chart.

* Metadata additions:
  * Added an `icon` field with a link to the Sentry Kubernetes logo.
  * Added a `home` field pointing to the GitHub repository for Sentry Kubernetes charts.
  * Added a `sources` field with a link to the source directory of the Sentry chart.