### PR TITLE
refactor: replace worker annotations/labels with web in hook jobs to prepare for future Taskworker use

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -27,8 +27,8 @@ spec:
     metadata:
       name: {{ template "sentry.fullname" . }}-db-check
       annotations:
-        {{- if .Values.sentry.worker.annotations }}
-{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
+        {{- if .Values.sentry.web.annotations }}
+{{ toYaml .Values.sentry.web.annotations | indent 8 }}
         {{- end }}
         {{- if .Values.hooks.dbCheck.podAnnotations }}
 {{ toYaml .Values.hooks.dbCheck.podAnnotations | indent 8 }}
@@ -36,8 +36,8 @@ spec:
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        {{- if .Values.sentry.worker.podLabels }}
-{{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
+        {{- if .Values.sentry.web.podLabels }}
+{{ toYaml .Values.sentry.web.podLabels | indent 8 }}
         {{- end }}
         {{- if .Values.hooks.dbCheck.podLabels }}
 {{ toYaml .Values.hooks.dbCheck.podLabels | indent 8 }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -23,8 +23,8 @@ spec:
       name: {{ template "sentry.fullname" . }}-db-init
       annotations:
         checksum/configmap.yaml: {{ include "sentry.config" . | sha256sum }}
-        {{- if .Values.sentry.worker.annotations }}
-{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
+        {{- if .Values.sentry.web.annotations }}
+{{ toYaml .Values.sentry.web.annotations | indent 8 }}
         {{- end }}
         {{- if .Values.hooks.dbInit.podAnnotations }}
 {{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
@@ -32,8 +32,8 @@ spec:
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        {{- if .Values.sentry.worker.podLabels }}
-{{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
+        {{- if .Values.sentry.web.podLabels }}
+{{ toYaml .Values.sentry.web.podLabels | indent 8 }}
         {{- end }}
         {{- if .Values.hooks.dbInit.podLabels }}
 {{ toYaml .Values.hooks.dbInit.podLabels | indent 8 }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -21,8 +21,8 @@ spec:
       name: {{ template "sentry.fullname" . }}-user-create
       annotations:
         checksum/configmap.yaml: {{ include "sentry.config" . | sha256sum }}
-        {{- if .Values.sentry.worker.annotations }}
-{{ toYaml .Values.sentry.worker.annotations | indent 8 }}
+        {{- if .Values.sentry.web.annotations }}
+{{ toYaml .Values.sentry.web.annotations | indent 8 }}
         {{- end }}
         {{- if .Values.hooks.dbInit.podAnnotations }}
 {{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
@@ -30,8 +30,8 @@ spec:
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        {{- if .Values.sentry.worker.podLabels }}
-{{ toYaml .Values.sentry.worker.podLabels | indent 8 }}
+        {{- if .Values.sentry.web.podLabels }}
+{{ toYaml .Values.sentry.web.podLabels | indent 8 }}
         {{- end }}
     spec:
       {{- if .Values.hooks.dbInit.affinity }}


### PR DESCRIPTION
This PR replaces references to `.Values.sentry.worker.annotations` and `.Values.sentry.worker.podLabels` with `.Values.sentry.web.annotations` and `.Values.sentry.web.podLabels` in hook job templates (sentry-db-check, sentry-db-init, user-create). This change is made in preparation for the upcoming rename of worker to Taskworker in future PRs, aiming to reduce diff size and simplify review of subsequent changes.