### PR TITLE
feat: Enhance clickhouse cleanup job

### DIFF
--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -69,8 +69,8 @@ spec:
           {{- end }}
           containers:
           - name: {{ .Chart.Name }}-clickhouse-cleanup
-            image: clickhouse/clickhouse-client:latest
-            imagePullPolicy: IfNotPresent
+            image: {{ .Values.snuba.cleanup.image.repository }}:{{ .Values.snuba.cleanup.image.tag }}
+            imagePullPolicy: {{ .Values.snuba.cleanup.image.pullPolicy }}
             command: ["/bin/bash"]
             args:
               - "-c"
@@ -78,27 +78,27 @@ spec:
                 set -e
                 echo "Starting ClickHouse cleanup with retention period of {{ .Values.snuba.cleanup.retentionDays }} days"
                 echo "Connecting to ClickHouse at $CLICKHOUSE_HOST:$CLICKHOUSE_PORT"
-                
+
+                # Build clickhouse-client arguments; omit --password if empty to avoid bad-arg error
+                CH_ARGS=(--host="$CLICKHOUSE_HOST" --port="$CLICKHOUSE_PORT" --user="$CLICKHOUSE_USER" --database="$CLICKHOUSE_DATABASE")
+                if [ -n "$CLICKHOUSE_PASSWORD" ]; then
+                  CH_ARGS+=(--password="$CLICKHOUSE_PASSWORD")
+                fi
+
                 # Function to discover tables
                 discover_tables() {
                   echo "Auto-detecting tables in ClickHouse database..."
-                  
+
                   # Get all tables from the database
-                  ALL_TABLES=$(clickhouse-client \
-                    --host="$CLICKHOUSE_HOST" \
-                    --port="$CLICKHOUSE_PORT" \
-                    --user="$CLICKHOUSE_USER" \
-                    --database="$CLICKHOUSE_DATABASE" \
-                    --password="$CLICKHOUSE_PASSWORD" \
-                    --query="SHOW TABLES" 2>/dev/null || echo "")
-                  
+                  ALL_TABLES=$(clickhouse-client "${CH_ARGS[@]}" --query="SHOW TABLES" 2>/dev/null || echo "")
+
                   if [ -z "$ALL_TABLES" ]; then
                     echo "Warning: Could not retrieve table list, falling back to hardcoded list"
                     return 1
                   fi
-                  
+
                   echo "Found tables: $ALL_TABLES"
-                  
+
                   # Filter tables based on include/exclude patterns
                   DISCOVERED_TABLES=()
                   {{- range .Values.snuba.cleanup.tables.includePatterns }}
@@ -107,7 +107,7 @@ spec:
                   {{- range .Values.snuba.cleanup.tables.excludePatterns }}
                   EXCLUDE_PATTERN="{{ . }}"
                   {{- end }}
-                  
+
                   for table in $ALL_TABLES; do
                     # Check include patterns
                     INCLUDE_MATCH=false
@@ -116,7 +116,7 @@ spec:
                       INCLUDE_MATCH=true
                     fi
                     {{- end }}
-                    
+
                     # Check exclude patterns
                     EXCLUDE_MATCH=false
                     {{- range .Values.snuba.cleanup.tables.excludePatterns }}
@@ -124,7 +124,7 @@ spec:
                       EXCLUDE_MATCH=true
                     fi
                     {{- end }}
-                    
+
                     # Add to discovered tables if it matches include and doesn't match exclude
                     if [ "$INCLUDE_MATCH" = true ] && [ "$EXCLUDE_MATCH" = false ]; then
                       DISCOVERED_TABLES+=("$table")
@@ -133,17 +133,17 @@ spec:
                       echo "Excluding table: $table (include=$INCLUDE_MATCH, exclude=$EXCLUDE_MATCH)"
                     fi
                   done
-                  
+
                   if [ ${#DISCOVERED_TABLES[@]} -eq 0 ]; then
                     echo "Warning: No tables matched the include/exclude patterns, falling back to hardcoded list"
                     return 1
                   fi
-                  
+
                   # Export discovered tables for cleanup
                   printf '%s\n' "${DISCOVERED_TABLES[@]}"
                   return 0
                 }
-                
+
                 # Determine which tables to clean up
                 {{- if .Values.snuba.cleanup.tables.autoDetect }}
                 echo "Table auto-detection enabled"
@@ -166,23 +166,32 @@ spec:
                   {{- end }}
                 )
                 {{- end }}
-                
+
                 echo "Tables to cleanup: ${TABLES[*]}"
-                
+
+                # Compute cutoff timestamp: retentionDays-ago at 00:00:00 (use UTC)
+                echo "Computing cutoff timestamp for retention {{ .Values.snuba.cleanup.retentionDays }} days (midnight UTC)..."
+                # Try to compute via GNU date (-d), fallback to BSD date (macOS) with -v
+                CUT_DAYS={{ .Values.snuba.cleanup.retentionDays }}
+                TIMESTAMP=$(date -u -d "${CUT_DAYS} days ago" '+%Y-%m-%d 00:00:00' 2>/dev/null || date -u -v -${CUT_DAYS}d '+%Y-%m-%d 00:00:00' 2>/dev/null || true)
+                if [ -z "$TIMESTAMP" ]; then
+                  echo "Warning: could not compute cutoff with local date; attempting ClickHouse calculation"
+                  TIMESTAMP=$(clickhouse-client "${CH_ARGS[@]}" --query="SELECT toString(toDateTime(toStartOfDay(now() - INTERVAL ${CUT_DAYS} DAY)))" 2>/dev/null | tr -d '\r' || true)
+                fi
+                if [ -z "$TIMESTAMP" ]; then
+                  echo "Error: could not determine cutoff timestamp" >&2
+                  exit 1
+                fi
+                echo "Using cutoff timestamp: $TIMESTAMP"
+
                 # Execute cleanup for each table
                 CLEANED_COUNT=0
                 FAILED_COUNT=0
-                
+
                 for table in "${TABLES[@]}"; do
                   if [ -n "$table" ]; then
                     echo "Cleaning up table: $table"
-                    if clickhouse-client \
-                      --host="$CLICKHOUSE_HOST" \
-                      --port="$CLICKHOUSE_PORT" \
-                      --user="$CLICKHOUSE_USER" \
-                      --database="$CLICKHOUSE_DATABASE" \
-                      --password="$CLICKHOUSE_PASSWORD" \
-                      --query="DELETE FROM $table WHERE timestamp < now() - INTERVAL {{ .Values.snuba.cleanup.retentionDays }} DAY"; then
+                    if clickhouse-client "${CH_ARGS[@]}" --query="DELETE FROM $table WHERE timestamp < toDateTime('$TIMESTAMP')"; then
                       echo "Successfully cleaned up table: $table"
                       CLEANED_COUNT=$((CLEANED_COUNT + 1))
                     else
@@ -191,7 +200,7 @@ spec:
                     fi
                   fi
                 done
-                
+
                 echo "ClickHouse cleanup completed: $CLEANED_COUNT tables cleaned, $FAILED_COUNT failed"
             env:
             - name: CLICKHOUSE_HOST

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -209,14 +209,19 @@ spec:
             - name: CLICKHOUSE_PORT
               value: {{ include "sentry.clickhouse.port" . | quote }}
             - name: CLICKHOUSE_USER
-              value: "default"
+              value: {{ include "sentry.clickhouse.username" . | quote }}
             - name: CLICKHOUSE_DATABASE
-              value: "default"
+              value: {{ include "sentry.clickhouse.database" . | quote }}
             - name: CLICKHOUSE_PASSWORD
               valueFrom:
                 secretKeyRef:
+                {{- if .Values.externalClickhouse.existingSecret }}
+                  name: {{ .Values.externalClickhouse.existingSecret | quote }}
+                  key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey | quote }}
+                {{- else }}
                   name: {{ template "sentry.fullname" . }}-clickhouse
                   key: clickhouse-password
