### PR TITLE
ci: remove blocking update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:recommended",
     ":rebaseStalePrs",
-    "docker:disable",
     "customManagers:helmChartYamlAppVersions"
   ],
   "enabled": true,


### PR DESCRIPTION
This pull request makes a small update to the `renovate.json` configuration file by removing the `docker:disable` extension. This change will re-enable Docker updates managed by Renovate and enable "customManagers:helmChartYamlAppVersions" :thinking:.