### PR TITLE
fix: add migrations excludePatterns for clickHouse cleanup

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2076,6 +2076,7 @@ snuba:
         - "^system\\."
         - "^information_schema\\."
         - "^INFORMATION_SCHEMA\\."
+        - ".*migrations.*"
       # -- Fallback hardcoded table list (used if autoDetect fails or is disabled)
       fallbackList:
         - "discover_local"


### PR DESCRIPTION
Try fix https://github.com/sentry-kubernetes/charts/issues/1897 and https://github.com/sentry-kubernetes/charts/issues/1893