### PR TITLE
feat: add configurable clusterDomain to global section in values.yaml

### DIFF
--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -83,7 +83,7 @@ spec:
       {{- end }}
       dnsConfig:
         searches:
-          - {{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}.{{ $root.Release.Namespace }}.svc.cluster.local
+          - {{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}.{{ $root.Release.Namespace }}.svc.{{ $root.Values.global.clusterDomain | default "cluster.local" }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" $root | indent 6 }}
       containers:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -8,6 +8,9 @@ global:
   # Set SAMPLED_DEFAULT_RATE parameter for all projects
   # sampledDefaultRate: 1.0
 
+  # Kubernetes cluster domain
+  clusterDomain: "cluster.local"
+
   nodeSelector: {}
   tolerations: []
   sidecars: []


### PR DESCRIPTION
Makes Kubernetes cluster domain configurable instead of hardcoded to cluster.local. Placed in global section for potential reuse across templates. Addresses #2045