### PR TITLE
Fix issue #2002 broken dependency on clickhouse

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "23.8.16.16"
+appVersion: "24.8.7.41"
 description: ClickHouse is an open source column-oriented database management
   system capable of real time generation of analytical data reports using SQL
   queries

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 28.0.3
+version: 28.0.4
 # renovate image=ghcr.io/getsentry/sentry
 appVersion: 25.12.1
 dependencies:


### PR DESCRIPTION
## Root Cause

The error occurred because Snuba migrations were trying to create a ClickHouse table column with the syntax `JSON(max_dynamic_paths=128)`, which is only supported in ClickHouse version 24.8 and later. The chart was using ClickHouse version 23.8.16.16, which doesn't support this syntax.

## Fix Applied

Updated the ClickHouse version in `charts/clickhouse/Chart.yaml`:

- __Before__: `appVersion: "23.8.16.16"`
- __After__: `appVersion: "24.8.7.41"`

This upgrade enables support for the `JSON(max_dynamic_paths=128)` syntax required by the Snuba EAP (Events Analytics Platform) migrations.

## Related issue, #2002 
