### PR TITLE
fix: relay rename topic events/attachments

### DIFF
--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -98,7 +98,8 @@ config.yml: |-
     {{- if ((.Values.kafkaTopicOverrides).prefix) }}
     topics:
       metrics_sessions: "{{ default "" .Values.kafkaTopicOverrides.prefix }}ingest-metrics"
-      events: "{{ default "" .Values.kafkaTopicOverrides.prefix }}ingest-attachments"
+      attachments: "{{ default "" .Values.kafkaTopicOverrides.prefix }}ingest-attachments"
+      events: "{{ default "" .Values.kafkaTopicOverrides.prefix }}ingest-events"
       transactions: "{{ default "" .Values.kafkaTopicOverrides.prefix }}ingest-transactions"
       outcomes: "{{ default "" .Values.kafkaTopicOverrides.prefix }}outcomes"
       outcomes_billing: "{{ default "" .Values.kafkaTopicOverrides.prefix }}ingest-outcomes"


### PR DESCRIPTION
see https://github.com/getsentry/relay/blame/master/relay-kafka/src/config.rs#L134-L135