### PR TITLE
feat: enhance worker deployments with additional packages and CA certificates

### DIFF
--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -83,8 +83,8 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
           - |
-            {{- if .Values.sentry.worker.installAdditionalPackages }}
-            pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
+            {{- if .Values.sentry.web.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.web.installAdditionalPackages }}{{ . }} {{ end }}
             {{- end }}
             {{- if .Values.sentry.web.caCertificatesSecret }}
             mkdir -p /usr/local/share/ca-certificates/

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -80,10 +80,20 @@ spec:
       - name: {{ .Chart.Name }}-web
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "web"
+          - |
+            {{- if .Values.sentry.worker.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
+            {{- end }}
+            {{- if .Values.sentry.web.caCertificatesSecret }}
+            mkdir -p /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            {{- end }}
+            sentry run web
           {{- if .Values.sentry.web.workers }}
           - "--workers"
           - "{{ .Values.sentry.web.workers }}"
@@ -131,6 +141,11 @@ spec:
         - name: custom-ca
           mountPath: /etc/pki/ca-trust/custom
         {{ end }}
+        {{- if .Values.sentry.web.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
 {{- if .Values.sentry.web.volumeMounts }}
 {{ toYaml .Values.sentry.web.volumeMounts | indent 8 }}
 {{- end }}
@@ -208,5 +223,11 @@ spec:
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.web.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.web.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -78,10 +78,20 @@ spec:
       - name: {{ .Chart.Name }}-worker
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "worker"
+          - |
+            {{- if .Values.sentry.workerEvents.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.workerEvents.installAdditionalPackages }}{{ . }} {{ end }}
+            {{- end }}
+            {{- if .Values.sentry.workerEvents.caCertificatesSecret }}
+            mkdir -p /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            {{- end }}
+            sentry run worker
           - "-Q"
           - {{ .Values.sentry.workerEvents.queues }}
           {{- if .Values.sentry.workerEvents.concurrency }}
@@ -122,6 +132,11 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+        {{- if .Values.sentry.workerEvents.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
 {{- if .Values.sentry.workerEvents.volumeMounts }}
 {{ toYaml .Values.sentry.workerEvents.volumeMounts | indent 8 }}
 {{- end }}
@@ -181,5 +196,11 @@ spec:
       {{- end }}
 {{- if .Values.sentry.workerEvents.volumes }}
 {{ toYaml .Values.sentry.workerEvents.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.workerEvents.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.workerEvents.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -78,10 +78,20 @@ spec:
       - name: {{ .Chart.Name }}-worker
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "worker"
+          - |
+            {{- if .Values.sentry.workerTransactions.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.workerTransactions.installAdditionalPackages }}{{ . }} {{ end }}
+            {{- end }}
+            {{- if .Values.sentry.workerTransactions.caCertificatesSecret }}
+            mkdir -p /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            {{- end }}
+            sentry run worker
           - "-Q"
           - {{ .Values.sentry.workerTransactions.queues }}
           {{- if .Values.sentry.workerTransactions.concurrency }}
@@ -122,6 +132,11 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+        {{- if .Values.sentry.workerTransactions.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
 {{- if .Values.sentry.workerTransactions.volumeMounts }}
 {{ toYaml .Values.sentry.workerTransactions.volumeMounts | indent 8 }}
 {{- end }}
@@ -181,5 +196,11 @@ spec:
       {{- end }}
 {{- if .Values.sentry.workerTransactions.volumes }}
 {{ toYaml .Values.sentry.workerTransactions.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.workerTransactions.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.workerTransactions.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -210,10 +210,10 @@ spec:
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
 {{- end }}
-{{- if .Values.sentry.web.caCertificatesSecret }}
+{{- if .Values.sentry.worker.caCertificatesSecret }}
       - name: ca-certificates
         secret:
-          secretName: {{ .Values.sentry.web.caCertificatesSecret }}
+          secretName: {{ .Values.sentry.worker.caCertificatesSecret }}
           defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -78,10 +78,20 @@ spec:
       - name: {{ .Chart.Name }}-worker
         image: "{{ template "sentry.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
-        command: ["sentry"]
+        command: ["/bin/bash", "-c"]
         args:
-          - "run"
-          - "worker"
+          - |
+            {{- if .Values.sentry.worker.installAdditionalPackages }}
+            pip install {{ range .Values.sentry.worker.installAdditionalPackages }}{{ . }} {{ end }}
+            {{- end }}
+            {{- if .Values.sentry.worker.caCertificatesSecret }}
+            mkdir -p /usr/local/share/ca-certificates/
+            for c in $(ls -1 /usr/local/share/ca-certificates/); do
+                cat /usr/local/share/ca-certificates/$c >> $(python3 -m certifi) && echo >> $(python3 -m certifi)
+            done
+            update-ca-certificates
+            {{- end }}
+            sentry run worker
           {{- if .Values.sentry.worker.excludeQueues }}
           - "--exclude-queues"
           - "{{ .Values.sentry.worker.excludeQueues }}"
@@ -129,6 +139,11 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+        {{- if .Values.sentry.worker.caCertificatesSecret }}
+        - name: ca-certificates
+          mountPath: /usr/local/share/ca-certificates
+          readOnly: true
+        {{- end }}
 {{- if .Values.sentry.worker.volumeMounts }}
 {{ toYaml .Values.sentry.worker.volumeMounts | indent 8 }}
 {{- end }}
@@ -194,5 +209,11 @@ spec:
       {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.sentry.web.caCertificatesSecret }}
+      - name: ca-certificates
+        secret:
+          secretName: {{ .Values.sentry.web.caCertificatesSecret }}
+          defaultMode: 0644
 {{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -294,6 +294,11 @@ sentry:
     volumes: []
     volumeMounts: []
     # workers: 3
+    installAdditionalPackages:
+      - django-multidb-router
+      - sentry-nodestore-elastic
+      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    caCertificatesSecret: ca-certificates # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=test
 
   features:
     orgSubdomains: false

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -298,7 +298,7 @@ sentry:
       - django-multidb-router
       - sentry-nodestore-elastic
       - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
-    caCertificatesSecret: ca-certificates # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=test
+    caCertificatesSecret: ca-certificates #  kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=test
 
   features:
     orgSubdomains: false

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -298,7 +298,7 @@ sentry:
       - django-multidb-router
       - sentry-nodestore-elastic
       - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
-    caCertificatesSecret: ca-certificates #  kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=test
+    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   features:
     orgSubdomains: false
@@ -355,6 +355,11 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
+    installAdditionalPackages:
+      - django-multidb-router
+      - sentry-nodestore-elastic
+      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   # allows to dedicate some workers to specific queues
   workerEvents:
@@ -395,6 +400,11 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
+    installAdditionalPackages:
+      - django-multidb-router
+      - sentry-nodestore-elastic
+      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   # allows to dedicate some workers to specific queues
   workerTransactions:
@@ -433,6 +443,11 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
+    installAdditionalPackages:
+      - django-multidb-router
+      - sentry-nodestore-elastic
+      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   ingestConsumerAttachments:
     enabled: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -294,11 +294,11 @@ sentry:
     volumes: []
     volumeMounts: []
     # workers: 3
-    installAdditionalPackages:
-      - django-multidb-router
-      - sentry-nodestore-elastic
-      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
-    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
+    # installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   features:
     orgSubdomains: false
@@ -355,11 +355,11 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
-    installAdditionalPackages:
-      - django-multidb-router
-      - sentry-nodestore-elastic
-      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
-    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
+    # installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   # allows to dedicate some workers to specific queues
   workerEvents:
@@ -400,11 +400,11 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
-    installAdditionalPackages:
-      - django-multidb-router
-      - sentry-nodestore-elastic
-      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
-    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
+    # installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   # allows to dedicate some workers to specific queues
   workerTransactions:
@@ -443,11 +443,11 @@ sentry:
     topologySpreadConstraints: []
     volumes: []
     volumeMounts: []
-    installAdditionalPackages:
-      - django-multidb-router
-      - sentry-nodestore-elastic
-      - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
-    caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
+    # installAdditionalPackages:
+    #   - django-multidb-router
+    #   - sentry-nodestore-elastic
+    #   - https://github.com/pavels/sentry-s3-nodestore/releases/download/v1.0.3/sentry-s3-nodestore-1.0.3.tar.gz
+    # caCertificatesSecret: ca-certificates  # kubectl create secret generic ca-certificates --from-file=you-certificates.crt --namespace=namespace
 
   ingestConsumerAttachments:
     enabled: true


### PR DESCRIPTION
This pull request introduces several enhancements to the Sentry worker deployments:

1. **Additional Package Installation**: 
   - Workers now have the capability to install additional Python packages during startup. This is controlled by the `installAdditionalPackages` flag in the `values.yaml` file.
   - If the flag is enabled, the following packages are installed, but packages can be overridden.:
     - `django-multidb-router`
     - `sentry-nodestore-elastic`
     - `sentry-s3-nodestore` (from a specific release)

2. **CA Certificates Management**:
   - Workers can now manage custom CA certificates by mounting a secret containing the certificates to `/usr/local/share/ca-certificates/`.
   - The certificates are then copied to the appropriate location and updated using `update-ca-certificates`.
   - This feature is controlled by the `caCertificatesSecret` field in the `values.yaml` file.

### Changes

- **Deployment Templates**:
  - Modified the `command` and `args` sections in the worker deployment templates to include a bash script that handles the installation of additional packages and CA certificates.
  - Added volume mounts and volume definitions for the CA certificates secret.


### Check pip packages

```
pip list | grep -E 'django|nodestore'
django-crispy-forms                        1.14.0
django_csp                                 3.8
django-multidb-router                      0.11
django-pg-zero-downtime-migrations         0.18
django-stubs-ext                           5.2.2
djangorestframework                        3.16.1
pytest-django                              4.9.0
sentry-forked-django-stubs                 5.2.2.post2
sentry-forked-djangorestframework-stubs    3.16.2.post1
sentry-nodestore-elastic                   1.0.2
sentry-s3-nodestore                        1.0.3
```

### Check certificates
```
import os
import ssl
import certifi
import re
from cryptography import x509
from cryptography.hazmat.backends import default_backend

def list_certificates():
    # Get the path to the cacert.pem file
    cacert_path = certifi.where()

    # Open the file containing the certificates
    with open(cacert_path, 'r') as f:
        pem_data = f.read()

    # Use a regular expression to extract certificates
    certificate_pattern = re.compile(r'-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE-----', re.DOTALL)
    certificates = certificate_pattern.findall(pem_data)

    # Display information about each certificate
    for i, cert_pem in enumerate(certificates):
        try:
            # Load and parse the certificate
            cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
            subject = cert.subject
            issuer = cert.issuer
            not_valid_before = cert.not_valid_before
            not_valid_after = cert.not_valid_after

            # Print certificate information
            print(f"Certificate #{i + 1}:")
            print(f"  Subject: {subject}")
            print(f"  Issuer: {issuer}")
            print(f"  Valid from: {not_valid_before}")
            print(f"  Valid until: {not_valid_after}")
            print()
        except Exception as e:
            # Print error message if there's an issue with the certificate
            print(f"Error processing certificate #{i + 1}: {e}")

# Example usage
list_certificates()
```

check certificate by openssl
```
openssl crl2pkcs7 -nocrl -certfile /.venv/lib/python3.13/site-packages/certifi/cacert.pem | openssl pkcs7 -print_certs -noout | grep subject | tail -n 2
```
output:
```
subject=DC = ru, DC = yandex, DC = ld, CN = YandexCLCA
subject=CN = YandexInternalRootCA
```