### PR TITLE
feat: optional separate replay storage

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1311,6 +1311,119 @@ sourcemaps:
 
 For details on the background see this blog post: https://engblog.yext.com/post/sentry-js-source-maps
 
+## External storage (filestore, replays, profiles)
+
+Sentry can offload blobs to filesystem or bucket storage. See the Sentry docs for details and backend-specific caveats:
+https://develop.sentry.dev/self-hosted/production-enhancements/external-storage/
+
+### Filestore (attachments, sourcemaps, and default replays)
+
+Set `filestore.backend` to one of `filesystem`, `s3`, or `gcs`:
+
+```yaml
+filestore:
+  backend: gcs
+  gcs:
+    bucketName: sentry-filestore
+    secretName: sentry-gcs
+    credentialsFile: credentials.json
+```
+
+### Replays storage (optional separate backend)
+
+By default, replays use the main filestore. To store replays separately, set `replay.storage.backend` to `filesystem`, `s3`, or `gcs`.
+
+Filesystem example (keep the path inside a mounted volume or add your own volume mounts):
+
+```yaml
+replay:
+  storage:
+    backend: filesystem
+    filesystem:
+      path: /var/lib/sentry/files/replays
+```
+
+Filesystem with a separate PVC (different from filestore):
+
+```yaml
+replay:
+  storage:
+    backend: filesystem
+    filesystem:
+      path: /var/lib/sentry/replays
+      persistence:
+        enabled: true
+        size: 20Gi
+```
+
+S3 example:
+
+```yaml
+replay:
+  storage:
+    backend: s3
+    s3:
+      bucketName: sentry-replays
+      endpointUrl: https://s3.example.com
+      region_name: auto
+      signature_version: s3v4
+      default_acl: private
+      bucket_acl: private
+```
+
+GCS example:
+
+```yaml
+replay:
+  storage:
+    backend: gcs
+    gcs:
+      bucketName: sentry-replays
+      secretName: sentry-gcs
+      credentialsFile: credentials.json
+```
+
+When using GCS for both filestore and replays, `replay.storage.gcs.secretName` and
+`replay.storage.gcs.credentialsFile` must match `filestore.gcs.*`.
+
+### Profiles storage (vroom)
+
+Profiling uses `filestore.profiles`. Supported backends are `filesystem` and `s3` (S3-compatible is recommended for production).
+
+### Retention and lifecycle policies
+
+- For S3 or GCS, all buckets except the **main filestore** should have a lifecycle policy to delete objects after your retention period (match `sentry.cleanup.days` / `SENTRY_EVENT_RETENTION_DAYS`).
+- For the main filestore bucket, you may configure a lifecycle rule to delete objects under `eventattachments/` after retention; other filestore paths should remain indefinitely.
+
+## Nodestore (raw events)
+
+Sentry stores raw event payloads in the nodestore. This chart supports an S3-compatible nodestore backend.
+When enabled, the `sentry-nodestore-s3` package is installed automatically via init containers.
+
+Example:
+
+```yaml
+nodestore:
+  backend: s3
+  s3:
+    bucketName: sentry-nodestore
+    bucketPath: nodestore
+    endpointUrl: https://s3.example.com
+    regionName: us-east-1
+```
+
+You can also supply credentials via an existing secret:
+
+```yaml
+nodestore:
+  backend: s3
+  s3:
+    existingSecret: nodestore-s3-credentials
+    accessKeyIdRef: s3-access-key-id
+    secretAccessKeyRef: s3-secret-access-key
+    bucketName: sentry-nodestore
+```
+
 
 ## Geolocation
 

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -814,6 +814,22 @@ Set S3
 {{- end }}
 
 {{/*
+Set Replay S3
+*/}}
+{{- if and (eq .Values.replay.storage.backend "s3") .Values.replay.storage.s3.existingSecret }}
+- name: REPLAY_S3_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.replay.storage.s3.existingSecret }}
+      key: {{ default "s3-access-key-id" .Values.replay.storage.s3.accessKeyIdRef }}
+- name: REPLAY_S3_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.replay.storage.s3.existingSecret }}
+      key: {{ default "s3-secret-access-key" .Values.replay.storage.s3.secretAccessKeyRef }}
+{{- end }}
+
+{{/*
 Set Profiles S3
 */}}
 {{- if and (eq .Values.filestore.profiles.backend "s3") (.Values.filestore.profiles.s3) (.Values.filestore.profiles.s3.existingSecret) }}
