### PR TITLE
feat: align defaults to sentry self hosted repo

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -652,7 +652,7 @@ sentry:
     # noStrictOffsetReset: false
 
   ingestFeedback:
-    enabled: false
+    enabled: true
     replicas: 1
     env: []
     resources: {}
@@ -721,7 +721,7 @@ sentry:
     # noStrictOffsetReset: false
 
   monitorsClockTasks:
-    enabled: false
+    enabled: true
     replicas: 1
     env: []
     resources: {}
@@ -752,7 +752,7 @@ sentry:
     # noStrictOffsetReset: false
 
   monitorsClockTick:
-    enabled: false
+    enabled: true
     replicas: 1
     env: []
     resources: {}


### PR DESCRIPTION
I've noticed that those three services were disabled by default. This is neither aligned with the sentry self-hoster repo nor with the practice for other services in this chart.

https://github.com/getsentry/self-hosted/blob/master/docker-compose.yml