### PR TITLE
chore: add missing Kubernetes pod configuration options

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -98,6 +98,7 @@ vroom:
   securityContext: {}
   containerSecurityContext: {}
   # priorityClassName: ""
+  # topologySpreadConstraints: []
   service:
     annotations: {}
   # tolerations: []
@@ -906,6 +907,9 @@ sentry:
     # volumeMounts: []
     # logLevel: "WARNING" # DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL
     # logFormat: "machine" # human|machine
+    # priorityClassName: ""
+    # securityContext: {}
+    # containerSecurityContext: {}
 
   subscriptionConsumerResultsEapItems:
     enabled: true
@@ -1198,6 +1202,12 @@ sentry:
     volumes: []
     # volumeMounts: []
     serviceAccount: {}
+    # priorityClassName: ""
+    # annotations: {}
+    # podLabels: {}
+    # affinity: {}
+    # nodeSelector: {}
+    # tolerations: {}
 
   # Sentry settings of connections to Kafka
   kafka:


### PR DESCRIPTION
Expand Kubernetes pod configuration options across various Sentry components

- Add topologySpreadConstraints option for vroom component
- Add priorityClassName, securityContext, and containerSecurityContext options for subscriptionConsumerResultsEapItems
- Add priorityClassName, annotations, podLabels, affinity, nodeSelector, and tolerations options for Kafka configuration