### PR TITLE
feat: bump appversion from 25.9.0 to 25.10.0

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 27.6.1
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 25.9.0
+appVersion: 25.10.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
+++ b/charts/sentry/templates/sentry/cron/deployment-sentry-cron.yaml
@@ -79,7 +79,7 @@ spec:
         command: ["sentry"]
         args:
           - "run"
-          - "cron"
+          - "taskworker-scheduler"
           {{- if .Values.sentry.cron.logLevel }}
           - "--loglevel"
           - "{{ .Values.sentry.cron.logLevel }}"

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -81,7 +81,7 @@ spec:
         command: ["sentry"]
         args:
           - "run"
-          - "worker"
+          - "taskworker"
           {{- if .Values.sentry.worker.excludeQueues }}
           - "--exclude-queues"
           - "{{ .Values.sentry.worker.excludeQueues }}"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2710,6 +2710,7 @@ kafka:
       - name: snuba-items-commit-log
       - name: snuba-eap-mutations
       - name: snuba-lw-deletions-generic-events
+      - name: snuba-lw-deletions-eap-items
       - name: shared-resources-usage
       - name: snuba-profile-chunks
       - name: buffered-segments
@@ -2726,6 +2727,8 @@ kafka:
       - name: taskworker-billing-dlq
       - name: taskworker-control
       - name: taskworker-control-dlq
+      - name: taskworker-control-limited
+      - name: taskworker-control-limited-dlq
       - name: taskworker-ingest
       - name: taskworker-ingest-dlq
       - name: taskworker-ingest-errors


### PR DESCRIPTION
This commit updates the Helm chart's appVersion from 25.9.0 to 25.10.0. The changes in this release have been reviewed by comparing the differences between versions 25.9.0 and 25.10.0 in the following key files:

- https://github.com/getsentry/snuba/blob/25.10.0/snuba/utils/streams/topics.py
- https://github.com/getsentry/sentry/blob/25.10.0/src/sentry/conf/server.py


Get error https://github.com/sentry-kubernetes/charts/issues/1937