+                {{- end }}
                   optional: true
 {{- if .Values.snuba.cleanup.env }}
 {{ toYaml .Values.snuba.cleanup.env | indent 12 }}

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -173,7 +173,7 @@ spec:
                 # Compute cutoff timestamp: retentionDays-ago at 00:00:00 (use UTC)
                 echo "Computing cutoff timestamp for retention {{ .Values.snuba.cleanup.retentionDays }} days (midnight UTC)..."
                 # Try to compute via GNU date (-d), fallback to BSD date (macOS) with -v
-                CUT_DAYS={{ .Values.snuba.cleanup.retentionDays }}
+                CUT_DAYS="{{ .Values.snuba.cleanup.retentionDays }}"
                 TIMESTAMP=$(date -u -d "${CUT_DAYS} days ago" '+%Y-%m-%d 00:00:00' 2>/dev/null || date -u -v -${CUT_DAYS}d '+%Y-%m-%d 00:00:00' 2>/dev/null || true)
                 if [ -z "$TIMESTAMP" ]; then
                   echo "Warning: could not compute cutoff with local date; attempting ClickHouse calculation"

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -89,8 +89,9 @@ spec:
                 discover_tables() {
                   echo "Auto-detecting tables in ClickHouse database..."
 
-                  # Get all tables from the database
-                  ALL_TABLES=$(clickhouse-client "${CH_ARGS[@]}" --query="SHOW TABLES" 2>/dev/null || echo "")
+                  # Get all tables that have a 'timestamp' column from system.columns for current database
+                  # This returns table names only
+                  ALL_TABLES=$(clickhouse-client "${CH_ARGS[@]}" --query="SELECT DISTINCT table FROM system.columns WHERE database = '${CLICKHOUSE_DATABASE}' AND name = 'timestamp'" 2>/dev/null || echo "")
 
                   if [ -z "$ALL_TABLES" ]; then
                     echo "Warning: Could not retrieve table list, falling back to hardcoded list"

--- a/charts/sentry/templates/snuba/cleanup/serviceaccount-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/serviceaccount-clickhouse-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled .Values.snuba.cleanup.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2023,6 +2023,10 @@ snuba:
   cleanup:
     # -- Enable ClickHouse database cleanup cronjob
     enabled: false
+    image:
+      repository: clickhouse/clickhouse-server
+      tag: latest
+      pullPolicy: IfNotPresent
     # -- Retention period in days for ClickHouse data cleanup
     retentionDays: 30
     # -- Cron schedule for cleanup job (daily at 2 AM by default)


### PR DESCRIPTION
1. [clickhouse-client](https://hub.docker.com/r/clickhouse/clickhouse-client/tags) image is not maintained(latest image is version 22, it doesn't support `DELETE FROM` syntax), so I changed it to clickhouse-server with configurable repository and tag
2. Default values.yaml doesn't set clickhouse password. In that config, you get error message `Bad arguments: the argument for option '--password' should follow immediately after the equal sign`, so I added `--password` arg optional
3. You also get error message `Code: 36. DB::Exception: Received from sentry-clickhouse:9000. DB::Exception: ALTER UPDATE/ALTER DELETE statements must use only deterministic functions. Function 'now' is non-deterministic. (BAD_ARGUMENTS)`, so I made the cut off timestamp in bash variable, and passed it to clickhouse query.
4. In discovering tables, I made it to filter tables having `timestamp` column only.