### PR TITLE
feat(gateway): add gateway api httpRoute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ As Relay is now part of this chart, you need to make sure you enable either Ngin
 
 If you are using an ingress gateway (like Istio), you have to change your inbound path from `sentry-web` to `nginx`.
 
-## NGINX and/or Ingress
+## Traffic Routing
 
 By default, NGINX is enabled to allow sending the incoming requests to [Sentry Relay](https://getsentry.github.io/relay/) or the Django backend depending on the path. When Sentry is meant to be exposed outside of the Kubernetes cluster, it is recommended to disable NGINX and let the Ingress do the same. It's recommended to go with the go-to Ingress Controller, [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/), but others should work as well.
 
@@ -309,6 +309,41 @@ nginx:
     hostname: fqdn
     ingressClassName: "nginx"
     tls: true
+```
+
+### Gateway API
+
+This chart supports [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute as an alternative to traditional Ingress.
+
+```yaml
+nginx:
+  enabled: false
+route:
+  main:
+    enabled: true
+    hostnames:
+      - sentry.example.com
+    parentRefs:
+      - name: my-gateway
+        namespace: default
+```
+
+With HTTP to HTTPS redirect:
+
+```yaml
+route:
+  main:
+    enabled: true
+    hostnames:
+      - sentry.example.com
+    parentRefs:
+      - name: my-gateway
+        sectionName: https
+  httpRedirect:
+    enabled: true
+    parentRefs:
+      - name: my-gateway
+        sectionName: http
 ```
 
 ## ClickHouse warning

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -465,6 +465,24 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | relay.topologySpreadConstraints | list | `[]` |  |
 | relay.volumeMounts | list | `[]` |  |
 | relay.volumes | list | `[]` |  |
+| route.httpRedirect.annotations | object | `{}` | Annotations for the HTTP redirect HTTPRoute |
+| route.httpRedirect.apiVersion | string | `"gateway.networking.k8s.io/v1"` | API version for HTTPRoute (auto-detected if not set) |
+| route.httpRedirect.enabled | bool | `false` | Enable HTTP to HTTPS redirect HTTPRoute |
+| route.httpRedirect.hostnames | list | `[]` | Hostnames (inherits from main route if empty) |
+| route.httpRedirect.kind | string | `"HTTPRoute"` | Route kind |
+| route.httpRedirect.labels | object | `{}` | Labels for the HTTP redirect HTTPRoute |
+| route.httpRedirect.parentRefs | list | `[]` | Parent Gateway references for HTTP listener |
+| route.httpRedirect.statusCode | int | `301` | HTTP redirect status code (301=permanent, 302=temporary) |
+| route.main.additionalRules | list | `[]` | Additional custom rules to prepend |
+| route.main.annotations | object | `{}` | Annotations for the HTTPRoute |
+| route.main.apiVersion | string | `"gateway.networking.k8s.io/v1"` | API version for HTTPRoute (auto-detected if not set) |
+| route.main.enabled | bool | `false` | Enable Gateway API HTTPRoute |
+| route.main.filters | list | `[]` | Filters applied to all backend requests |
+| route.main.hostnames | list | `[]` | Hostnames for the HTTPRoute |
+| route.main.kind | string | `"HTTPRoute"` | Route kind (HTTPRoute, GRPCRoute, etc.) |
+| route.main.labels | object | `{}` | Labels for the HTTPRoute |
+| route.main.parentRefs | list | `[]` | Parent Gateway references (required when enabled) |
+| route.main.path | string | `"/"` | Base path prefix for subpath deployments |
 | revisionHistoryLimit | int | `10` |  |
 | sentry.billingMetricsConsumer.affinity | object | `{}` |  |
 | sentry.billingMetricsConsumer.autoscaling.enabled | bool | `false` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1180,3 +1180,16 @@ app.kubernetes.io/name: {{ include "sentry.name" .ctx }}
 app.kubernetes.io/instance: {{ .ctx.Release.Name }}
 app.kubernetes.io/component: {{ .component }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for Gateway API HTTPRoute.
+Returns empty string if Gateway API is not available in the cluster.
+Gateway API v1 is GA since Kubernetes 1.29.
+*/}}
+{{- define "sentry.route.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" -}}
+{{- print "gateway.networking.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1" -}}
+{{- print "gateway.networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sentry/templates/route.yaml
+++ b/charts/sentry/templates/route.yaml
@@ -1,0 +1,132 @@
+{{- $mainRoute := .Values.route.main -}}
+{{- $redirectRoute := .Values.route.httpRedirect -}}
+{{- $defaultApiVersion := include "sentry.route.apiVersion" . -}}
+{{- if and $mainRoute.enabled $defaultApiVersion }}
+{{- $fullName := include "sentry.fullname" . -}}
+{{- $relayPort := (include "relay.port" .) | int -}}
+{{- $webPort := .Values.service.externalPort | int -}}
+{{- $nginxEnabled := .Values.nginx.enabled -}}
+{{- $nginxPort := .Values.nginx.service.ports.http | int -}}
+{{- $hostnames := $mainRoute.hostnames -}}
+{{- $basePath := $mainRoute.path | default "/" | trimSuffix "/" -}}
+{{- if $redirectRoute.enabled }}
+{{- $redirectHostnames := $redirectRoute.hostnames | default $hostnames -}}
+---
+apiVersion: {{ $redirectRoute.apiVersion | default $defaultApiVersion }}
+kind: {{ $redirectRoute.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullName }}-http-redirect
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "sentry.labels" . | nindent 4 }}
+    {{- with $redirectRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $redirectRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $redirectRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $redirectHostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $basePath | default "/" }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: {{ $redirectRoute.statusCode | default 301 }}
+{{- end }}
+---
+apiVersion: {{ $mainRoute.apiVersion | default $defaultApiVersion }}
+kind: {{ $mainRoute.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "sentry.labels" . | nindent 4 }}
+    {{- with $mainRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $mainRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $mainRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+{{- if $mainRoute.additionalRules }}
+    {{- tpl (toYaml $mainRoute.additionalRules) $ | nindent 4 }}
+{{- end }}
+{{- if $nginxEnabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $basePath | default "/" }}
+      {{- with $mainRoute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-nginx
+          port: {{ $nginxPort }}
+{{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $basePath }}/api/0
+      {{- with $mainRoute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-web
+          port: {{ $webPort }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $basePath }}/api
+      {{- with $mainRoute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-relay
+          port: {{ $relayPort }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $basePath | default "/" }}
+      {{- with $mainRoute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-web
+          port: {{ $webPort }}
+{{- end }}
+{{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2348,6 +2348,80 @@ traefikIngressRoute:
   priority: 100
 
 
+# Kubernetes Gateway API HTTPRoute configuration
+# Configure gateway routes for the chart here. More routes can be added by adding
+# a dictionary key like the 'main' route.
+# Reference: https://gateway-api.sigs.k8s.io/
+route:
+  main:
+    # -- Enables or disables the route
+    enabled: false
+
+    # -- Set the route apiVersion
+    apiVersion: gateway.networking.k8s.io/v1
+
+    # -- Set the route kind
+    # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+    kind: HTTPRoute
+
+    # -- Route annotations
+    annotations: {}
+
+    # -- Route labels
+    labels: {}
+
+    # -- Hostnames for the HTTPRoute
+    # Example: ["sentry.example.com", "sentry.internal.example.com"]
+    hostnames: []
+
+    # -- Parent Gateway references
+    # At least one parentRef is required when enabled
+    parentRefs: []
+      # - name: my-gateway
+      #   namespace: default
+      #   sectionName: https
+
+    # -- Base path prefix for all routes (for subpath deployments)
+    # Use this if Sentry is deployed at a subpath, e.g., "/sentry"
+    path: /
+
+    # -- Additional custom rules to prepend
+    additionalRules: []
+
+    # -- Filters applied to requests
+    filters: []
+
+  # -- HTTP to HTTPS redirect route
+  # Creates a separate HTTPRoute that redirects HTTP traffic to HTTPS
+  httpRedirect:
+    # -- Enables or disables the redirect route
+    enabled: false
+
+    # -- Set the route apiVersion
+    apiVersion: gateway.networking.k8s.io/v1
+
+    # -- Set the route kind
+    kind: HTTPRoute
+
+    # -- Route annotations
+    annotations: {}
+
+    # -- Route labels
+    labels: {}
+
+    # -- Hostnames (if empty, inherits from main route)
+    hostnames: []
+
+    # -- Parent reference for the HTTP listener
+    parentRefs: []
+      # - name: my-gateway
+      #   namespace: default
+      #   sectionName: http
+
+    # -- HTTP status code for redirect (301 = permanent, 302 = temporary)
+    statusCode: 301
+
+
 filestore:
   # Set to one of filesystem, gcs or s3 as supported by Sentry.
   backend: filesystem


### PR DESCRIPTION
Fix #1992

## Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  This PR adds native Kubernetes Gateway API HTTPRoute support to the Sentry Helm chart, providing a modern, portable alternative to traditional Ingress for traffic routing.                                                           
                                                                                                                                                                                                                                        
  - **Add Gateway API HTTPRoute template** with intelligent routing logic mirroring existing Ingress behavior                                                                                                                           
  - **Support HTTP-to-HTTPS redirect** via separate HTTPRoute with RequestRedirect filter                                                                                                                                               
  - **Auto-detect Gateway API version** (v1 GA or v1beta1 fallback)                                                                                                                                                                     
  - **Document comprehensive routing architecture** for both Ingress and Gateway API                                                                                                                                                    
                                                                                                                                                                                                                                        
  ## Motivation                                                                                                                                                                                                                         
                                                                                                                                                                                                                                        
  The [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) is the successor to Ingress, offering:                                                                                                                                 
  - **Portability**: Standard API across all conformant implementations                                                                                                                                                                 
  - **Role-oriented design**: Separation of concerns between infrastructure and application teams                                                                                                                                       
  - **Expressiveness**: Native support for redirects, header modification, and traffic splitting                                                                                                                                        
  - **GA stability**: HTTPRoute reached GA in Kubernetes 1.29                                                                                                                                                                           
                                                                                                                                                                                                                                        
  ## Implementation Details                                                                                                                                                                                                             
                                                                                                                                                                                                                                        
  ### Routing Logic                                                                                                                                                                                                                     
                                                                                                                                                                                                                                        
  The HTTPRoute follows the same proven routing patterns as existing Ingress modes:                                                                                                                                                     
                                                                                                                                                                                                                                        
  | Path | Backend | Purpose |                                                                                                                                                                                                          
  |------|---------|---------|                                                                                                                                                                                                          
  | `/api/0/*` | `sentry-web` | REST API (dashboard) |                                                                                                                                                                                  
  | `/api/*` | `sentry-relay` | SDK event ingestion |                                                                                                                                                                                   
  | `/*` | `sentry-web` | Web UI, static assets |                                                                                                                                                                                       
                                                                                                                                                                                                                                        
  When `nginx.enabled: true`, all traffic routes to the bundled NGINX proxy instead.                                                                                                                                                    
                                                                                                                                                                                                                                        
  ### New Configuration Options                                                                                                                                                                                                         
                                                                                                                                                                                                                                        
  ```yaml                                                                                                                                                                                                                               
  route:                                                                                                                                                                                                                                
    main:                                                                                                                                                                                                                               
      enabled: true                                                                                                                                                                                                                     
      hostnames:                                                                                                                                                                                                                        
        - sentry.example.com                                                                                                                                                                                                            
      parentRefs:                                                                                                                                                                                                                       
        - name: my-gateway                                                                                                                                                                                                              
          sectionName: https                                                                                                                                                                                                            
    httpRedirect:                                                                                                                                                                                                                       
      enabled: true                                                                                                                                                                                                                     
      parentRefs:                                                                                                                                                                                                                       
        - name: my-gateway                                                                                                                                                                                                              
          sectionName: http                                                                                                                                                                                                             
```
