### PR TITLE
fix: Convert github-app.id to integer for Sentry 26.x compatibility

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -707,7 +707,10 @@ sentry.conf.py: |-
   # Github #
   ##########
   {{- if .Values.github.existingSecretAppIdKey }}
-  SENTRY_OPTIONS['github-app.id'] = os.environ.get("GITHUB_APP_ID")
+  # GitHub App ID must be an integer (Sentry 26.x+)
+  _github_app_id = os.environ.get("GITHUB_APP_ID")
+  if _github_app_id:
+      SENTRY_OPTIONS['github-app.id'] = int(_github_app_id)
   {{- end }}
   {{- if .Values.github.existingSecretAppNameKey }}
   SENTRY_OPTIONS['github-app.name'] = os.environ.get("GITHUB_APP_NAME")


### PR DESCRIPTION
## Summary
Sentry 26.x requires `github-app.id` to be an integer, but environment variables from Kubernetes secrets are always strings. This causes a `TypeError` during startup when using GitHub integration with `existingSecret`:

```
TypeError: 'github-app.id': got <class 'str'>, expected integer
```

## Changes
- Convert the `GITHUB_APP_ID` environment variable to an integer in the sentry.conf.py template

## Test Plan
- [x] Tested upgrade from 25.12.1 to 26.1.0 with GitHub App integration using `existingSecret`
- [x] Verified Sentry web pods start successfully after the fix

## Related Issues
This is a breaking change in Sentry 26.x that affects all self-hosted deployments using GitHub App integration via Kubernetes secrets.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)