### PR TITLE
28.0.1 - Fix symbolicator statefulset cleaner configuration

### DIFF
--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -132,9 +132,6 @@ spec:
       - name: {{ .Chart.Name }}-symbolicator-cleaner
         image: "{{ template "symbolicator.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.symbolicator.pullPolicy }}
-        command:
-          - /bin/sh
-          - -c
         args:
           - cleanup
           - -c


### PR DESCRIPTION
Currently the symbolicator-cleaner container is failing due to this:

`Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown`

On investigation I noticed another drift between the deployment and statefulset variant.

Therefore I removed the command definition for symbolicator cleaner since `/bin/sh` is not installed in the symbolicator image