### PR TITLE
fix(relay): indent logging key to be a root key

### DIFF
--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -24,15 +24,15 @@ config.yml: |-
     {{- end }}
     {{- end }}
 
-    {{- if .Values.relay.logging }}
-    logging:
-      {{- if .Values.relay.logging.level }}
-      level: {{ .Values.relay.logging.level }}
-      {{- end }}
-      {{- if .Values.relay.logging.format }}
-      format: {{ .Values.relay.logging.format }}
-      {{- end }}
+  {{- if .Values.relay.logging }}
+  logging:
+    {{- if .Values.relay.logging.level }}
+    level: {{ .Values.relay.logging.level }}
     {{- end }}
+    {{- if .Values.relay.logging.format }}
+    format: {{ .Values.relay.logging.format }}
+    {{- end }}
+  {{- end }}
 
   processing:
     enabled: true


### PR DESCRIPTION
### Problem

Updating values under  `relay.logging` does nothing because the key is not indented properly.

The `logging` key should be a root key in the relay config file as the documentation and the example config file show:

* https://docs.sentry.io/product/relay/options/#logging
* https://github.com/getsentry/self-hosted/blob/master/relay/config.example.yml



