### PR TITLE
fix: update clickhouse to 4.1.1

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.3.14
 - name: clickhouse
   repository: https://sentry-kubernetes.github.io/charts
-  version: 4.1.0
+  version: 4.1.1
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.4.11
@@ -23,5 +23,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.2.5
-digest: sha256:d2d9ed95a3d4add3948dc237ba578be86e8dbee03bbee6ba7a886bc950b75ab2
-generated: "2025-09-22T01:15:11.742892877Z"
+digest: sha256:296f5606621dc181c7c97b2bd7e75f4167ff1aa58659ccbee2290e7e7da95ffe
+generated: "2025-11-15T14:08:34.184429119+06:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     condition: kafka.enabled
   - name: clickhouse
     repository: https://sentry-kubernetes.github.io/charts
-    version: 4.1.0
+    version: 4.1.1
     condition: clickhouse.enabled
   - name: zookeeper
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
fix Bug: override.xml mounted under wrong ConfigMap in ClickHouse volumes  https://github.com/sentry-kubernetes/charts/issues/1901

install

```
helm upgrade --install -n test --wait sentry . --values values.yaml --timeout=1000s 
Release "sentry" does not exist. Installing it now.
coalesce.go:237: warning: skipped value for kafka.config: Not a table.
I1115 13:54:21.223822    9314 warnings.go:110] "Warning: metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: [must be no more than 63 characters]"
NAME: sentry
LAST DEPLOYED: Sat Nov 15 13:35:31 2025
NAMESPACE: test
STATUS: deployed
REVISION: 1
TEST SUITE: None
```