### PR TITLE
fix: snuba-subscription-consumer-eap-items followed-consumer-group

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -89,7 +89,7 @@ spec:
           - "--no-strict-offset-reset"
           {{- end }}
           - "--consumer-group=snuba-eap-items-subscriptions-consumers"
-          - "--followed-consumer-group=eap_spans_group"
+          - "--followed-consumer-group=eap_items_group"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
           {{- if .Values.snuba.subscriptionConsumerEapItems.livenessProbe.enabled }}


### PR DESCRIPTION

I noticed when looking at metrics in our deployment that `snuba_subscriptions_scheduler_executor_followed_group_mismatch{dataset="events_analytics_platform",group="eap_items_group"}` was happening a lot.
It seems to be because of this misconfig.

It looks like a minor oversight from the [initial upgrade to Sentry 25.8.0](https://github.com/sentry-kubernetes/charts/pull/1851).

This also matched the self-hosted: https://github.com/getsentry/self-hosted/blob/83f07124bf9f5a821cf854f625378da20a8cebdb/docker-compose.yml#L465
