### PR TITLE
fix(deps): change pgbouncer repository

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3092,7 +3092,7 @@ pgbouncer:
     user: ''
     password: ''
   image:
-    repository: "bitnami/pgbouncer"
+    repository: "bitnamilegacy/pgbouncer"
     tag: "1.23.1-debian-12-r5"
     pullPolicy: IfNotPresent
   replicas: 2


### PR DESCRIPTION
# Description

This MR addresses a missing fix for #1828 by updating the pgbouncer image repository in the Sentry Helm chart from `bitnami` to `bitnamilegacy`. 