### PR TITLE
fix: add missing dnsPolicy to deployments

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 29.2.0
+version: 29.2.1
 # renovate image=ghcr.io/getsentry/sentry
 appVersion: 26.1.0
 dependencies:

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 29.2.1
+version: 29.2.0
 # renovate image=ghcr.io/getsentry/sentry
 appVersion: 26.1.0
 dependencies:

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -50,6 +50,13 @@ spec:
       nodeSelector:
 {{ toYaml $root.Values.global.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if $root.Values.sentry.taskBroker.tolerations }}
       tolerations:
 {{ toYaml $root.Values.sentry.taskBroker.tolerations | indent 8 }}

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -33,7 +33,7 @@ spec:
         checksum/config.yaml: {{ include "sentry.config" $root | sha256sum }}
       {{- if $root.Values.sentry.taskBroker.annotations }}
 {{ toYaml $root.Values.sentry.taskBroker.annotations | indent 8 }}
-      {{- end }}          
+      {{- end }}
     spec:
       {{- if $root.Values.images.taskbroker.imagePullSecrets }}
       imagePullSecrets:
@@ -49,6 +49,13 @@ spec:
       {{- else if $root.Values.global.nodeSelector }}
       nodeSelector:
 {{ toYaml $root.Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if $root.Values.dnsPolicy }}
+      dnsPolicy: {{ $root.Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if $root.Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml $root.Values.dnsConfig | indent 8 }}
       {{- end }}
       {{- if $root.Values.sentry.taskBroker.tolerations }}
       tolerations:
@@ -122,13 +129,6 @@ spec:
       {{- end }}
 {{- if $root.Values.sentry.taskBroker.volumes }}
 {{ toYaml $root.Values.sentry.taskBroker.volumes | indent 6 }}
