### PR TITLE
feat(hook): ArgoCd Compatible Annotations for hook

### DIFF
--- a/charts/sentry/templates/hooks/sentry-secret-create.yaml
+++ b/charts/sentry/templates/hooks/sentry-secret-create.yaml
@@ -9,8 +9,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
+    {{- if .Values.useArgoCdCompatibleAnnotations }}
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/sync-wave": "-1"
+    {{- else }}
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-weight": "-1"
+    {{- end }}
 type: Opaque
 data:
   key: {{ randAlphaNum 50 | b64enc | quote }}

--- a/charts/sentry/templates/hooks/sentry-secret-create.yaml
+++ b/charts/sentry/templates/hooks/sentry-secret-create.yaml
@@ -14,7 +14,7 @@ metadata:
     "argocd.argoproj.io/sync-wave": "-1"
     {{- else }}
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-weight": "3"
     {{- end }}
 type: Opaque
 data:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3157,3 +3157,8 @@ pgbouncer:
     #   clientIP:
     #     timeoutSeconds: 180
     sessionAffinityConfig: {}
+
+# Helm hooks are similar to Argo CD hooks, but some of them are incompatible.
+# Please refer to for details:
+# https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
+useArgoCdCompatibleAnnotations: false


### PR DESCRIPTION
replaces this PR https://github.com/sentry-kubernetes/charts/pull/1975

If persistent resource (f/e Secret) is created with helm-hook it is not a part of release. Argocd prunes such resources. This PR makes sentry-secret compatible with Argocd