### PR TITLE
feat(hpa): add behavior support for hpa v2

### DIFF
--- a/charts/sentry/templates/relay/hpa-relay.yaml
+++ b/charts/sentry/templates/relay/hpa-relay.yaml
@@ -35,4 +35,10 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.relay.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.relay.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-ingest-consumer-attachments
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-consumer-attachments
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.ingestConsumerAttachments.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-ingest-consumer-events
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-consumer-events
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.ingestConsumerEvents.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
@@ -15,21 +15,27 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-ingest-consumer-transactions
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-consumer-transactions
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.ingestConsumerTransactions.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
@@ -15,21 +15,27 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-vroom
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-vroom
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.vroom.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/web/hpa-web.yaml
+++ b/charts/sentry/templates/sentry/web/hpa-web.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-web
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-web
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.web.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/hpa-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/hpa-worker-events.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-worker
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-worker
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.workerEvents.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.workerEvents.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/hpa-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/hpa-worker-transactions.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-worker
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-worker
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.workerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.workerTransactions.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/hpa-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/hpa-worker.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.sentry.worker.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-worker
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-worker
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.worker.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.sentry.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.worker.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.worker.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/hpa-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/hpa-snuba-api.yaml
@@ -14,20 +14,26 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
   {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
   metrics:
-  - type: ContainerResource
-    containerResource:
-      container: {{ .Chart.Name }}-snuba
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-snuba
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
   {{- else }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.snuba.api.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -109,6 +109,8 @@ vroom:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
+    # Only available with autoscaling/v2
+    behavior: {}
   sidecars: []
   # topologySpreadConstraints: []
   volumes: []
@@ -150,6 +152,8 @@ relay:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
+    # Only available with autoscaling/v2
+    behavior: {}
   sidecars: []
   topologySpreadConstraints: []
   volumes: []
@@ -245,6 +249,8 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -292,6 +298,8 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     livenessProbe:
       enabled: true
       periodSeconds: 60
@@ -330,6 +338,8 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     livenessProbe:
       enabled: false
       periodSeconds: 60
@@ -366,6 +376,8 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     livenessProbe:
       enabled: false
       periodSeconds: 60
@@ -405,6 +417,8 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -445,6 +459,8 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -485,6 +501,8 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1184,6 +1202,8 @@ snuba:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # Only available with autoscaling/v2
+      behavior: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []


### PR DESCRIPTION
Hello,

This feature add the support of [`behavior`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) configuration for `autoscaling/v2`.

I also fix a yaml indentation.

Regards,