@@ -892,9 +908,11 @@ Set redis password
 {{/*
 Set google application
 */}}
-{{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{- $gcsSecretName := include "sentry.gcs.secretName" . -}}
+{{- $gcsCredentialsFile := include "sentry.gcs.credentialsFile" . -}}
+{{- if and $gcsSecretName $gcsCredentialsFile }}
 - name: GOOGLE_APPLICATION_CREDENTIALS
-  value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+  value: /var/run/secrets/google/{{ $gcsCredentialsFile }}
 {{- end }}
 
 {{/*
@@ -1095,6 +1113,35 @@ Pgbouncer environment variables
 - name: POSTGRESQL_USERNAME
   value: {{ include "sentry.postgresql.username" . | quote }}
 {{- end }}
+{{- end -}}
+
+{{/*
+GCS settings for filestore/replay storage.
+*/}}
+{{- define "sentry.gcs.secretName" -}}
+{{- $filestoreSecret := default "" .Values.filestore.gcs.secretName -}}
+{{- $replaySecret := default "" .Values.replay.storage.gcs.secretName -}}
+{{- if and (eq .Values.filestore.backend "gcs") (eq .Values.replay.storage.backend "gcs") $filestoreSecret $replaySecret (ne $filestoreSecret $replaySecret) -}}
+{{- fail "When using GCS for both filestore and replays, filestore.gcs.secretName and replay.storage.gcs.secretName must match." -}}
+{{- end -}}
+{{- if and (eq .Values.replay.storage.backend "gcs") .Values.replay.storage.gcs.secretName -}}
+{{- .Values.replay.storage.gcs.secretName -}}
+{{- else if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName -}}
+{{- .Values.filestore.gcs.secretName -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sentry.gcs.credentialsFile" -}}
+{{- $filestoreCredentialsFile := default "" .Values.filestore.gcs.credentialsFile -}}
+{{- $replayCredentialsFile := default "" .Values.replay.storage.gcs.credentialsFile -}}
+{{- if and (eq .Values.filestore.backend "gcs") (eq .Values.replay.storage.backend "gcs") $filestoreCredentialsFile $replayCredentialsFile (ne $filestoreCredentialsFile $replayCredentialsFile) -}}
+{{- fail "When using GCS for both filestore and replays, filestore.gcs.credentialsFile and replay.storage.gcs.credentialsFile must match." -}}
+{{- end -}}
+{{- if and (eq .Values.replay.storage.backend "gcs") .Values.replay.storage.gcs.credentialsFile -}}
+{{- .Values.replay.storage.gcs.credentialsFile -}}
+{{- else if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.credentialsFile -}}
+{{- .Values.filestore.gcs.credentialsFile -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/sentry/templates/pvc.yaml
+++ b/charts/sentry/templates/pvc.yaml
@@ -25,5 +25,34 @@ spec:
   storageClassName: "{{ .Values.filestore.filesystem.persistence.storageClass }}"
 {{- end }}
 {{- end }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
+
+{{ if and (eq .Values.replay.storage.backend "filesystem") .Values.replay.storage.filesystem.persistence.enabled (not .Values.replay.storage.filesystem.persistence.existingClaim) }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "sentry.fullname" . }}-replay-data
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.replay.storage.filesystem.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.replay.storage.filesystem.persistence.size | quote }}
+{{- if and (.Values.replay.storage.filesystem.persistence.lookupVolumeName) (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-replay-data" (include "sentry.fullname" .))) }}
+  volumeName: {{ (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-replay-data" (include "sentry.fullname" .))).spec.volumeName }}
+{{- end }}
+{{- if .Values.replay.storage.filesystem.persistence.storageClass }}
+{{- if (eq "-" .Values.replay.storage.filesystem.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.replay.storage.filesystem.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{ end }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -549,6 +549,57 @@ sentry.conf.py: |-
   }
   {{- end }}
 
+  ##################
+  # Replay Storage #
+  ##################
+  {{- if .Values.replay.storage.backend }}
+  SENTRY_OPTIONS['replay.storage.backend'] = {{ .Values.replay.storage.backend | quote }}
+
+  {{- if eq .Values.replay.storage.backend "filesystem" }}
+  SENTRY_OPTIONS['replay.storage.options'] = {
+      'location': {{ .Values.replay.storage.filesystem.path | quote }},
+  }
+  {{- end }}
+
+  {{- if eq .Values.replay.storage.backend "gcs" }}
+  SENTRY_OPTIONS['replay.storage.options'] = {
+      'bucket_name': {{ .Values.replay.storage.gcs.bucketName | quote }},
+  }
+  {{- end }}
+
+  {{- if eq .Values.replay.storage.backend "s3" }}
+  {{- $replayS3 := .Values.replay.storage.s3 | default dict }}
+  SENTRY_OPTIONS['replay.storage.options'] = {
+      'access_key': os.getenv("REPLAY_S3_ACCESS_KEY_ID", {{ $replayS3.accessKey | default "" | quote }}),
+      'secret_key': os.getenv("REPLAY_S3_SECRET_ACCESS_KEY", {{ $replayS3.secretKey | default "" | quote }}),
+      {{- if $replayS3.bucketName }}
+      'bucket_name': {{ $replayS3.bucketName | quote }},
+      {{- end }}
+      {{- if $replayS3.endpointUrl }}
+      'endpoint_url': {{ $replayS3.endpointUrl | quote }},
+      {{- end }}
+      {{- if $replayS3.signature_version }}
+      'signature_version': {{ $replayS3.signature_version | quote }},
+      {{- end }}
+      {{- if $replayS3.region_name }}
+      'region_name': {{ $replayS3.region_name | quote }},
+      {{- end }}
+      {{- if $replayS3.default_acl }}
+      'default_acl': {{ $replayS3.default_acl | quote }},
+      {{- end }}
+      {{- if $replayS3.bucket_acl }}
+      'bucket_acl': {{ $replayS3.bucket_acl | quote }},
+      {{- end }}
+      {{- if $replayS3.addressing_style }}
+      'addressing_style': {{ $replayS3.addressing_style | quote }},
+      {{- end }}
+      {{- if $replayS3.location }}
+      'location': {{ $replayS3.location | quote }},
+      {{- end }}
+  }
+  {{- end }}
+  {{- end }}
+
   ###################
   # Profiling Store #
   ###################
@@ -763,6 +814,32 @@ Volume mount for sentry plugins
 {{- if .Values.nodestore.backend }}
 - name: sentry-plugins
   mountPath: /sentry-plugins
+{{- end }}
+{{- end -}}
+
+{{/*
+Volume definition for replay filesystem storage
+*/}}
+{{- define "sentry.volume.replay-filesystem" -}}
+{{- if and (eq .Values.replay.storage.backend "filesystem") .Values.replay.storage.filesystem.persistence.enabled }}
+- name: sentry-replay-data
+  {{- if .Values.replay.storage.filesystem.persistence.existingClaim }}
+  persistentVolumeClaim:
+    claimName: {{ .Values.replay.storage.filesystem.persistence.existingClaim }}
+  {{- else }}
+  persistentVolumeClaim:
+    claimName: {{ template "sentry.fullname" . }}-replay-data
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Volume mount for replay filesystem storage
+*/}}
+{{- define "sentry.volumeMount.replay-filesystem" -}}
+{{- if and (eq .Values.replay.storage.backend "filesystem") .Values.replay.storage.filesystem.persistence.enabled }}
+- name: sentry-replay-data
+  mountPath: {{ .Values.replay.storage.filesystem.path }}
 {{- end }}
 {{- end -}}
 

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -102,7 +102,7 @@ spec:
   {{ include "sentry.volumeMount.nodestore-s3" . | indent 12 }}
             - mountPath: {{ .Values.filestore.filesystem.path }}
               name: sentry-data
-            {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+            {{- if include "sentry.gcs.secretName" . }}
             - name: sentry-google-cloud-key
               mountPath: /var/run/secrets/google
             {{ end }}
@@ -139,10 +139,10 @@ spec:
           {{- else }}
             emptyDir: {}
           {{ end }}
-          {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+          {{- if include "sentry.gcs.secretName" . }}
           - name: sentry-google-cloud-key
             secret:
-              secretName: {{ .Values.filestore.gcs.secretName }}
+              secretName: {{ include "sentry.gcs.secretName" . }}
           {{ end }}
 {{- if .Values.sentry.cleanup.volumes }}
 {{ toYaml .Values.sentry.cleanup.volumes | indent 10 }}

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -150,8 +150,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -190,10 +191,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestConsumerAttachments.volumes }}
 {{ toYaml .Values.sentry.ingestConsumerAttachments.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -150,8 +150,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -190,10 +191,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestConsumerEvents.volumes }}
 {{ toYaml .Values.sentry.ingestConsumerEvents.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -130,8 +130,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -170,10 +171,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestFeedback.volumes }}
 {{ toYaml .Values.sentry.ingestFeedback.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -135,8 +135,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -175,10 +176,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestMonitors.volumes }}
 {{ toYaml .Values.sentry.ingestMonitors.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -129,8 +129,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -169,10 +170,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.monitorsClockTasks.volumes }}
 {{ toYaml .Values.sentry.monitorsClockTasks.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -129,8 +129,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -169,10 +170,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.monitorsClockTick.volumes }}
 {{ toYaml .Values.sentry.monitorsClockTick.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -130,8 +130,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -170,10 +171,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestOccurrences.volumes }}
 {{ toYaml .Values.sentry.ingestOccurrences.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -130,12 +130,13 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
         {{- if eq .Values.filestore.profiles.backend "filesystem" }}
         - mountPath: {{ .Values.filestore.profiles.filesystem.path }}
           name: profiles-data
         {{- end }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -174,6 +175,7 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
       {{- if eq .Values.filestore.profiles.backend "filesystem" }}
       - name: profiles-data
         {{- if .Values.filestore.profiles.filesystem.persistence.enabled }}
@@ -189,10 +191,10 @@ spec:
         emptyDir: {}
         {{- end }}
       {{- end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestProfiles.volumes }}
 {{ toYaml .Values.sentry.ingestProfiles.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -135,8 +135,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -175,10 +176,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestReplayRecordings.volumes }}
 {{ toYaml .Values.sentry.ingestReplayRecordings.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -151,8 +151,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -191,10 +192,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.ingestConsumerTransactions.volumes }}
 {{ toYaml .Values.sentry.ingestConsumerTransactions.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -131,8 +131,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -171,10 +172,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.billingMetricsConsumer.volumes }}
 {{ toYaml .Values.sentry.billingMetricsConsumer.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -141,8 +141,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -181,10 +182,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.metricsConsumer.volumes }}
 {{ toYaml .Values.sentry.metricsConsumer.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -141,8 +141,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -181,10 +182,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.genericMetricsConsumer.volumes }}
 {{ toYaml .Values.sentry.genericMetricsConsumer.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -127,8 +127,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -167,10 +168,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.postProcessForwardErrors.volumes }}
 {{ toYaml .Values.sentry.postProcessForwardErrors.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -129,8 +129,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -172,10 +173,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.postProcessForwardIssuePlatform.volumes }}
 {{ toYaml .Values.sentry.postProcessForwardIssuePlatform.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -136,8 +136,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -176,10 +177,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.postProcessForwardTransactions.volumes }}
 {{ toYaml .Values.sentry.postProcessForwardTransactions.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -126,8 +126,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -166,10 +167,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.processSegments.volumes }}
 {{ toYaml .Values.sentry.processSegments.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -126,8 +126,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -166,10 +167,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.processSpans.volumes }}
 {{ toYaml .Values.sentry.processSpans.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -118,8 +118,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -158,10 +159,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.subscriptionConsumerEvents.volumes }}
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -137,8 +137,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -177,10 +178,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.subscriptionConsumerGenericMetrics.volumes }}
 {{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -137,8 +137,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -177,10 +178,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.subscriptionConsumerMetrics.volumes }}
 {{ toYaml .Values.sentry.subscriptionConsumerMetrics.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -118,8 +118,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -158,10 +159,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.subscriptionConsumerResultsEapItems.volumes }}
 {{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -119,8 +119,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -159,10 +160,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.subscriptionConsumerTransactions.volumes }}
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
@@ -99,13 +99,14 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
         {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
           readOnly: true
         {{- end }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -135,10 +136,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -118,13 +118,14 @@ spec:
           readOnly: true
         - mountPath: {{ $root.Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" $root | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" $root | indent 8 }}
         {{- if and $root.Values.geodata.volumeName $root.Values.geodata.accountID }}
         - name: {{ $root.Values.geodata.volumeName }}
           mountPath: {{ $root.Values.geodata.mountPath }}
           readOnly: true
         {{- end }}
-        {{- if and (eq $root.Values.filestore.backend "gcs") $root.Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" $root }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -162,10 +163,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq $root.Values.filestore.backend "gcs") $root.Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" $root | indent 6 }}
+      {{- if include "sentry.gcs.secretName" $root }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ $root.Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" $root }}
       {{ end }}
       {{- if and $root.Values.geodata.volumeName $root.Values.geodata.accountID }}
       - name: {{ $root.Values.geodata.volumeName }}

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -126,8 +126,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -166,10 +167,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.sentry.uptimeResults.volumes }}
 {{ toYaml .Values.sentry.uptimeResults.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -123,13 +123,14 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.filestore.filesystem.path }}
           name: sentry-data
+{{ include "sentry.volumeMount.replay-filesystem" . | indent 8 }}
 {{ include "sentry.volumeMount.nodestore-s3" . | indent 8 }}
         {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
         - name: {{ .Values.geodata.volumeName }}
           mountPath: {{ .Values.geodata.mountPath }}
           readOnly: true
         {{- end }}
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -192,10 +193,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+{{ include "sentry.volume.replay-filesystem" . | indent 6 }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
       {{- if .Values.sentry.web.customCA }}
       - name: custom-ca

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -81,9 +81,9 @@ spec:
         ports:
         - containerPort: {{ template "symbolicator.port" }}
         env:
-        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{ if include "sentry.gcs.secretName" . }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+          value: /var/run/secrets/google/{{ include "sentry.gcs.credentialsFile" . }}
         {{ end }}
 {{- if .Values.symbolicator.api.env }}
 {{ toYaml .Values.symbolicator.api.env | indent 8 }}
@@ -94,7 +94,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: symbolicator-data
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -138,9 +138,9 @@ spec:
           - --repeat
           - {{ .Values.symbolicator.api.cleaner.repeat }}
         env:
-        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{ if include "sentry.gcs.secretName" . }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+          value: /var/run/secrets/google/{{ include "sentry.gcs.credentialsFile" . }}
         {{ end }}
         volumeMounts:
         - mountPath: /etc/symbolicator
@@ -148,7 +148,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: symbolicator-data
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -178,10 +178,10 @@ spec:
       - name: symbolicator-data
         emptyDir: {}
       {{- end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.symbolicator.api.volumes }}
 {{ toYaml .Values.symbolicator.api.volumes | indent 6 }}

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -82,9 +82,9 @@ spec:
         ports:
         - containerPort: {{ template "symbolicator.port" }}
         env:
-        {{ if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{ if include "sentry.gcs.secretName" . }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
+          value: /var/run/secrets/google/{{ include "sentry.gcs.credentialsFile" . }}
         {{ end }}
 {{- if .Values.symbolicator.api.env }}
 {{ toYaml .Values.symbolicator.api.env | indent 8 }}
@@ -95,7 +95,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: symbolicator-data
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -144,7 +144,7 @@ spec:
           readOnly: true
         - mountPath: /data
           name: symbolicator-data
-        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        {{- if include "sentry.gcs.secretName" . }}
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
@@ -160,10 +160,10 @@ spec:
       - name: symbolicator-data
         emptyDir: {}
       {{- end }}
-      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      {{- if include "sentry.gcs.secretName" . }}
       - name: sentry-google-cloud-key
         secret:
-          secretName: {{ .Values.filestore.gcs.secretName }}
+          secretName: {{ include "sentry.gcs.secretName" . }}
       {{ end }}
 {{- if .Values.symbolicator.api.volumes }}
 {{ toYaml .Values.symbolicator.api.volumes | indent 6 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2591,23 +2591,6 @@ replay:
     #  addressing_style:
     #  location:
 
-# Cronjob for filesystem cleanup when using backend filesystem
-cleanerfs:
-  enabled: false
-  successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 5
-  activeDeadlineSeconds: 900
-  concurrencyPolicy: Allow
-  schedule: "0 1 * * *"
-  days: 90
-# securityContext: {}
-# containerSecurityContext: {}
-  annotations: {}
-# podLabels: {}
-# affinity: {}
-# nodeSelector: {}
-# tolerations: {}
-
 ## Node Storage configuration
 ## Sentry uses an abstraction layer called "node storage" to store raw events.
 ## Previously, it used PostgreSQL as the backend, but this didn't scale for
@@ -2643,6 +2626,24 @@ nodestore:
     # regionName: "us-east-1"
     # If you are using S3 provider other than AWS, and seeing SignatureDoesNotMatch errors enable this
     # setAwsChecksumCalculationVar: false
+
+# Cronjob for filesystem cleanup when using backend filesystem
+# WARNING: Use with caution as some files in the default filestore should never be deleted after the retention period
+cleanerfs:
+  enabled: false
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  activeDeadlineSeconds: 900
+  concurrencyPolicy: Allow
+  schedule: "0 1 * * *"
+  days: 90
+# securityContext: {}
+# containerSecurityContext: {}
+  annotations: {}
+# podLabels: {}
+# affinity: {}
+# nodeSelector: {}
+# tolerations: {}
 
 config:
   # No YAML Extension Config Given

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2552,6 +2552,45 @@ filestore:
         ## the current value of 'spec.volumeName' and incorporate it into the template.
         lookupVolumeName: true
 
+replay:
+  storage:
+    # Leave empty to use the main filestore.
+    # Set to one of filesystem, gcs or s3 to use a separate backend for replays.
+    backend: ""
+    filesystem:
+      path: /var/lib/sentry/files/replays
+      ## Use a separate PVC for replays (optional).
+      ## When disabled, replays are stored on the container filesystem,
+      ## or on the main filestore PVC if the path is under filestore.filesystem.path.
+      persistence:
+        enabled: false
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        existingClaim: ""
+        lookupVolumeName: true
+        # storageClass: "-"
+    gcs: {}
+      ## Point this at a pre-configured secret containing a service account. The resulting
+      ## secret will be mounted at /var/run/secrets/google
+      ## When using GCS for both filestore and replays, this must match filestore.gcs.*
+      # secretName:
+      # credentialsFile: credentials.json
+    # bucketName:
+    s3: {}
+    #  existingSecret:
+    #  accessKeyIdRef:
+    #  secretAccessKeyRef:
+    #  accessKey:
+    #  secretKey:
+    #  bucketName:
+    #  endpointUrl:
+    #  signature_version:
+    #  region_name:
+    #  default_acl:
+    #  bucket_acl:
+    #  addressing_style:
+    #  location:
+
 # Cronjob for filesystem cleanup when using backend filesystem
 cleanerfs:
   enabled: false


### PR DESCRIPTION
After having a discussion [here](https://github.com/sentry-kubernetes/charts/pull/2037) and a conversation with @aldy505 (big thanks for your input!), I've decided to add support for optional replays storage and added documentation on different storage options available in this chart.