### PR TITLE
feat: update sentry to v26

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 28.0.2
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 25.12.1
+appVersion: 26.1.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
Not much (none) configuration changes needed for this release; https://github.com/getsentry/self-hosted/compare/25.12.1...26.1.0 :)