### PR TITLE
fix: move configOverride to correct place in ClickHouse replica State…

### DIFF
--- a/charts/clickhouse/templates/statefulset-clickhouse-replica.yaml
+++ b/charts/clickhouse/templates/statefulset-clickhouse-replica.yaml
@@ -153,6 +153,10 @@ spec:
           items:
           - key: config.xml
             path: config.xml
+      {{- if .Values.clickhouse.configmap.configOverride }}
+          - key: override.xml
+            path: override.xml
+      {{- end }}
       - name: {{ include "clickhouse.fullname" . }}-metrica
         configMap:
           name: {{ include "clickhouse.fullname" . }}-metrica
@@ -165,10 +169,6 @@ spec:
           items:
           - key: users.xml
             path: users.xml
-      {{- end }}
-      {{- if .Values.clickhouse.configmap.configOverride }}
-          - key: override.xml
-            path: override.xml
       {{- end }}
 {{- if .Values.clickhouse.volumes }}
 {{ toYaml .Values.clickhouse.volumes | indent 6 }}


### PR DESCRIPTION
This PR updates `charts/clickhouse/templates/statefulset-clickhouse-replica.yaml` and Closes #1901 