### PR TITLE
chore!: remove bundled clickhouse chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ For now the full list of values is not documented, but you can get inspired by t
 
 ## Upgrading to Chart 29.x.x
 
+## External ClickHouse
+
+Removed bundled ClickHouse. Use an external ClickHouse deployment and follow the [External ClickHouse guide](charts/sentry/docs/external-clickhouse.md).
+
 ### Memcached chart switch
 
 This release replaces the Bitnami Memcached dependency with the CloudPirates Memcached chart (`oci://registry-1.docker.io/cloudpirates/memcached`). Values have changed accordingly:

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -13,5 +13,4 @@ name: clickhouse
 sources:
   - https://github.com/sentry-kubernetes/charts
 version: 4.1.1
-maintainers:
-  - name: sentry-kubernetes
+deprecated: true

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -2,6 +2,10 @@
 
 [ClickHouse](https://clickhouse.yandex/) is an open source column-oriented database management system capable of real time generation of analytical data reports using SQL queries.
 
+## Deprecation Notice
+
+This chart is deprecated and will not receive further updates in this repository. For Sentry deployments, use an external ClickHouse cluster and follow the [External ClickHouse guide](../sentry/docs/external-clickhouse.md).
+
 ## Introduction
 This chart bootstraps a [ClickHouse](https://clickhouse.yandex/) replication cluster deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 

--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -8,17 +8,11 @@ dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 29.3.14
-- name: clickhouse
-  repository: https://sentry-kubernetes.github.io/charts
-  version: 4.1.1
-- name: zookeeper
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.4.11
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.5.1
 - name: nginx
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 22.3.9
-digest: sha256:421e258cff10d78a00f0b353e21e1e42834f4f1aa5d1880468c0738e04568501
-generated: "2026-01-21T15:30:56.019590047+01:00"
+digest: sha256:3fe0b2d43a3db134b6df02bf1afb57c5e1e6012fb2786f0487e334c3d836ec88
+generated: "2026-02-03T11:05:38.208270483+01:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -18,14 +18,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 29.3.14
     condition: kafka.enabled
-  - name: clickhouse
-    repository: https://sentry-kubernetes.github.io/charts
-    version: 4.1.1
-    condition: clickhouse.enabled
-  - name: zookeeper
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 11.4.11
-    condition: zookeeper.enabled
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 12.5.1

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -41,24 +41,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 |-----|------|---------|-------------|
 | asHook | bool | `true` |  |
 | auth.register | bool | `true` |  |
-| clickhouse.clickhouse.configmap.remote_servers.internal_replication | bool | `true` |  |
-| clickhouse.clickhouse.configmap.remote_servers.replica.backup.enabled | bool | `false` |  |
-| clickhouse.clickhouse.configmap.users.enabled | bool | `false` |  |
-| clickhouse.clickhouse.configmap.users.user[0].config.networks[0] | string | `"::/0"` |  |
-| clickhouse.clickhouse.configmap.users.user[0].config.password | string | `""` |  |
-| clickhouse.clickhouse.configmap.users.user[0].config.profile | string | `"default"` |  |
-| clickhouse.clickhouse.configmap.users.user[0].config.quota | string | `"default"` |  |
-| clickhouse.clickhouse.configmap.users.user[0].name | string | `"default"` |  |
-| clickhouse.clickhouse.configmap.zookeeper_servers.config[0].hostTemplate | string | `"{{ .Release.Name }}-zookeeper-clickhouse"` |  |
-| clickhouse.clickhouse.configmap.zookeeper_servers.config[0].index | string | `"clickhouse"` |  |
-| clickhouse.clickhouse.configmap.zookeeper_servers.config[0].port | string | `"2181"` |  |
-| clickhouse.clickhouse.configmap.zookeeper_servers.enabled | bool | `true` |  |
-| clickhouse.clickhouse.persistentVolumeClaim.dataPersistentVolume.accessModes[0] | string | `"ReadWriteOnce"` |  |
-| clickhouse.clickhouse.persistentVolumeClaim.dataPersistentVolume.enabled | bool | `true` |  |
-| clickhouse.clickhouse.persistentVolumeClaim.dataPersistentVolume.storage | string | `"30Gi"` |  |
-| clickhouse.clickhouse.persistentVolumeClaim.enabled | bool | `true` |  |
-| clickhouse.clickhouse.replicas | string | `"1"` |  |
-| clickhouse.enabled | bool | `true` |  |
 | clickhouse.nodeSelector | object | `{}` |  |
 | config.configYml | object | `{}` |  |
 | config.relay | string | `"# No YAML relay config given\n"` |  |
@@ -1163,10 +1145,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | vroom.persistence.accessModes[0] | string | `"ReadWriteOnce"` | Access mode for vroom PVC. Use ReadWriteMany if sharing with ingest-profiles (filestore.profiles.filesystem.persistence.shareWithVroom) |
 | vroom.persistence.size | string | `"10Gi"` | Size of vroom PVC |
 | vroom.persistence.storageClassName | string | `nil` | Storage class for vroom PVC |
-| zookeeper.enabled | bool | `true` |  |
-| zookeeper.nameOverride | string | `"zookeeper-clickhouse"` |  |
-| zookeeper.nodeSelector | object | `{}` |  |
-| zookeeper.replicaCount | int | `1` |  |
 
 ## NGINX and/or Ingress
 

--- a/charts/sentry/ci/kind-values.yaml
+++ b/charts/sentry/ci/kind-values.yaml
@@ -20,9 +20,6 @@ redis:
 rabbitmq:
   enabled: false
 
-clickhouse:
-  enabled: false
-
 externalClickhouse:
   host: "clickhouse-clickhouse-external.default.svc"
   tcpPort: 9000

--- a/charts/sentry/docs/external-clickhouse.md
+++ b/charts/sentry/docs/external-clickhouse.md
@@ -124,10 +124,6 @@ Once your ClickHouse cluster is running, configure the Sentry Helm chart to use 
 In your `values.yaml`:
 
 ```yaml
-# Disable the bundled ClickHouse
-clickhouse:
-  enabled: false
-
 externalClickhouse:
   host: "clickhouse-sentry-clickhouse.sentry.svc" # Service name of your CHI
   tcpPort: 9000

--- a/charts/sentry/docs/external-services.md
+++ b/charts/sentry/docs/external-services.md
@@ -8,7 +8,7 @@ This guide outlines how to configure the various external services required by S
 
 **Status: REQUIRED**
 
-The bundled ClickHouse chart is deprecated. You must provide an external ClickHouse endpoint.
+The bundled ClickHouse chart has been removed. You must provide an external ClickHouse endpoint.
 
 - [ClickHouse Setup Guide](external-clickhouse.md)
 

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -188,10 +188,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{- define "sentry.clickhouse.fullname" -}}
-{{- printf "%s-%s" .Release.Name "clickhouse" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{- define "sentry.kafka.fullname" -}}
 {{- printf "%s-%s" .Release.Name "kafka" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -365,102 +361,63 @@ Create the name of the service account to use
 Set ClickHouse host
 */}}
 {{- define "sentry.clickhouse.host" -}}
-{{- if .Values.clickhouse.enabled -}}
-{{- template "sentry.clickhouse.fullname" . -}}
-{{- else -}}
 {{ required "A valid .Values.externalClickhouse.host is required" .Values.externalClickhouse.host }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse port
 */}}
 {{- define "sentry.clickhouse.port" -}}
-{{- if .Values.clickhouse.enabled -}}
-{{- default 9000 .Values.clickhouse.clickhouse.tcp_port }}
-{{- else -}}
 {{ required "A valid .Values.externalClickhouse.tcpPort is required" .Values.externalClickhouse.tcpPort }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse HTTP port
 */}}
 {{- define "sentry.clickhouse.http_port" -}}
-{{- if .Values.clickhouse.enabled -}}
-{{- default 8123 .Values.clickhouse.clickhouse.http_port }}
-{{- else -}}
 {{ required "A valid .Values.externalClickhouse.httpPort is required" .Values.externalClickhouse.httpPort }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse Database
 */}}
 {{- define "sentry.clickhouse.database" -}}
-{{- if .Values.clickhouse.enabled -}}
-default
-{{- else -}}
 {{ required "A valid .Values.externalClickhouse.database is required" .Values.externalClickhouse.database }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse User
 */}}
 {{- define "sentry.clickhouse.username" -}}
-{{- if .Values.clickhouse.enabled -}}
-  {{- if .Values.clickhouse.clickhouse.configmap.users.enabled -}}
-{{ (index .Values.clickhouse.clickhouse.configmap.users.user 0).name }}
-  {{- else -}}
-default
-  {{- end -}}
-{{- else -}}
 {{ required "A valid .Values.externalClickhouse.username is required" .Values.externalClickhouse.username }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse Password
 */}}
 {{- define "sentry.clickhouse.password" -}}
-{{- if .Values.clickhouse.enabled -}}
-  {{- if .Values.clickhouse.clickhouse.configmap.users.enabled -}}
-{{ (index .Values.clickhouse.clickhouse.configmap.users.user 0).config.password }}
-  {{- else -}}
-  {{- end -}}
-{{- else -}}
 {{ .Values.externalClickhouse.password }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse cluster name
 */}}
 {{- define "sentry.clickhouse.cluster.name" -}}
-{{- if .Values.clickhouse.enabled -}}
-{{ .Release.Name | printf "%s-clickhouse" }}
-{{- else -}}
 {{ required "A valid .Values.externalClickhouse.clusterName is required" .Values.externalClickhouse.clusterName }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse distributed cluster name
 */}}
 {{- define "sentry.clickhouse.distributed.cluster.name" -}}
-{{- if .Values.clickhouse.enabled -}}
-{{ .Release.Name | printf "%s-clickhouse" }}
-{{- else -}}
 {{ default .Values.externalClickhouse.clusterName .Values.externalClickhouse.distributedClusterName }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Set ClickHouse secure setting
 */}}
 {{- define "sentry.clickhouse.secure" -}}
-{{- if and (.Values.externalClickhouse.enabled) (.Values.externalClickhouse.secure) -}}
+{{- if .Values.externalClickhouse.secure -}}
 True
 {{- end -}}
 {{- end -}}
@@ -469,7 +426,7 @@ True
 Set ClickHouse ca_certs setting
 */}}
 {{- define "sentry.clickhouse.ca_certs" -}}
-{{- if and (.Values.externalClickhouse.enabled) (.Values.externalClickhouse.ca_certs) -}}
+{{- if .Values.externalClickhouse.ca_certs -}}
 {{ .Values.externalClickhouse.ca_certs }}
 {{- end -}}
 {{- end -}}
@@ -478,7 +435,7 @@ Set ClickHouse ca_certs setting
 Set ClickHouse verify ca setting
 */}}
 {{- define "sentry.clickhouse.verify" -}}
-{{- if and (.Values.externalClickhouse.enabled) (.Values.externalClickhouse.verify) -}}
+{{- if .Values.externalClickhouse.verify -}}
 True
 {{- end -}}
 {{- end -}}

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -87,26 +87,11 @@ spec:
             CLICKHOUSE_STATUS=0
             while [ $CLICKHOUSE_STATUS -eq 0 ]; do
               CLICKHOUSE_STATUS=1
-              CLICKHOUSE_REPLICAS={{ .Values.clickhouse.enabled | ternary .Values.clickhouse.clickhouse.replicas "1" }}
-              i=0; while [ $i -lt $CLICKHOUSE_REPLICAS ]; do
-                {{- if .Values.clickhouse.enabled }}
-                CLICKHOUSE_HOST={{ $clickhouseHost }}-$i.{{ $clickhouseHost }}-headless
-                {{- else }}
-                CLICKHOUSE_HOST={{ .Values.externalClickhouse.host }}
-                {{- end }}
-                if ! nc -z "$CLICKHOUSE_HOST" {{ $clickhousePort }}; then
-                  CLICKHOUSE_STATUS=0
-                  echo "$CLICKHOUSE_HOST is not available yet"
-                fi
-                {{- if and .Values.clickhouse.enabled .Values.clickhouse.clickhouse.configmap.remote_servers.replica.backup.enabled }}
-                CLICKHOUSE_HOST={{ $clickhouseHost }}-replica-$i.{{ $clickhouseHost }}-replica-headless
-                if ! nc -z "$CLICKHOUSE_HOST" {{ $clickhousePort }}; then
-                  CLICKHOUSE_STATUS=0
-                  echo "$CLICKHOUSE_HOST is not available yet"
-                fi
-                {{- end }}
-                i=$((i+1))
-              done
+              CLICKHOUSE_HOST={{ $clickhouseHost }}
+              if ! nc -z "$CLICKHOUSE_HOST" {{ $clickhousePort }}; then
+                CLICKHOUSE_STATUS=0
+                echo "$CLICKHOUSE_HOST is not available yet"
+              fi
               if [ "$CLICKHOUSE_STATUS" -eq 0 ]; then
                 echo "Clickhouse not ready. Sleeping for 10s before trying again"
                 sleep 10;

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -71,15 +71,13 @@ settings.py: |
           "profile_chunks",
       },
       {{- /*
-        The default clickhouse installation runs in distributed mode, while the external
-        clickhouse configured can be configured any way you choose
+        External ClickHouse can be single-node or clustered. When singleNode is
+        enabled, omit cluster settings.
       */}}
-      {{- if and .Values.externalClickhouse.singleNode (not .Values.clickhouse.enabled) }}
+      {{- if .Values.externalClickhouse.singleNode }}
       "single_node": True,
       {{- else }}
       "single_node": False,
-      {{- end }}
-      {{- if or .Values.clickhouse.enabled (not .Values.externalClickhouse.singleNode) }}
       "cluster_name": {{ include "sentry.clickhouse.cluster.name" . | quote }},
       "distributed_cluster_name": {{ include "sentry.clickhouse.distributed.cluster.name" . | quote }},
       {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2618,54 +2618,8 @@ config:
     ignoreWriteErrors: true
     disableWriteException: true
 
-clickhouse:
-  enabled: true
-  nodeSelector: {}
-  tolerations: []
-  clickhouse:
-    replicas: "1"
-    configmap:
-      remote_servers:
-        internal_replication: true
-        replica:
-          backup:
-            enabled: false
-      zookeeper_servers:
-        enabled: true
-        config:
-          - index: "clickhouse"
-            hostTemplate: "{{ .Release.Name }}-zookeeper-clickhouse"
-            port: "2181"
-      users:
-        enabled: false
-        user:
-          # the first user will be used if enabled
-          - name: default
-            config:
-              password: ""
-              networks:
-                - ::/0
-              profile: default
-              quota: default
-
-    persistentVolumeClaim:
-      enabled: true
-      dataPersistentVolume:
-        enabled: true
-        accessModes:
-          - "ReadWriteOnce"
-        storage: "30Gi"
-
-  ## Use this to enable an extra service account
-  # serviceAccount:
-  #   annotations: {}
-  #   enabled: false
-  #   name: "sentry-clickhouse"
-  #   automountServiceAccountToken: true
-
-## This value is only used when clickhouse.enabled is set to false
-##
 externalClickhouse:
+  ## External ClickHouse configuration (required).
   ## Hostname or ip address of external clickhouse
   ##
   host: "clickhouse"
@@ -2687,20 +2641,6 @@ externalClickhouse:
   ## Use this when your ClickHouse distributed queries need a different cluster name
   ##
   # distributedClusterName: distributed_test_shard_localhost
-
-# Settings for Zookeeper.
-# See https://github.com/bitnami/charts/tree/master/bitnami/zookeeper
-zookeeper:
-  enabled: true
-  image:
-    repository: bitnamilegacy/zookeeper
-  nameOverride: zookeeper-clickhouse
-  replicaCount: 1
-  nodeSelector: {}
-  tolerations: []
-  ## When increasing the number of exceptions, you need to increase persistence.size
-  # persistence:
-  #   size: 8Gi
 
 # Settings for Kafka.
 # See https://github.com/bitnami/charts/tree/master/bitnami/kafka


### PR DESCRIPTION
For cleanup reasons + not removing it completely led to some confusion.

Examples:

- https://github.com/sentry-kubernetes/charts/pull/2013
- https://github.com/sentry-kubernetes/charts/issues/2024
- https://github.com/sentry-kubernetes/charts/issues/2002

---

Again, to avoid multiple major releases, should be bundled with https://github.com/sentry-kubernetes/charts/pull/2012