### PR TITLE
fix(templates): fix indentation for multiple deployments yamls

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -39,7 +39,7 @@ spec:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: snuba-subscription-consumer-generic-metrics-counters
-        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-counters" "ctx" .) | nindent 4 }}
+        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-counters" "ctx" .) | nindent 8 }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsCounters.podLabels }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsCounters.podLabels | indent 8 }}
         {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -39,7 +39,7 @@ spec:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: snuba-subscription-consumer-generic-metrics-gauges
-        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-gauges" "ctx" .) | nindent 4 }}
+        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-gauges" "ctx" .) | nindent 8 }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsGauges.podLabels }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsGauges.podLabels | indent 8 }}
         {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -39,7 +39,7 @@ spec:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: snuba-subscription-consumer-generic-metrics-sets
-        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-sets" "ctx" .) | nindent 4 }}
+        {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-generic-metrics-sets" "ctx" .) | nindent 8 }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsSets.podLabels }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsSets.podLabels | indent 8 }}
         {{- end }}

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -31,7 +31,7 @@ spec:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: symbolicator-api
-        {{- include "sentry.component.labels" (dict "component" "symbolicator-api" "ctx" .) | nindent 4 }}
+        {{- include "sentry.component.labels" (dict "component" "symbolicator-api" "ctx" .) | nindent 8 }}
         {{- if .Values.symbolicator.api.podLabels }}
 {{ toYaml .Values.symbolicator.api.podLabels | indent 8 }}
         {{- end }}


### PR DESCRIPTION
The recently added labels are not correctly placed in some files.

This fixes this.