### PR TITLE
fix: Add missing topics for snuba-subscription-consumer-eap-items

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2673,6 +2673,8 @@ kafka:
       - name: snuba-eap-spans-commit-log
       - name: scheduled-subscriptions-eap-spans
       - name: eap-spans-subscription-results
+      - name: subscription-results-eap-items
+      - name: snuba-items-commit-log
       - name: snuba-eap-mutations
       - name: snuba-lw-deletions-generic-events
       - name: shared-resources-usage


### PR DESCRIPTION
snuba-subscription-consumer-eap-items failed because of these missing topics