### PR TITLE
fix: correct swapped default args for taskScheduler replicas in Helm chart

### DIFF
--- a/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "sentry.component.labels" (dict "component" "taskscheduler" "ctx" .) | nindent 4 }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  replicas: {{ default .Values.sentry.taskScheduler.replicas 1 }}
+  replicas: {{ default 1 .Values.sentry.taskScheduler.replicas }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}


### PR DESCRIPTION

### Summary

The upstream sentry chart (v29.4.0) has a bug in
`templates/sentry/taskscheduler/deployment-taskscheduler.yaml` where the arguments to the Sprig `default` function are reversed:

#### Before (broken) — always evaluates to 1
replicas: {{ default .Values.sentry.taskScheduler.replicas 1 }}

#### After (fixed) — uses the configured value, falls back to 1 
replicas: {{ default 1 .Values.sentry.taskScheduler.replicas }}