### PR TITLE
feat: Add flexible PagerDuty configuration via values.yaml or Kubernetes secrets

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -333,6 +333,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | nginx.service.ports.http | int | `80` |  |
 | nginx.service.type | string | `"ClusterIP"` |  |
 | openai | object | `{}` |  |
+| pagerduty | object | `{}` |  |
 | pgbouncer.affinity | object | `{}` |  |
 | pgbouncer.authType | string | `"md5"` |  |
 | pgbouncer.enabled | bool | `false` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -930,6 +930,17 @@ Set discord
 {{- end }}
 
 {{/*
+Set pagerduty
+*/}}
+{{- if .Values.pagerduty.existingSecret }}
+- name: PAGERDUTY_APP_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.pagerduty.existingSecret }}
+      key: {{ default "app-id" .Values.pagerduty.existingSecretAppId }}
+{{- end }}
+
+{{/*
 Set github app
 */}}
 {{- if and .Values.github.existingSecret }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -72,6 +72,13 @@ config.yml: |-
   discord.bot-token: {{ .Values.discord.botToken | quote }}
   {{ end }}
 
+  ###########
+  # Pagerduty #
+  ###########
+  {{- if and (.Values.pagerduty.appId) (not .Values.pagerduty.existingSecret) }}
+  pagerduty.app-id: {{ .Values.pagerduty.appId | quote }}
+  {{- end }}
+
   #########
   # Redis #
   #########
@@ -674,6 +681,13 @@ sentry.conf.py: |-
   SENTRY_OPTIONS['discord.public-key'] = os.environ.get("DISCORD_PUBLIC_KEY")
   SENTRY_OPTIONS['discord.client-secret'] = os.environ.get("DISCORD_CLIENT_SECRET")
   SENTRY_OPTIONS['discord.bot-token'] = os.environ.get("DISCORD_BOT_TOKEN")
+{{- end }}
+
+{{- if .Values.pagerduty.existingSecret }}
+  #############
+  # PAGERDUTY #
+  #############
+  SENTRY_OPTIONS['pagerduty.app-id'] = os.environ.get("PAGERDUTY_APP_ID")
 {{- end }}
 
 {{- if .Values.google.existingSecret }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2114,6 +2114,12 @@ discord: {}
 #   existingSecretBotToken: ""          # by default "bot-token"
 #   Reference -> https://develop.sentry.dev/integrations/discord/
 
+pagerduty: {}
+#   appId: ""
+#   existingSecret: "xxxxx"
+#   existingSecretAppId: ""     # by default "app-id"
+#   Reference -> https://develop.sentry.dev/integrations/pagerduty/
+
 openai: {}
 #   existingSecret: "xxxxx"
 #   existingSecretKey: ""               # by default "api-token"


### PR DESCRIPTION
## Summary
This PR adds flexible PagerDuty configuration options to the Sentry Helm chart, allowing users to configure PagerDuty integration either directly through values.yaml or by referencing existing Kubernetes secrets.

## Changes Made

### 1. Enhanced PagerDuty Configuration Options
- **Direct Configuration**: Users can now set `pagerduty.appId` directly in values.yaml for simple deployments
- **Secret-based Configuration**: Support for `pagerduty.existingSecret` to reference existing Kubernetes secrets containing PagerDuty credentials
- **Flexible Secret Key**: Configurable secret key via `pagerduty.existingSecretAppId` (defaults to "app-id")

### 2. Template Updates
- **`_helper-sentry.tpl`**: Added logic to handle both configuration methods
  - Direct appId configuration when no existing secret is specified
  - Environment variable reference when using existing secrets
- **`_helper.tpl`**: Added environment variable injection for secret-based configuration

### 3. Configuration Examples
```yaml
# Option 1: Direct configuration
pagerduty:
  appId: "your-pagerduty-app-id"

# Option 2: Secret-based configuration
pagerduty:
  existingSecret: "pagerduty-secret"
  existingSecretAppId: "app-id"  # optional, defaults to "app-id"
```

## Benefits
- **Flexibility**: Supports both simple and enterprise-grade deployment patterns
- **Security**: Allows sensitive credentials to be managed through Kubernetes secrets
- **Backward Compatibility**: Existing configurations continue to work unchanged
- **Best Practices**: Follows Helm chart patterns for secret management

## Documentation
Updated values.yaml with comprehensive examples and references to Sentry's PagerDuty integration documentation.
