### PR TITLE
feat(statefulset): add persistentVolumeClaimRetentionPolicy option

### DIFF
--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   serviceName: {{ template "sentry.fullname" $root }}-taskbroker-{{ $broker.name }}
   replicas: {{ default $root.Values.sentry.taskBroker.replicas $broker.replicas }}
+  {{- if $root.Values.sentry.taskBroker.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml $root.Values.sentry.taskBroker.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" $root }}

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -13,6 +13,10 @@ metadata:
 spec:
   serviceName: {{ template "sentry.fullname" . }}-symbolicator-api
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.symbolicator.api.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.symbolicator.api.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -348,6 +348,11 @@ sentry:
       size: 1Gi
       storageClass: ""
       accessMode: ReadWriteOnce
+      # persistentVolumeClaimRetentionPolicy controls PVC lifecycle on StatefulSet deletion/scale-down.
+      # Requires Kubernetes 1.27+ with StatefulSetAutoDeletePVC feature gate enabled.
+      # persistentVolumeClaimRetentionPolicy:
+      #   whenDeleted: Retain  # or Delete
+      #   whenScaled: Retain   # or Delete
     brokers:
       - name: default
         topic: taskworker
@@ -2137,6 +2142,11 @@ symbolicator:
       ## If 'lookupVolumeName' is set to true, Helm will attempt to retrieve
       ## the current value of 'spec.volumeName' and incorporate it into the template.
       lookupVolumeName: true
+      # persistentVolumeClaimRetentionPolicy controls PVC lifecycle on StatefulSet deletion/scale-down.
+      # Requires Kubernetes 1.27+ with StatefulSetAutoDeletePVC feature gate enabled.
+      # persistentVolumeClaimRetentionPolicy:
+      #   whenDeleted: Retain  # or Delete
+      #   whenScaled: Retain   # or Delete
     replicas: 1
     env: []
     probeInitialDelaySeconds: 10


### PR DESCRIPTION
What: Added `persistentVolumeClaimRetentionPolicy` config for StatefulSets
Why: Allows automatic PVC cleanup on StatefulSet deletion (K8s 1.27+)
How: New values in `symbolicator.api.persistence` and `sentry.taskBroker.persistence`