### PR TITLE
fix(routing): nil pointer error using Gateway API without nginx

### DIFF
--- a/charts/sentry/templates/routing/route.yaml
+++ b/charts/sentry/templates/routing/route.yaml
@@ -6,7 +6,7 @@
 {{- $relayPort := (include "relay.port" .) | int -}}
 {{- $webPort := .Values.service.externalPort | int -}}
 {{- $nginxEnabled := .Values.nginx.enabled -}}
-{{- $nginxPort := .Values.nginx.service.ports.http | int -}}
+{{- $nginxPort := (((.Values.nginx).service).ports).http | int -}}
 {{- $hostnames := $mainRoute.hostnames -}}
 {{- if $redirectRoute.enabled }}
 {{- $redirectHostnames := $redirectRoute.hostnames | default $hostnames -}}


### PR DESCRIPTION
This PR fixes a nil pointer evaluating interface error when using Gateway API `route.main.enabled` without nginx.
```sh
Error: UPGRADE FAILED: template: sentry/templates/routing/route.yaml:9:25: executing "sentry/templates/routing/route.yaml" at <.Values.nginx.service.ports.http>: nil pointer evaluating interface {}.ports
```