### PR TITLE
feat(worker): use lightweight liveness & add Celery readiness probe

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -788,8 +788,15 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.worker.existingSecretEnv | string | `""` |  |
 | sentry.worker.livenessProbe.enabled | bool | `true` |  |
 | sentry.worker.livenessProbe.failureThreshold | int | `3` |  |
+| ssentry.worker.livenessProbe.initialDelaySeconds | int | `10` |  |
 | sentry.worker.livenessProbe.periodSeconds | int | `60` |  |
 | sentry.worker.livenessProbe.timeoutSeconds | int | `10` |  |
+| sentry.worker.readinessProbe.enabled | bool | `true` |  |
+| sentry.worker.readinessProbe.failureThreshold | int | `3` |  |
+| ssentry.worker.readinessProbe.initialDelaySeconds | int | `10` |  |
+| sentry.worker.readinessProbe.periodSeconds | int | `60` |  |
+| sentry.worker.readinessProbe.timeoutSeconds | int | `10` |  |
+| sentry.worker.readinessProbe.celeryTimeoutSeconds | int | `5` |  |
 | sentry.worker.nodeSelector | object | `{}` |  |
 | sentry.worker.replicas | int | `1` |  |
 | sentry.worker.resources | object | `{}` |  |

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -131,6 +131,7 @@ spec:
         {{ end }}
 {{- if .Values.sentry.worker.volumeMounts }}
 {{ toYaml .Values.sentry.worker.volumeMounts | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.worker.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.worker.livenessProbe.periodSeconds }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -131,19 +131,30 @@ spec:
         {{ end }}
 {{- if .Values.sentry.worker.volumeMounts }}
 {{ toYaml .Values.sentry.worker.volumeMounts | indent 8 }}
-{{- end }}
-  {{- if .Values.sentry.worker.livenessProbe.enabled }}
+{{- if .Values.sentry.worker.livenessProbe.enabled }}
         livenessProbe:
           periodSeconds: {{ .Values.sentry.worker.livenessProbe.periodSeconds }}
-          initialDelaySeconds: 10
+          initialDelaySeconds: {{ .Values.sentry.worker.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.sentry.worker.livenessProbe.timeoutSeconds }}
           failureThreshold: {{ .Values.sentry.worker.livenessProbe.failureThreshold }}
+          exec:
+            command:
+              - rm
+              - -f
+              - /tmp/health.txt
+{{- end }}
+{{- if .Values.sentry.worker.readinessProbe.enabled }}
+        readinessProbe:
+          periodSeconds: {{ .Values.sentry.worker.readinessProbe.periodSeconds }}
+          initialDelaySeconds: {{ .Values.sentry.worker.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.sentry.worker.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.sentry.worker.readinessProbe.failureThreshold }}
           exec:
             command:
               - sentry
               - exec
               - -c
-              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout={{ default .Values.sentry.worker.readinessProbe.celeryTimeoutSeconds }})[0][dest]["ok"])'
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.worker.resources | indent 12 }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -155,7 +155,7 @@ spec:
               - sentry
               - exec
               - -c
-              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout={{ default .Values.sentry.worker.readinessProbe.celeryTimeoutSeconds }})[0][dest]["ok"])'
+              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout={{ .Values.sentry.worker.readinessProbe.celeryTimeoutSeconds }})[0][dest]["ok"])'
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.worker.resources | indent 12 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -341,8 +341,17 @@ sentry:
     livenessProbe:
       enabled: true
       periodSeconds: 60
+      initialDelaySeconds: 10
       timeoutSeconds: 10
       failureThreshold: 3
+    readinessProbe:
+      enabled: true
+      periodSeconds: 60
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
+      failureThreshold: 3
+      # time to wait for celery to respond
+      celeryTimeoutSeconds: 5
     sidecars: []
     # securityContext: {}
     # containerSecurityContext: {}


### PR DESCRIPTION
This update prevents worker pods from restart loops caused by Celery ping timeouts.

- Liveness probe: replaced the Celery ping with a lightweight command (`rm -f /tmp/health.txt`) to only check container health.

- Readiness probe: added an optional Celery app.control.ping() check with configurable timeout (`celeryTimeoutSeconds`).

The liveness probe now ensures the container is alive, while readiness reflects broker connectivity - avoiding restarts when Celery or the broker is slow (increase `celeryTimeoutSeconds` to allow the process to complete)
