### PR TITLE
feat(pgbouncer/deployment): Pass (extra) env from values

### DIFF
--- a/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -29,6 +29,9 @@ spec:
         resources:
           {{ toYaml .Values.pgbouncer.resources | nindent 10 }}
         env:
+          {{- if .Values.pgbouncer.env }}
+          {{ toYaml .Values.pgbouncer.env | nindent 10 }}
+          {{- end }}
           {{ include "sentry.pgbouncer.env" . | nindent 10 }}
           - name: PGBOUNCER_PORT
             value: "5432"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3114,6 +3114,7 @@ extraManifests: []
 
 pgbouncer:
   enabled: false
+  env: []
   postgres:
     cp_max: 10
     cp_min: 5


### PR DESCRIPTION
Currently there is no way to set settings like

```yaml
      - PGBOUNCER_SERVER_IDLE_TIMEOUT=300
      - PGBOUNCER_DSN_0=db=host=pg1 port=5432 dbname=db
      - PGBOUNCER_DSN_1=db-replicas=host=pg2 port=5432 dbname=db
      ...
```

Adding the ability to pass envs from values would allow users to set *almost* all settings.

For example, this can be useful in combination with `django-multidb-router` to send read queries to RO PostgreSQL replicas.

> [!TIP]
> For PGBouncer to have the PostgreSQL leader on `db` and replicas on eg. `db-replica` you may want to have something like HAProxy between PGBouncer and your PostgreSQL cluster so that it the leader is always exposed on one endpoint and replicas on another.

<details>
<summary>Example sentry config</summary>

```python3
import multidb

DATABASES = {
    "default": {
        "ENGINE": "sentry.db.postgres",
        "NAME": os.environ.get("POSTGRES_NAME", ""),
        "USER": os.environ.get("POSTGRES_USER", ""),
        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
        "HOST": os.environ.get("POSTGRES_HOST", ""),
        "PORT": os.environ.get("POSTGRES_PORT", ""),
        "CONN_MAX_AGE": 0,
    },
    "replicas": {
        "ENGINE": "sentry.db.postgres",
        "NAME": f"{os.environ.get("POSTGRES_NAME", "")}-replicas",
        "USER": os.environ.get("POSTGRES_USER", ""),
        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
        "HOST": os.environ.get("POSTGRES_HOST", ""),
        "PORT": os.environ.get("POSTGRES_PORT", ""),
        "CONN_MAX_AGE": 0,
    }
}
REPLICA_DATABASES = ['replicas']
DATABASE_ROUTERS = ('multidb.ReplicaRouter',)
```

</details>

Doing the same for volumes and volume mounts can be considered and done in another PR to, *hopefully*, allow users to access the full configuration of bitnami PGBouncer.