### PR TITLE
fix(sentry-ingest-consumer-attachments): max batch time ms cli param

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -122,7 +122,7 @@ spec:
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchSize }}"
           {{- end }}
           {{- if .Values.sentry.ingestConsumerAttachments.maxBatchTimeMs }}
-          - "--max-batch-size"
+          - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchTimeMs }}"
           {{- end }}
         {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}


### PR DESCRIPTION
This PR fixes the maxBatchTimeMs CLI parameter used inside Sentry Ingest Consumer Attachments.

Currently it's setting --max-batch-size which is the incorrect option. This was the only consumer I saw with this option all others seem to correctly reference --max-batch-time-ms