### PR TITLE
fix(nginx): set correct name for nginx conf

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1151,3 +1151,5 @@ Gateway API v1 is GA since Kubernetes 1.29.
 {{- print "gateway.networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "nginx.configName" -}}{{ template "sentry.fullname" . }}-nginx{{- end -}}

--- a/charts/sentry/templates/routing/nginx-config.yaml
+++ b/charts/sentry/templates/routing/nginx-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sentry.fullname" . }}-nginx
+  name: {{ include "nginx.configName" . }}
   labels:
     {{- include "sentry.component.labels" (dict "component" "nginx" "ctx" .) | nindent 4 }}
 data:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2424,7 +2424,7 @@ route:
 # For other configuration options see: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/nginx
 nginx:
   enabled: false
-  existingServerConfigConfigmap: '{{ template "sentry.fullname" . }}'
+  existingServerConfigConfigmap: '{{ include "nginx.configName" . }}'
   extraLocationSnippet: false
   # extraLocationSnippet: |
   #  location /admin {


### PR DESCRIPTION
The name of configmap and name specified in values for new nginx subchart were different. This PR fixes this by adding new template that is included in the configmap name and in nginx values ​​for the `nginx.existingServerConfigConfigmap`