### PR TITLE
feat: bump appversion from 25.8.0 to 25.9.0

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 27.5.0
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 25.8.0
+appVersion: 25.9.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
This commit updates the Helm chart's appVersion from 25.8.0 to 25.9.0. The changes in this release have been reviewed by comparing the differences between versions 25.8.0 and 25.9.0 in the following key files:

- https://github.com/getsentry/snuba/blob/25.9.0/snuba/utils/streams/topics.py
- https://github.com/getsentry/sentry/blob/25.9.0/src/sentry/conf/server.py
