### PR TITLE
ci: fix chart testing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Add Helm Repositories
         run: |
           helm repo add sentry-kubernetes https://sentry-kubernetes.github.io/charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
 
       - name: Run chart-testing (list-changed)
@@ -47,8 +48,8 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1.12.0
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s --set sentry.features.enableProfiling=true --set sentry.features.enableSessionReplay=true --set sentry.features.enableFeedback=true --set sentry.features.enableSpan=true"
+        run: ct install --debug --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args "--timeout 1000s"

--- a/charts/sentry/ci/kind-values.yaml
+++ b/charts/sentry/ci/kind-values.yaml
@@ -1,0 +1,28 @@
+profiles:
+  - errors-only
+
+kafka:
+  enabled: true
+  kraft:
+    enabled: true
+  provisioning:
+    replicationFactor: 1
+  controller:
+    replicaCount: 1
+  broker:
+    replicaCount: 1
+
+redis:
+  enabled: true
+  master.persistence.enabled: false
+  replica.replicaCount: 0
+
+rabbitmq:
+  enabled: false
+
+clickhouse:
+  enabled: true
+  replicaCount: 1
+  shards: 1
+  keeper:
+    replicaCount: 1


### PR DESCRIPTION
This pull request updates the Helm chart testing workflow and introduces a new configuration file for kind-based testing. The main changes focus on improving the CI pipeline for Helm charts and adding a dedicated set of values for local testing with kind.

**CI/CD Workflow Improvements:**

* Updated the Helm kind-action version from `v1.10.0` to `v1.12.0` to ensure compatibility and access to newer features.
* Added the Bitnami Helm repository to the workflow setup for broader chart support.
* Enabled debug mode for chart-testing installs and simplified Helm extra arguments, removing feature-specific flags for a cleaner install process.

**Kind Testing Configuration:**

* Added `charts/sentry/ci/kind-values.yaml` to provide tailored values for kind-based CI testing, including enabling Kafka (with Kraft mode), Redis (without persistence), ClickHouse, and disabling RabbitMQ for simplified local testing.