### PR TITLE
28.0.0 - Symbolicator cleanup for statefulset fix

### DIFF
--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -136,11 +136,11 @@ spec:
           - /bin/sh
           - -c
         args:
-          - |
-            while true; do
-              symbolicator cleanup -c /etc/symbolicator/config.yml;
-              sleep {{ .Values.symbolicator.api.cleaner.sleepInterval }};
-            done
+          - cleanup
+          - -c
+          - /etc/symbolicator/config.yml 
+          - --repeat
+          - {{ .Values.symbolicator.api.cleaner.repeat }}
         volumeMounts:
         - mountPath: /etc/symbolicator
           name: config


### PR DESCRIPTION
This change was done is 28.0.0 only for the deployment.
[charts/sentry/templates/symbolicator/deployment-symbolicator.yaml](https://github.com/sentry-kubernetes/charts/pull/1981/files#diff-4066718458755030f05b4c06a66c2e09dd1d89bac3dadcc7058d090be4ca7a59)

Since the helm chart gives the option to use a statefulset, this should also be done in the statefulset, which is what I've done in this PR.