### PR TITLE
fix: optionally take app_id and app_name from secrets for Github

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1024,6 +1024,20 @@ Set github app
     secretKeyRef:
       name: {{ .Values.github.existingSecret }}
       key: {{ default "client-secret" .Values.github.existingSecretClientSecretKey }}
+{{- if .Values.github.existingSecretAppIdKey }}
+- name: GITHUB_APP_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.github.existingSecret }}
+      key: {{ .Values.github.existingSecretAppIdKey }}
+{{- end }}
+{{- if .Values.github.existingSecretAppNameKey }}
+- name: GITHUB_APP_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.github.existingSecret }}
+      key: {{ .Values.github.existingSecretAppNameKey }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -706,6 +706,12 @@ sentry.conf.py: |-
   ##########
   # Github #
   ##########
+  {{- if .Values.github.existingSecretAppIdKey }}
+  SENTRY_OPTIONS['github-app.id'] = os.environ.get("GITHUB_APP_ID")
+  {{- end }}
+  {{- if .Values.github.existingSecretAppNameKey }}
+  SENTRY_OPTIONS['github-app.name'] = os.environ.get("GITHUB_APP_NAME")
+  {{- end }}
   SENTRY_OPTIONS['github-app.private-key'] = os.environ.get("GITHUB_APP_PRIVATE_KEY")
   SENTRY_OPTIONS['github-app.webhook-secret'] = os.environ.get("GITHUB_APP_WEBHOOK_SECRET")
   SENTRY_OPTIONS['github-app.client-id'] = os.environ.get("GITHUB_APP_CLIENT_ID")

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2203,13 +2203,17 @@ github: {}
 #   Note: if you use `existingSecret`, all above `clientId`, `clientSecret`, `privateKey`, `webhookSecret`
 #   params would be ignored, because chart will suppose that they are stored in `existingSecret`. So you
 #   must define all required keys and set it at least to empty strings if they are not needed in `existingSecret`
-#   secret (client-id, client-secret, webhook-secret, private-key)
+#   secret (client-id, client-secret, webhook-secret, private-key).
+#   However, `appId` and `appName` will be used from the values above,
+#   if `existingSecretAppIdKey` and `existingSecretAppNameKey` are not specified.
 #
 #   existingSecret: "xxxxx"
 #   existingSecretPrivateKeyKey: ""     # by default "private-key"
 #   existingSecretWebhookSecretKey: ""  # by default "webhook-secret"
 #   existingSecretClientIdKey: ""       # by default "client-id"
 #   existingSecretClientSecretKey: ""   # by default "client-secret"
+#   existingSecretAppIdKey: ""          # if it is specified, it will override .Values.github.appId
+#   existingSecretAppNameKey: ""        # if it is specified, it will override .Values.github.appName
 #
 #   Reference -> https://docs.sentry.io/product/integrations/source-code-mgmt/github/
 


### PR DESCRIPTION
We have many Sentry installations, and a separate GitHub application is used for each. It will be useful to take appId and appName from the secret, as it's done for other fields.