### PR TITLE
fix: high uwsgi memory usage caused by uwsgi allocating memory based on max-fd

### DIFF
--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -101,6 +101,8 @@ spec:
         ports:
         - containerPort: {{ template "sentry.port" }}
         env:
+        - name: UWSGI_MAX_FD
+          value: {{ .Values.sentry.web.uwsgiMaxFd|quote }}
 {{ include "sentry.env" . | indent 8 }}
 {{ include "sentry.env.nodestore-s3" . | indent 8 }}
         {{ if .Values.sentry.web.customCA }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -307,6 +307,7 @@ sentry:
     volumes: []
     volumeMounts: []
     # workers: 3
+    uwsgiMaxFd: 8192
 
   features:
     orgSubdomains: false


### PR DESCRIPTION
Hello,

I've run into issue that `sentry-web` was consuming huge amount of RAM (9GB). After a lot of investigation it seems it's a feature of uwsgi that allocates some structures based on max-fd. In some setups it can be really high and this solves the issue.

References:
https://github.com/getsentry/sentry/issues/40617
https://github.com/devopsfreelancer1/sentry/commit/6695b45770a8e72d96837698fee7ea2131729d4a
https://github.com/unbit/uwsgi/issues/2299