-{{- end }}
-{{- if .Values.dnsPolicy }}
-dnsPolicy: {{ .Values.dnsPolicy | quote }}
-{{- end }}
-{{- if .Values.dnsConfig }}
-dnsConfig:
-{{ toYaml .Values.dnsConfig | indent 8 }}
 {{- end }}
 {{- if $root.Values.global.volumes }}
 {{ toYaml $root.Values.global.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -50,13 +50,6 @@ spec:
       nodeSelector:
 {{ toYaml $root.Values.global.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy | quote }}
-      {{- end }}
-      {{- if .Values.dnsConfig }}
-      dnsConfig:
-{{ toYaml .Values.dnsConfig | indent 8 }}
-      {{- end }}
       {{- if $root.Values.sentry.taskBroker.tolerations }}
       tolerations:
 {{ toYaml $root.Values.sentry.taskBroker.tolerations | indent 8 }}
@@ -129,6 +122,13 @@ spec:
       {{- end }}
 {{- if $root.Values.sentry.taskBroker.volumes }}
 {{ toYaml $root.Values.sentry.taskBroker.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.dnsPolicy }}
+dnsPolicy: {{ .Values.dnsPolicy | quote }}
+{{- end }}
+{{- if .Values.dnsConfig }}
+dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
 {{- end }}
 {{- if $root.Values.global.volumes }}
 {{ toYaml $root.Values.global.volumes | indent 6 }}

--- a/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
@@ -48,6 +48,13 @@ spec:
       nodeSelector:
 {{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.sentry.taskScheduler.tolerations }}
       tolerations:
 {{ toYaml .Values.sentry.taskScheduler.tolerations | indent 8 }}

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -81,17 +81,9 @@ spec:
       {{- if $root.Values.serviceAccount.enabled }}
       serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskworker
       {{- end }}
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy | quote }}
-      {{- end }}
-      {{- if .Values.dnsConfig }}
-      dnsConfig:
-      {{ toYaml .Values.dnsConfig | indent 8 }}
-      {{- else }}
       dnsConfig:
         searches:
           - {{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}.{{ $root.Release.Namespace }}.svc.cluster.local
-      {{- end }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" $root | indent 6 }}
       containers:

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -67,6 +67,13 @@ spec:
       tolerations:
 {{ toYaml $root.Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if $root.Values.sentry.taskWorker.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml $root.Values.sentry.taskWorker.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -67,13 +67,6 @@ spec:
       tolerations:
 {{ toYaml $root.Values.global.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy | quote }}
-      {{- end }}
-      {{- if .Values.dnsConfig }}
-      dnsConfig:
-{{ toYaml .Values.dnsConfig | indent 8 }}
-      {{- end }}
       {{- if $root.Values.sentry.taskWorker.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml $root.Values.sentry.taskWorker.topologySpreadConstraints | indent 8 }}
@@ -88,9 +81,17 @@ spec:
       {{- if $root.Values.serviceAccount.enabled }}
       serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskworker
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+      {{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- else }}
       dnsConfig:
         searches:
           - {{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}.{{ $root.Release.Namespace }}.svc.cluster.local
+      {{- end }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" $root | indent 6 }}
       containers:

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -81,9 +81,17 @@ spec:
       {{- if $root.Values.serviceAccount.enabled }}
       serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskworker
       {{- end }}
+      {{- if $root.Values.dnsPolicy }}
+      dnsPolicy: {{ $root.Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if $root.Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml $root.Values.dnsConfig | indent 8 }}
+      {{- else }}
       dnsConfig:
         searches:
           - {{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}.{{ $root.Release.Namespace }}.svc.cluster.local
+      {{- end }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" $root | indent 6 }}
       containers:

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -91,6 +91,7 @@ spec:
       dnsConfig:
         searches:
           - {{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}.{{ $root.Release.Namespace }}.svc.{{ $root.Values.global.clusterDomain | default "cluster.local" }}
+      {{- end }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" $root | indent 6 }}
       containers:

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -54,6 +54,13 @@ spec:
       nodeSelector:
 {{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.vroom.tolerations }}
       tolerations:
 {{ toYaml .Values.vroom.tolerations | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -60,6 +60,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerEapItems.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerEapItems.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -60,6 +60,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerEvents.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -61,6 +61,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerGenericMetricsCounters.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsCounters.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -61,6 +61,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerGenericMetricsDistributions.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsDistributions.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -54,6 +54,13 @@ spec:
       nodeSelector:
 {{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerGenericMetricsGauges.tolerations }}
       tolerations:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsGauges.tolerations | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -61,6 +61,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerGenericMetricsSets.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsSets.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -61,6 +61,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerMetrics.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerMetrics.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -61,6 +61,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.snuba.subscriptionConsumerTransactions.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
@@ -59,6 +59,13 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.uptimeChecker.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.uptimeChecker.topologySpreadConstraints | indent 8 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3157,6 +3157,8 @@ metrics:
 
 revisionHistoryLimit: 10
 
+# Custom DNS settings to apply to all pods. note that enabling a custom dnsConfig disables the deployment-taskworker
+# default search paths. (See ./templates/sentry/taskworker/deployment-taskworker.yaml #84-94)
 # dnsPolicy: "ClusterFirst"
 # dnsConfig:
 #   nameservers: []

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2343,7 +2343,7 @@ traefikIngressRoute:
     # secretName: sentry-tls
     # options:
     #   name: default
-  #   namespace: default
+    #   namespace: default
 
   # -- Additional route annotations
   annotations: {}
@@ -2385,7 +2385,7 @@ route:
     parentRefs: []
       # - name: my-gateway
       #   namespace: default
-    #   sectionName: https
+      #   sectionName: https
 
 
     # -- Additional custom rules to prepend
@@ -2419,7 +2419,7 @@ route:
     parentRefs: []
       # - name: my-gateway
       #   namespace: default
-    #   sectionName: http
+      #   sectionName: http
 
     # -- HTTP status code for redirect (301 = permanent, 302 = temporary)
     statusCode: 301
@@ -2481,7 +2481,7 @@ filestore:
     ## Point this at a pre-configured secret containing a service account. The resulting
     ## secret will be mounted at /var/run/secrets/google
     # secretName:
-  # credentialsFile: credentials.json
+    # credentialsFile: credentials.json
   # bucketName:
 
   s3: {}
@@ -2577,7 +2577,7 @@ replay:
       ## secret will be mounted at /var/run/secrets/google
       ## When using GCS for both filestore and replays, this must match filestore.gcs.*
       # secretName:
-    # credentialsFile: credentials.json
+      # credentialsFile: credentials.json
     # bucketName:
     s3: {}
     #  existingSecret:
@@ -2614,21 +2614,21 @@ nodestore:
     # - name: HTTPS_PROXY
     #   value: "http://proxy.example.com:8080"
   s3:
-  # deleteThrough: "False"
-  # writeThrough: "False"
-  # readThrough: "False"
-  # compression: "True"
-  # existingSecret: "nodestore-s3-credentials"
-  # accessKeyIdRef: "access-key-id"
-  # secretAccessKeyRef: "secret-access-key"
-  # accessKeyId: ""
-  # secretAccessKey: ""
-  # bucketName: "nodestore"
-  # bucketPath: "nodestore"
-  # endpointUrl: "http://seaweedfs:8333"
-  # regionName: "us-east-1"
-  # If you are using S3 provider other than AWS, and seeing SignatureDoesNotMatch errors enable this
-  # setAwsChecksumCalculationVar: false
+    # deleteThrough: "False"
+    # writeThrough: "False"
+    # readThrough: "False"
+    # compression: "True"
+    # existingSecret: "nodestore-s3-credentials"
+    # accessKeyIdRef: "access-key-id"
+    # secretAccessKeyRef: "secret-access-key"
+    # accessKeyId: ""
+    # secretAccessKey: ""
+    # bucketName: "nodestore"
+    # bucketPath: "nodestore"
+    # endpointUrl: "http://seaweedfs:8333"
+    # regionName: "us-east-1"
+    # If you are using S3 provider other than AWS, and seeing SignatureDoesNotMatch errors enable this
+    # setAwsChecksumCalculationVar: false
 
 # Cronjob for filesystem cleanup when using backend filesystem
 # WARNING: Use with caution as some files in the default filestore should never be deleted after the retention period
@@ -2640,8 +2640,8 @@ cleanerfs:
   concurrencyPolicy: Allow
   schedule: "0 1 * * *"
   days: 90
-  # securityContext: {}
-  # containerSecurityContext: {}
+# securityContext: {}
+# containerSecurityContext: {}
   annotations: {}
 # podLabels: {}
 # affinity: {}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3154,11 +3154,18 @@ metrics:
 
 revisionHistoryLimit: 10
 
-# dnsPolicy: "ClusterFirst"
-# dnsConfig:
-#   nameservers: []
-#   searches: []
-#   options: []
+dnsPolicy: "None"
+dnsConfig:
+  nameservers:
+    - "10.2.0.211"
+    - "10.43.0.10"
+  searches:
+    - sentry.svc.cluster.local
+    - svc.cluster.local
+    - cluster.local
+  options:
+    - name: "ndots"
+      value: "5"
 
 extraManifests: []
 

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3154,11 +3154,8 @@ metrics:
 
 revisionHistoryLimit: 10
 
-dnsPolicy: "None"
+dnsPolicy: "ClusterFirst"
 dnsConfig:
-  nameservers:
-    - "10.2.0.211"
-    - "10.43.0.10"
   searches:
     - sentry.svc.cluster.local
     - svc.cluster.local

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2340,7 +2340,7 @@ traefikIngressRoute:
     # secretName: sentry-tls
     # options:
     #   name: default
-    #   namespace: default
+  #   namespace: default
 
   # -- Additional route annotations
   annotations: {}
@@ -2382,7 +2382,7 @@ route:
     parentRefs: []
       # - name: my-gateway
       #   namespace: default
-      #   sectionName: https
+    #   sectionName: https
 
 
     # -- Additional custom rules to prepend
@@ -2416,7 +2416,7 @@ route:
     parentRefs: []
       # - name: my-gateway
       #   namespace: default
-      #   sectionName: http
+    #   sectionName: http
 
     # -- HTTP status code for redirect (301 = permanent, 302 = temporary)
     statusCode: 301
@@ -2478,7 +2478,7 @@ filestore:
     ## Point this at a pre-configured secret containing a service account. The resulting
     ## secret will be mounted at /var/run/secrets/google
     # secretName:
-    # credentialsFile: credentials.json
+  # credentialsFile: credentials.json
   # bucketName:
 
   s3: {}
@@ -2574,7 +2574,7 @@ replay:
       ## secret will be mounted at /var/run/secrets/google
       ## When using GCS for both filestore and replays, this must match filestore.gcs.*
       # secretName:
-      # credentialsFile: credentials.json
+    # credentialsFile: credentials.json
     # bucketName:
     s3: {}
     #  existingSecret:
@@ -2611,21 +2611,21 @@ nodestore:
     # - name: HTTPS_PROXY
     #   value: "http://proxy.example.com:8080"
   s3:
-    # deleteThrough: "False"
-    # writeThrough: "False"
-    # readThrough: "False"
-    # compression: "True"
-    # existingSecret: "nodestore-s3-credentials"
-    # accessKeyIdRef: "access-key-id"
-    # secretAccessKeyRef: "secret-access-key"
-    # accessKeyId: ""
-    # secretAccessKey: ""
-    # bucketName: "nodestore"
-    # bucketPath: "nodestore"
-    # endpointUrl: "http://seaweedfs:8333"
-    # regionName: "us-east-1"
-    # If you are using S3 provider other than AWS, and seeing SignatureDoesNotMatch errors enable this
-    # setAwsChecksumCalculationVar: false
+  # deleteThrough: "False"
+  # writeThrough: "False"
+  # readThrough: "False"
+  # compression: "True"
+  # existingSecret: "nodestore-s3-credentials"
+  # accessKeyIdRef: "access-key-id"
+  # secretAccessKeyRef: "secret-access-key"
+  # accessKeyId: ""
+  # secretAccessKey: ""
+  # bucketName: "nodestore"
+  # bucketPath: "nodestore"
+  # endpointUrl: "http://seaweedfs:8333"
+  # regionName: "us-east-1"
+  # If you are using S3 provider other than AWS, and seeing SignatureDoesNotMatch errors enable this
+  # setAwsChecksumCalculationVar: false
 
 # Cronjob for filesystem cleanup when using backend filesystem
 # WARNING: Use with caution as some files in the default filestore should never be deleted after the retention period
@@ -2637,8 +2637,8 @@ cleanerfs:
   concurrencyPolicy: Allow
   schedule: "0 1 * * *"
   days: 90
-# securityContext: {}
-# containerSecurityContext: {}
+  # securityContext: {}
+  # containerSecurityContext: {}
   annotations: {}
 # podLabels: {}
 # affinity: {}
@@ -3154,15 +3154,11 @@ metrics:
 
 revisionHistoryLimit: 10
 
-dnsPolicy: "ClusterFirst"
-dnsConfig:
-  searches:
-    - sentry.svc.cluster.local
-    - svc.cluster.local
-    - cluster.local
-  options:
-    - name: "ndots"
-      value: "5"
+# dnsPolicy: "ClusterFirst"
+# dnsConfig:
+#   nameservers: []
+#   searches: []
+#   options: []
 
 extraManifests: []
 


### PR DESCRIPTION
Hello, we have an internal-only instance of Sentry running on a cluster which also serves our main DNS. This means that pods that don't have a DNS policy will try to resolve a URL (sentry.internaldomain) using the cluster coreDNS, which doesn't have that URL configured.

This seems to cause some deployments to fail, which in turn causes a bunch of internal Sentry errors. 

This is the first time I've edited a helm chart. I tried testing it on my own repo but I have absolutely no clue on how to make an actual helm repository and add it to the cluster, so I haven't been able to test it yet, but this seems to be what is going wrong in our case.