### PR TITLE
feat: add serviceAccount.shared option for using single ServiceAccount

### DIFF
--- a/charts/sentry/templates/geoip/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/geoip/deployment-geoip-job.yaml
@@ -15,7 +15,7 @@ spec:
       {{- end }}
     spec:
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-geoip
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-geoip{{ end }}
       {{- end }}
       initContainers:
         - name: init-create-geoip-dir

--- a/charts/sentry/templates/geoip/serviceaccount-geoip.yaml
+++ b/charts/sentry/templates/geoip/serviceaccount-geoip.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.geodata.accountID .Values.serviceAccount.enabled }}
+{{- if and .Values.geodata.accountID .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -201,7 +201,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-relay
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-relay{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -154,6 +154,6 @@ spec:
           priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"
           {{- end }}
           {{- if .Values.serviceAccount.enabled }}
-          serviceAccountName: {{ .Values.serviceAccount.name }}-cleanup
+          serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-cleanup{{ end }}
           {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/cleanup/serviceaccount-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/serviceaccount-sentry-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -171,7 +171,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-consumer-attachments
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-consumer-attachments{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/attachments/serviceaccount-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/serviceaccount-sentry-ingest-consumer-attachments.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerAttachments.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestConsumerAttachments.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -171,7 +171,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-consumer-events
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-consumer-events{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/events/serviceaccount-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/serviceaccount-sentry-ingest-consumer-events.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerEvents.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestConsumerEvents.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -151,7 +151,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-feedback
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-feedback{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestMonitors.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestMonitors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -156,7 +156,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-monitors
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-monitors{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -150,7 +150,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-monitors-clock-tasks
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-monitors-clock-tasks{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -150,7 +150,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-monitors-clock-tick
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-monitors-clock-tick{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-ingest-monitors.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestMonitors.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestMonitors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTasks.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.monitorsClockTasks.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTick.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.monitorsClockTick.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -151,7 +151,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-occurrences
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-occurrences{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/occurrences/serviceaccount-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/serviceaccount-sentry-ingest-occurrences.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestOccurrences.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestOccurrences.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -155,7 +155,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-profiles
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-profiles{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/profiles/serviceaccount-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/serviceaccount-sentry-ingest-profiles.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableProfiling }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.features.enableProfiling }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -156,7 +156,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-replay-recordings
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-replay-recordings{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/serviceaccount-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/serviceaccount-sentry-ingest-replay-recordings.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestReplayRecordings.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestReplayRecordings.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -172,7 +172,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-consumer-transactions
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-consumer-transactions{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/transactions/serviceaccount-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/serviceaccount-sentry-ingest-consumer-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerTransactions.enabled  }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestConsumerTransactions.enabled  }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -152,7 +152,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-billing-metrics-consumer
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-billing-metrics-consumer{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/metrics/billing/serviceaccount-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/serviceaccount-sentry-billing-metrics-consumer.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.billingMetricsConsumer.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.billingMetricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -134,6 +134,6 @@ spec:
 {{- end }}
 
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-metrics
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-metrics{{ end }}
       {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -162,7 +162,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-metrics-consumer
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-metrics-consumer{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -162,7 +162,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-generic-metrics-consumer
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-generic-metrics-consumer{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/metrics/generic/serviceaccount-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/serviceaccount-sentry-generic-metrics-consumer.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.genericMetricsConsumer.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.genericMetricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/serviceaccount-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/serviceaccount-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/serviceaccount-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/serviceaccount-sentry-metrics-consumer.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.metricsConsumer.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.metricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -148,7 +148,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-errors
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-post-process-forwarder-errors{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/serviceaccount-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/serviceaccount-sentry-post-process-forwarder-errors.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardErrors.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.postProcessForwardErrors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -153,7 +153,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-issue-platform
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-post-process-forwarder-issue-platform{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/serviceaccount-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/serviceaccount-sentry-post-process-forwarder-issue-platform.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardIssuePlatform.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.postProcessForwardIssuePlatform.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -157,7 +157,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-transactions
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-post-process-forwarder-transactions{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/serviceaccount-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/serviceaccount-sentry-post-process-forwarder-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardTransactions.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.postProcessForwardTransactions.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -147,7 +147,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-process-segments
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-process-segments{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/process/segments/serviceaccount-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/serviceaccount-sentry-process-segments.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.processSegments.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.processSegments.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -147,7 +147,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-process-spans
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-process-spans{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/process/spans/serviceaccount-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/serviceaccount-sentry-process-spans.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.processSpans.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.processSpans.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-events
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-subscription-consumer-events{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/subscription-consumer/events/serviceaccount-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/serviceaccount-sentry-subscription-consumer-events.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerEvents.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.subscriptionConsumerEvents.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -158,7 +158,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-generic-metrics
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-subscription-consumer-generic-metrics{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/serviceaccount-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/serviceaccount-sentry-subscription-consumer-generic-metrics.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerGenericMetrics.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.subscriptionConsumerGenericMetrics.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -158,7 +158,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-metrics
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-subscription-consumer-metrics{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/serviceaccount-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/serviceaccount-sentry-subscription-consumer-metrics.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerMetrics.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.subscriptionConsumerMetrics.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-results-eap-items
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-subscription-consumer-results-eap-items{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/serviceaccount-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/serviceaccount-sentry-subscription-results-eap-items.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerResultsEapItems.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.subscriptionConsumerResultsEapItems.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -140,7 +140,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-subscription-consumer-transactions
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-subscription-consumer-transactions{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/serviceaccount-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/serviceaccount-sentry-subscription-consumer-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.subscriptionConsumerTransactions.enabled}}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.subscriptionConsumerTransactions.enabled}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/taskbroker/serviceaccount-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/serviceaccount-taskbroker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.taskBroker.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.sentry.taskBroker.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -69,7 +69,7 @@ spec:
       priorityClassName: "{{ $root.Values.sentry.taskBroker.priorityClassName }}"
       {{- end }}
       {{- if $root.Values.serviceAccount.enabled }}
-      serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskbroker
+      serviceAccountName: {{ if $root.Values.serviceAccount.shared }}{{ $root.Values.serviceAccount.name }}{{ else }}{{ $root.Values.serviceAccount.name }}-taskbroker{{ end }}
       {{- end }}
       containers:
       - name: taskbroker

--- a/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
@@ -67,7 +67,7 @@ spec:
       priorityClassName: "{{ .Values.sentry.taskScheduler.priorityClassName }}"
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-taskscheduler
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-taskscheduler{{ end }}
       {{- end }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" . | indent 6 }}

--- a/charts/sentry/templates/sentry/taskscheduler/serviceaccount-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/serviceaccount-taskscheduler.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.taskScheduler.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.sentry.taskScheduler.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -79,7 +79,7 @@ spec:
       priorityClassName: "{{ $root.Values.sentry.taskWorker.priorityClassName }}"
       {{- end }}
       {{- if $root.Values.serviceAccount.enabled }}
-      serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskworker
+      serviceAccountName: {{ if $root.Values.serviceAccount.shared }}{{ $root.Values.serviceAccount.name }}{{ else }}{{ $root.Values.serviceAccount.name }}-taskworker{{ end }}
       {{- end }}
       dnsConfig:
         searches:

--- a/charts/sentry/templates/sentry/taskworker/serviceaccount-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/serviceaccount-taskworker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.taskWorker.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.sentry.taskWorker.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -147,7 +147,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-uptime-results
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-uptime-results{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/uptime/serviceaccount-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/serviceaccount-sentry-uptime-results.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.uptimeResults.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.uptimeResults.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -129,7 +129,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-vroom
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-vroom{{ end }}
       {{- end }}
       volumes:
       {{- if .Values.vroom.persistence.enabled }}

--- a/charts/sentry/templates/sentry/vroom/serviceaccount-sentry-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/serviceaccount-sentry-vroom.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableProfiling }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.features.enableProfiling }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -173,7 +173,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-web
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-web{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/web/serviceaccount-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/serviceaccount-sentry-web.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.web.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.web.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/serviceaccount-shared.yaml
+++ b/charts/sentry/templates/serviceaccount-shared.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.relay.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
+{{- if and .Values.serviceAccount.enabled .Values.serviceAccount.shared }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}-relay
+  name: {{ .Values.serviceAccount.name }}
   labels:
-    {{- include "sentry.component.labels" (dict "component" "relay" "ctx" .) | nindent 4 }}
+    {{- include "sentry.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -252,6 +252,6 @@ spec:
           priorityClassName: "{{ .Values.snuba.cleanup.priorityClassName }}"
           {{- end }}
           {{- if .Values.serviceAccount.enabled }}
-          serviceAccountName: {{ .Values.serviceAccount.name }}-clickhouse-cleanup
+          serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-clickhouse-cleanup{{ end }}
           {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/cleanup/serviceaccount-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/serviceaccount-clickhouse-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.snuba.cleanup.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.snuba.cleanup.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -131,7 +131,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -168,7 +168,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -168,7 +168,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -174,7 +174,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -166,7 +166,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -140,7 +140,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -174,7 +174,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -135,7 +135,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -135,7 +135,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -136,7 +136,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -136,7 +136,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -136,7 +136,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -136,7 +136,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -137,7 +137,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -136,7 +136,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/serviceaccount-snuba.yaml
+++ b/charts/sentry/templates/snuba/serviceaccount-snuba.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.snuba.api.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.snuba.api.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -164,7 +164,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-symbolicator-api{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/symbolicator/serviceaccount-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/serviceaccount-symbolicator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -150,7 +150,7 @@ spec:
         {{ end }}
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-symbolicator-api{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
@@ -102,7 +102,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-uptime-checker
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-uptime-checker{{ end }}
       {{- end }}
       volumes:
 {{- if .Values.uptimeChecker.volumes }}

--- a/charts/sentry/templates/uptime-checker/serviceaccount-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/serviceaccount-uptime-checker.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableUptime }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.features.enableUptime }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -83,6 +83,9 @@ serviceAccount:
   name: "sentry"
   # serviceAccount.automountServiceAccountToken -- Automount API credentials for a Service Account.
   automountServiceAccountToken: true
+  # serviceAccount.shared -- If `true`, all components will use a single shared ServiceAccount with the name specified in `serviceAccount.name`.
+  # If `false` (default), each component will have its own ServiceAccount with a suffix (e.g., `sentry-web`, `sentry-snuba`).
+  shared: false
 
 vroom:
   annotations: {}


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                                                         
                                                                                                                                                                                                                                     
When using AWS EKS Pod Identity to grant S3 access to Sentry components, the current chart creates a separate ServiceAccount for each component (e.g., `sentry-web`, `sentry-snuba`, `sentry-relay`). 
This requires:                                                                                                                                                                                                    
- Binding Pod Identity/IAM roles to multiple ServiceAccounts                                                                                                                                                                       
- Maintaining separate IAM role mappings for each ServiceAccount                                                                                                                                                                   
- Complex RBAC configuration                                                                                                                                                                                                       
                                                                                                                                                                                                                                     
For S3 access (used by filestore, profiles, and nodestore), it's more practical to use a single ServiceAccount across all Sentry components.                                                                                       
                                                                                                                                                                                                                                     
## Solution                                                                                                                                                                                                                        
                                                                                                                                                                                                                                     
Added a new `serviceAccount.shared` parameter that allows using a single ServiceAccount for all components:
- When `serviceAccount.shared: false` (default): maintains current behavior - each component gets its own ServiceAccount with a suffix (e.g., `sentry-web`, `sentry-snuba`)
- When `serviceAccount.shared: true`: all components use the ServiceAccount specified in `serviceAccount.name`