### PR TITLE
Fix double prefix in NGINX ConfigMap and update broken NGINX dependency

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 12.5.1
 - name: nginx
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 0.5.9
-digest: sha256:a774350500f92b172ad828e9ee3ca4051a364d8fb409f4e172baed9f7c63157e
-generated: "2026-02-03T23:55:16.377342482+01:00"
+  version: 0.7.0
+digest: sha256:b1db91770a93016ac2b0ad35c779b4a0f268cf65d06de9558ac3fbe03185035f
+generated: "2026-02-25T13:11:28.901973313+01:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     condition: postgresql.enabled
   - name: nginx
     repository: oci://registry-1.docker.io/cloudpirates
-    version: 0.5.9
+    version: 0.7.0
     condition: nginx.enabled
 maintainers:
   - name: sentry-kubernetes

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1220,5 +1220,3 @@ Gateway API v1 is GA since Kubernetes 1.29.
 {{- print "gateway.networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "nginx.configName" -}}{{ template "sentry.fullname" . }}-nginx{{- end -}}

--- a/charts/sentry/templates/routing/nginx-config.yaml
+++ b/charts/sentry/templates/routing/nginx-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "nginx.configName" . }}
+  name: {{ template "sentry.fullname" . }}-nginx
   labels:
     {{- include "sentry.component.labels" (dict "component" "nginx" "ctx" .) | nindent 4 }}
 data:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2428,7 +2428,7 @@ route:
 # For other configuration options see: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/nginx
 nginx:
   enabled: false
-  existingServerConfigConfigmap: '{{ include "nginx.configName" . }}'
+  existingServerConfigConfigmap: '{{ template "sentry.fullname" . }}'
   extraLocationSnippet: false
   # extraLocationSnippet: |
   #  location /admin {


### PR DESCRIPTION
There was an issue with ConfigMap in nginx dependency chart which is fixed in latest version. #2050 

The previous PR (#2042) which apparently tried to fix the issue, introduced a helper `nginx.configName` that appends `-nginx` to `{{ template "sentry.fullname" . }}`. While the intention was to standardize ConfigMap names across different setups, in our chart setup this causes **duplicate prefixes**. For example, with our release and chart naming, it produces:

sentry-sentry-nginx

instead of the expected:

sentry-nginx

Now with the working nginx chart its working fine after reverting