### PR TITLE
fix: snuba-subscription-consumer-generic-metrics-distribution indentation

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -38,7 +38,7 @@ spec:
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
-        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-distributions" "ctx" .) | nindent 4 }}
+        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-distributions" "ctx" .) | nindent 8 }}
         role: snuba-subscription-consumer-generic-metrics-distributions
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsDistributions.podLabels }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsDistributions.podLabels | indent 8 }}


### PR DESCRIPTION
Hello, 
this fixes #1857 
it was caused by an indentation error