### PR TITLE
feat: allow to override livenessProbe & readinessProbe

### DIFF
--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -168,26 +168,19 @@ spec:
 {{- if .Values.relay.volumeMounts }}
 {{ toYaml .Values.relay.volumeMounts | indent 10 }}
 {{- end }}
+{{- $port := include "relay.port" . | atoi -}}
+{{- if .Values.relay.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: {{ .Values.relay.probeFailureThreshold }}
-          httpGet:
-            path: {{ template "relay.healthCheck.livenessRequestPath" }}
-            port: {{ template "relay.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.relay.probePeriodSeconds }}
-          successThreshold: {{ .Values.relay.probeSuccessThreshold }}
-          timeoutSeconds: {{ .Values.relay.probeTimeoutSeconds }}
+            {{- $livenessProbePath := include "relay.healthCheck.livenessRequestPath" . -}}
+            {{- $livenessProbeFixedSettings := dict "httpGet" (dict "path" $livenessProbePath "port" $port "scheme" "HTTP") -}}
+            {{- merge $livenessProbeFixedSettings (omit .Values.relay.livenessProbe "enabled") | toYaml | nindent 12 }}
+{{- end }}
+{{- if .Values.relay.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: {{ .Values.relay.probeFailureThreshold }}
-          httpGet:
-            path: {{ template "relay.healthCheck.readinessRequestPath" }}
-            port: {{ template "relay.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.relay.probeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.relay.probePeriodSeconds }}
-          successThreshold: {{ .Values.relay.probeSuccessThreshold }}
-          timeoutSeconds: {{ .Values.relay.probeTimeoutSeconds }}
+            {{- $readinessProbePath := include "relay.healthCheck.readinessRequestPath" . -}}
+            {{- $readinessProbeFixedSettings := dict "httpGet" (dict "path" $readinessProbePath "port" $port "scheme" "HTTP") -}}
+            {{- merge $readinessProbeFixedSettings (omit .Values.relay.readinessProbe "enabled") | toYaml | nindent 12 }}
+{{- end }}
         resources:
 {{ toYaml .Values.relay.resources | indent 12 }}
 {{- if .Values.relay.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -127,12 +127,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestConsumerAttachments.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestConsumerAttachments.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestConsumerAttachments.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -127,12 +127,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.ingestConsumerEvents.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestConsumerEvents.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestConsumerEvents.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestConsumerEvents.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -107,12 +107,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.ingestFeedback.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestFeedback.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestFeedback.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestFeedback.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -112,12 +112,7 @@ spec:
           - "--"
         {{- if .Values.sentry.ingestMonitors.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestMonitors.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -106,12 +106,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.monitorsClockTasks.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.monitorsClockTasks.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -106,12 +106,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.monitorsClockTick.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.monitorsClockTick.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -107,12 +107,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.ingestOccurrences.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestOccurrences.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -107,12 +107,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.ingestProfiles.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestProfiles.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -112,12 +112,7 @@ spec:
           - "--"
         {{- if .Values.sentry.ingestReplayRecordings.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestReplayRecordings.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -128,12 +128,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.ingestConsumerTransactions.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.ingestConsumerTransactions.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.ingestConsumerTransactions.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.ingestConsumerTransactions.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -108,12 +108,7 @@ spec:
           - "--"
         {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.billingMetricsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -89,27 +89,11 @@ spec:
 {{- end }}
 {{- if .Values.metrics.livenessProbe.enabled }}
         livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 9102
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          {{- omit .Values.metrics.livenessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
 {{- if .Values.metrics.readinessProbe.enabled }}
         readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 9102
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          {{- omit .Values.metrics.readinessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -118,12 +118,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.metricsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -118,12 +118,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.genericMetricsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -106,12 +106,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.postProcessForwardErrors.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.postProcessForwardErrors.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -108,12 +108,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.postProcessForwardIssuePlatform.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -115,12 +115,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.postProcessForwardTransactions.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.postProcessForwardTransactions.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -105,12 +105,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.processSegments.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.processSegments.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.processSegments.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.processSegments.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -105,12 +105,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.processSpans.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.processSpans.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.processSpans.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.processSpans.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -97,12 +97,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerEvents.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerEvents.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -114,12 +114,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -114,12 +114,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerMetrics.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -97,12 +97,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -98,12 +98,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.subscriptionConsumerTransactions.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerTransactions.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -105,12 +105,7 @@ spec:
           {{- end }}
         {{- if .Values.sentry.uptimeResults.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.sentry.uptimeResults.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.uptimeResults.livenessProbe.periodSeconds }}
+          {{- omit .Values.sentry.uptimeResults.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -96,26 +96,16 @@ spec:
 {{- if .Values.vroom.volumeMounts }}
 {{ toYaml .Values.vroom.volumeMounts | indent 8 }}
 {{- end }}
+        {{- $port := include "vroom.port" . | atoi -}}
+        {{- $probeFixed := dict "httpGet" (dict "port" $port "scheme" "HTTP") -}}
+        {{- if .Values.vroom.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: {{ .Values.vroom.probeFailureThreshold }}
-          httpGet:
-            path: /health
-            port: {{ template "vroom.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.vroom.probeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.vroom.probePeriodSeconds }}
-          successThreshold: {{ .Values.vroom.probeSuccessThreshold }}
-          timeoutSeconds: {{ .Values.vroom.probeTimeoutSeconds }}
+            {{- merge $probeFixed (omit .Values.vroom.livenessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.vroom.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: {{ .Values.vroom.probeFailureThreshold }}
-          httpGet:
-            path: /health
-            port: {{ template "vroom.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.vroom.probeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.vroom.probePeriodSeconds }}
-          successThreshold: {{ .Values.vroom.probeSuccessThreshold }}
-          timeoutSeconds: {{ .Values.vroom.probeTimeoutSeconds }}
+            {{- merge $probeFixed (omit .Values.vroom.readinessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.vroom.resources | indent 12 }}
 {{- if .Values.vroom.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -134,26 +134,17 @@ spec:
 {{- if .Values.sentry.web.volumeMounts }}
 {{ toYaml .Values.sentry.web.volumeMounts | indent 8 }}
 {{- end }}
+        {{- $port := include "sentry.port" . | atoi -}}
+        {{- $healthRequestPath:= include "sentry.healthCheck.requestPath" . -}}
+        {{- $probeFixed := dict "httpGet" (dict "path" $healthRequestPath "port" $port "scheme" "HTTP") -}}
+        {{- if .Values.sentry.web.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: {{ .Values.sentry.web.probeFailureThreshold }}
-          httpGet:
-            path: {{ template "sentry.healthCheck.requestPath" }}
-            port: {{ template "sentry.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.sentry.web.probeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.web.probePeriodSeconds }}
-          successThreshold: {{ .Values.sentry.web.probeSuccessThreshold }}
-          timeoutSeconds: {{ .Values.sentry.web.probeTimeoutSeconds }}
+            {{- merge $probeFixed (omit .Values.sentry.web.livenessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.sentry.web.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: {{ .Values.sentry.web.probeFailureThreshold }}
-          httpGet:
-            path: {{ template "sentry.healthCheck.requestPath" }}
-            port: {{ template "sentry.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.sentry.web.probeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.sentry.web.probePeriodSeconds }}
-          successThreshold: {{ .Values.sentry.web.probeSuccessThreshold }}
-          timeoutSeconds: {{ .Values.sentry.web.probeTimeoutSeconds }}
+            {{- merge $probeFixed (omit .Values.sentry.web.readinessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.sentry.web.resources | indent 12 }}
 {{- if .Values.sentry.web.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-events.yaml
@@ -125,18 +125,9 @@ spec:
 {{- if .Values.sentry.workerEvents.volumeMounts }}
 {{ toYaml .Values.sentry.workerEvents.volumeMounts | indent 8 }}
 {{- end }}
-  {{- if .Values.sentry.workerEvents.livenessProbe.enabled }}
+{{- if .Values.sentry.workerEvents.livenessProbe.enabled }}
         livenessProbe:
-          periodSeconds: {{ .Values.sentry.workerEvents.livenessProbe.periodSeconds }}
-          initialDelaySeconds: 10
-          timeoutSeconds: {{ .Values.sentry.workerEvents.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.sentry.workerEvents.livenessProbe.failureThreshold }}
-          exec:
-            command:
-              - sentry
-              - exec
-              - -c
-              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+          {{- omit .Values.sentry.workerEvents.livenessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.workerEvents.resources | indent 12 }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker-transactions.yaml
@@ -125,18 +125,9 @@ spec:
 {{- if .Values.sentry.workerTransactions.volumeMounts }}
 {{ toYaml .Values.sentry.workerTransactions.volumeMounts | indent 8 }}
 {{- end }}
-  {{- if .Values.sentry.workerTransactions.livenessProbe.enabled }}
+{{- if .Values.sentry.workerTransactions.livenessProbe.enabled }}
         livenessProbe:
-          periodSeconds: {{ .Values.sentry.workerTransactions.livenessProbe.periodSeconds }}
-          initialDelaySeconds: 10
-          timeoutSeconds: {{ .Values.sentry.workerTransactions.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.sentry.workerTransactions.livenessProbe.failureThreshold }}
-          exec:
-            command:
-              - sentry
-              - exec
-              - -c
-              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+          {{- omit .Values.sentry.workerTransactions.livenessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.workerTransactions.resources | indent 12 }}

--- a/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
+++ b/charts/sentry/templates/sentry/worker/deployment-sentry-worker.yaml
@@ -132,18 +132,9 @@ spec:
 {{- if .Values.sentry.worker.volumeMounts }}
 {{ toYaml .Values.sentry.worker.volumeMounts | indent 8 }}
 {{- end }}
-  {{- if .Values.sentry.worker.livenessProbe.enabled }}
+{{- if .Values.sentry.worker.livenessProbe.enabled }}
         livenessProbe:
-          periodSeconds: {{ .Values.sentry.worker.livenessProbe.periodSeconds }}
-          initialDelaySeconds: 10
-          timeoutSeconds: {{ .Values.sentry.worker.livenessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.sentry.worker.livenessProbe.failureThreshold }}
-          exec:
-            command:
-              - sentry
-              - exec
-              - -c
-              - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+          {{- omit .Values.sentry.worker.livenessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
         resources:
 {{ toYaml .Values.sentry.worker.resources | indent 12 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -98,26 +98,17 @@ spec:
 {{- if .Values.snuba.api.volumeMounts }}
 {{ toYaml .Values.snuba.api.volumeMounts | indent 8 }}
 {{- end }}
+        {{- $port := include "snuba.port" . | atoi -}}
+        {{- $probeFixedSettings := dict "httpGet" (dict "path" "/health" "port" $port "scheme" "HTTP") -}}
+
+        {{- if .Values.snuba.api.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /health
-            port: {{ template "snuba.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.snuba.api.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: {{ .Values.snuba.api.liveness.timeoutSeconds }}
+          {{- merge $probeFixedSettings (omit .Values.snuba.api.livenessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.snuba.api.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /health
-            port: {{ template "snuba.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.snuba.api.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: {{ .Values.snuba.api.readiness.timeoutSeconds }}
+          {{- merge $probeFixedSettings (omit .Values.snuba.api.readinessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.snuba.api.resources | indent 12 }}
 {{- if .Values.snuba.api.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -131,12 +131,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.consumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.consumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.consumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.consumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.eapItemsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.eapItemsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.eapItemsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.eapItemsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.genericMetricsCountersConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.genericMetricsCountersConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.genericMetricsDistributionConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.genericMetricsGaugesConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.genericMetricsSetsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.genericMetricsSetsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -131,12 +131,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.groupAttributesConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.groupAttributesConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.groupAttributesConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.groupAttributesConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.issueOccurrenceConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.issueOccurrenceConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.metricsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.metricsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -137,12 +137,7 @@ spec:
           - "--"
         {{- if .Values.snuba.outcomesBillingConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.outcomesBillingConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.outcomesBillingConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.outcomesBillingConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -129,12 +129,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.outcomesConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.outcomesConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.profilingChunksConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.profilingChunksConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.profilingChunksConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.profilingChunksConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.profilingFunctionsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.profilingFunctionsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.profilingProfilesConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.profilingProfilesConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -137,12 +137,7 @@ spec:
           - "--"
         {{- if .Values.snuba.replaysConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.replaysConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-spans-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.spansConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.spansConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.spansConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.spansConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -98,12 +98,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerEapItems.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerEapItems.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerEapItems.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerEapItems.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -98,12 +98,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerEvents.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerEvents.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -99,12 +99,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -99,12 +99,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -99,12 +99,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -99,12 +99,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -100,12 +100,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerMetrics.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerMetrics.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -99,12 +99,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.subscriptionConsumerTransactions.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.subscriptionConsumerTransactions.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.transactionsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.transactionsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-uptime-results-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-uptime-results-consumer.yaml
@@ -132,12 +132,7 @@ spec:
           {{- end }}
         {{- if .Values.snuba.uptimeResultsConsumer.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command:
-              - rm
-              - /tmp/health.txt
-          initialDelaySeconds: {{ .Values.snuba.uptimeResultsConsumer.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.snuba.uptimeResultsConsumer.livenessProbe.periodSeconds }}
+          {{- omit .Values.snuba.uptimeResultsConsumer.livenessProbe "enabled" | toYaml | nindent 12 }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -101,26 +101,16 @@ spec:
 {{- if .Values.symbolicator.api.volumeMounts }}
 {{ toYaml .Values.symbolicator.api.volumeMounts | indent 8 }}
 {{- end }}
+        {{- $port := include "symbolicator.port" . | atoi -}}
+        {{- $portOverride := dict "httpGet" (dict "port" $port) -}}
+        {{- if .Values.symbolicator.api.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /healthcheck
-            port: {{ template "symbolicator.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.symbolicator.api.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- merge $portOverride (omit .Values.symbolicator.api.livenessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.symbolicator.api.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /healthcheck
-            port: {{ template "symbolicator.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.symbolicator.api.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- merge $portOverride (omit .Values.symbolicator.api.readinessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.symbolicator.api.resources | indent 12 }}
 {{- if .Values.symbolicator.api.containerSecurityContext }}

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -102,26 +102,16 @@ spec:
 {{- if .Values.symbolicator.api.volumeMounts }}
 {{ toYaml .Values.symbolicator.api.volumeMounts | indent 8 }}
 {{- end }}
+        {{- $port := include "symbolicator.port" . | atoi -}}
+        {{- $portOverride := dict "httpGet" (dict "port" $port) -}}
+        {{- if .Values.symbolicator.api.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /healthcheck
-            port: {{ template "symbolicator.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.symbolicator.api.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- merge $portOverride (omit .Values.symbolicator.api.livenessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.symbolicator.api.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /healthcheck
-            port: {{ template "symbolicator.port" }}
-            scheme: HTTP
-          initialDelaySeconds: {{ .Values.symbolicator.api.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          {{- merge $portOverride (omit .Values.symbolicator.api.readinessProbe "enabled") | toYaml | nindent 12 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.symbolicator.api.resources | indent 12 }}
 {{- if .Values.symbolicator.api.containerSecurityContext }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -84,11 +84,26 @@ vroom:
   # args: []
   replicas: 1
   env: []
-  probeFailureThreshold: 5
-  probeInitialDelaySeconds: 10
-  probePeriodSeconds: 10
-  probeSuccessThreshold: 1
-  probeTimeoutSeconds: 2
+  livenessProbe:
+    enabled: true
+    failureThreshold: 5
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
+    httpGet:
+      path: /health
+      scheme: HTTP
+  readinessProbe:
+    enabled: true
+    failureThreshold: 5
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
+    httpGet:
+      path: /health
+      scheme: HTTP
   resources: {}
   #  requests:
   #    cpu: 100m
@@ -156,11 +171,20 @@ relay:
   # args: []
   mode: managed
   env: []
-  probeFailureThreshold: 5
-  probeInitialDelaySeconds: 10
-  probePeriodSeconds: 10
-  probeSuccessThreshold: 1
-  probeTimeoutSeconds: 2
+  livenessProbe:
+    enabled: true
+    failureThreshold: 5
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
+  readinessProbe:
+    enabled: true
+    failureThreshold: 5
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
   resources: {}
   #  requests:
   #    cpu: 100m
@@ -255,11 +279,20 @@ sentry:
     replicas: 1
     env: []
     existingSecretEnv: ""
-    probeFailureThreshold: 5
-    probeInitialDelaySeconds: 10
-    probePeriodSeconds: 10
-    probeSuccessThreshold: 1
-    probeTimeoutSeconds: 2
+    livenessProbe:
+      enabled: true
+      failureThreshold: 5
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 2
+    readinessProbe:
+      enabled: true
+      failureThreshold: 5
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 2
     resources: {}
     #  requests:
     #    cpu: 200m
@@ -340,9 +373,17 @@ sentry:
       behavior: {}
     livenessProbe:
       enabled: true
+      initialDelaySeconds: 10
       periodSeconds: 60
       timeoutSeconds: 10
       failureThreshold: 3
+      exec:
+        command:
+          - sentry
+          - exec
+          - -c
+          - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+
     sidecars: []
     # securityContext: {}
     # containerSecurityContext: {}
@@ -380,9 +421,17 @@ sentry:
       behavior: {}
     livenessProbe:
       enabled: false
+      initialDelaySeconds: 10
       periodSeconds: 60
       timeoutSeconds: 10
       failureThreshold: 3
+      exec:
+        command:
+          - sentry
+          - exec
+          - -c
+          - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+
     sidecars: []
     # securityContext: {}
     # containerSecurityContext: {}
@@ -418,9 +467,17 @@ sentry:
       behavior: {}
     livenessProbe:
       enabled: false
+      initialDelaySeconds: 10
       periodSeconds: 60
       timeoutSeconds: 10
       failureThreshold: 3
+      exec:
+        command:
+          - sentry
+          - exec
+          - -c
+          - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
+
     sidecars: []
     # securityContext: {}
     # containerSecurityContext: {}
@@ -464,6 +521,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -506,6 +567,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -548,6 +613,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -583,6 +652,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -613,6 +686,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -647,6 +724,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -681,6 +762,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -716,6 +801,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -747,6 +836,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -778,6 +871,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -812,6 +909,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -849,6 +950,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -886,6 +991,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -927,6 +1036,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -953,6 +1066,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # volumeMounts: []
@@ -978,6 +1095,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # volumeMounts: []
@@ -1003,6 +1124,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # volumeMounts: []
@@ -1029,6 +1154,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1054,6 +1183,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumeMounts: []
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
@@ -1080,6 +1213,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1105,6 +1242,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1130,6 +1271,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1156,6 +1301,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1182,6 +1331,10 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1231,9 +1384,19 @@ snuba:
     #   - api
     env: []
     probeInitialDelaySeconds: 10
-    liveness:
+    livenessProbe:
+      enabled: true
+      failureThreshold: 5
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
       timeoutSeconds: 2
-    readiness:
+    readinessProbe:
+      enabled: true
+      failureThreshold: 5
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
       timeoutSeconds: 2
     resources: {}
     #  requests:
@@ -1277,6 +1440,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -1310,6 +1477,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1345,6 +1516,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -1379,6 +1554,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -1430,6 +1609,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # maxBatchSize: ""
@@ -1457,6 +1640,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1478,6 +1665,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1499,6 +1690,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1520,6 +1715,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1541,6 +1740,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1562,6 +1765,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1584,6 +1791,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # maxBatchSize: ""
@@ -1612,6 +1823,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # maxBatchSize: ""
@@ -1640,6 +1855,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # maxBatchSize: ""
@@ -1668,6 +1887,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
     # maxBatchSize: ""
@@ -1699,6 +1922,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # volumes: []
     # volumeMounts: []
 
@@ -1723,6 +1950,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1744,6 +1975,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1777,6 +2012,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1810,6 +2049,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1843,6 +2086,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1877,6 +2124,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1910,6 +2161,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1943,6 +2198,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1976,6 +2235,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2009,6 +2272,10 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      exec:
+        command:
+          - rm
+          - /tmp/health.txt
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2222,7 +2489,26 @@ symbolicator:
       lookupVolumeName: true
     replicas: 1
     env: []
-    probeInitialDelaySeconds: 10
+    livenessProbe:
+      enabled: true
+      failureThreshold: 5
+      httpGet:
+        path: /healthcheck
+        scheme: HTTP
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 2
+    readinessProbe:
+      enabled: true
+      failureThreshold: 5
+      httpGet:
+        path: /healthcheck
+        scheme: HTTP
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 2
     resources: {}
     affinity: {}
     nodeSelector: {}
@@ -3047,6 +3333,11 @@ metrics:
     timeoutSeconds: 2
     failureThreshold: 3
     successThreshold: 1
+    httpGet:
+      path: /metrics
+      port: 9102
+      scheme: HTTP
+
   readinessProbe:
     enabled: true
     initialDelaySeconds: 30
@@ -3054,6 +3345,10 @@ metrics:
     timeoutSeconds: 2
     failureThreshold: 3
     successThreshold: 1
+    httpGet:
+      path: /metrics
+      port: 9102
+      scheme: HTTP
 
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
I need to override readinessProbe & livenessProbe on my platform, actually sometimes we can sometimes not

PS: I think we should use port name, not an include/template for probe & co