### PR TITLE
fix  'ast' has no attribute 'Num' in  chart-testing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.9'
           check-latest: true
 
       - name: Set up chart-testing


### PR DESCRIPTION
https://github.com/helm/chart-testing/issues/780
https://github.com/helm/chart-testing-action/issues/177

```
Linting chart "sentry => (version: \"27.5.0\", path: \"charts/sentry\")"
Validating /home/runner/work/charts/charts/charts/sentry/Chart.yaml...
Traceback (most recent call last):
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/bin/yamale", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 124, in main
    _router(args.path, args.schema, args.cpu_num, args.parser, not args.no_strict)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 104, in _router
Error: failed linting charts: failed processing charts
    _validate_single(root, schema_name, parser, strict)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 69, in _validate_single
    _validate(s, yaml_path, parser, strict, True)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 28, in _validate
    schema = yamale.make_schema(schema_path, parser)
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/yamale.py", line 15, in make_schema
    s = Schema(raw_schemas[0], path, validators=validators)
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 17, in __init__
    self._schema = self._process_schema(DataPath(),
                   ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
                                        schema_dict,
                                        ^^^^^^^^^^^^
                                        self.validators)
                                        ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 36, in _process_schema
    schema_data[key] = self._process_schema(path + DataPath(key),
                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
                                            data,
                                            ^^^^^
                                            validators)
                                            ^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 40, in _process_schema
    schema_data = self._parse_schema_item(path,
                                          schema_data,
                                          validators)
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 47, in _parse_schema_item
    return syntax.parse(expression, validators)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/syntax/parser.py", line 40, in parse
    _validate_expr(tree.body, validators)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/syntax/parser.py", line 22, in _validate_expr
    ast.Constant, ast.Num, ast.Str, ast.Bytes, ast.NameConstant]
                  ^^^^^^^
AttributeError: module 'ast' has no attribute 'Num'

------------------------------------------------------------------------------------------------------------------------
 ✖︎ sentry => (version: "27.5.0", path: "charts/sentry") > failed waiting for process: exit status 1
------------------------------------------------------------------------------------------------------------------------
failed linting charts: failed processing charts
Error: Process completed with exit code 1.
```