### PR TITLE
feat(sentry): support reading Kafka SASL credentials from existing secret

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -594,6 +594,23 @@ Common Snuba environment variables
   value: /etc/snuba/settings.py
 - name: DEFAULT_BROKERS
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+- name: KAFKA_SASL_MECHANISM
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "mechanism" .Values.externalKafka.sasl.existingSecretKeys.mechanism }}
+- name: KAFKA_SASL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "username" .Values.externalKafka.sasl.existingSecretKeys.username }}
+- name: KAFKA_SASL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
+{{- else }}
 {{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
 {{- if not (eq "None" $sentryKafkaSaslMechanism) }}
 - name: KAFKA_SASL_MECHANISM
@@ -608,6 +625,7 @@ Common Snuba environment variables
 {{- if not (eq "None" $sentryKafkaSaslPassword) }}
 - name: KAFKA_SASL_PASSWORD
   value: {{ $sentryKafkaSaslPassword | quote }}
+{{- end }}
 {{- end }}
 - name: KAFKA_SECURITY_PROTOCOL
   value: {{ include "sentry.kafka.security_protocol" . | quote }}
@@ -709,6 +727,27 @@ Common Sentry environment variables
     secretKeyRef:
       name: {{ template "sentry.fullname" . }}-sentry-secret
       key: "key"
+{{- end }}
+
+{{/*
+Set Kafka SASL credentials from existingSecret
+*/}}
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+- name: KAFKA_SASL_MECHANISM
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "mechanism" .Values.externalKafka.sasl.existingSecretKeys.mechanism }}
+- name: KAFKA_SASL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "username" .Values.externalKafka.sasl.existingSecretKeys.username }}
+- name: KAFKA_SASL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
 {{- end }}
 
 {{/*

--- a/charts/sentry/templates/relay/_helper-sentry-relay.tpl
+++ b/charts/sentry/templates/relay/_helper-sentry-relay.tpl
@@ -63,6 +63,14 @@ config.yml: |-
       - name: "api.version.request.timeout.ms"
         value: {{ int64 .Values.relay.processing.kafkaConfig.apiVersionRequestTimeoutMs | quote }}
       {{- end }}
+      {{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+      - name: "sasl.mechanism"
+        value: "${KAFKA_SASL_MECHANISM}"
+      - name: "sasl.username"
+        value: "${KAFKA_SASL_USERNAME}"
+      - name: "sasl.password"
+        value: "${KAFKA_SASL_PASSWORD}"
+      {{- else }}
       {{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
       {{- if not (eq "None" $sentryKafkaSaslMechanism) }}
       - name: "sasl.mechanism"
@@ -77,6 +85,7 @@ config.yml: |-
       {{- if not (eq "None" $sentryKafkaSaslPassword) }}
       - name: "sasl.password"
         value: {{ $sentryKafkaSaslPassword | quote }}
+      {{- end }}
       {{- end }}
       {{- $sentryKafkaSecurityProtocol := include "sentry.kafka.security_protocol" . -}}
       {{- if not (eq "plaintext" $sentryKafkaSecurityProtocol) }}

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -81,6 +81,44 @@ spec:
 {{ toYaml .Values.relay.securityContext | indent 8 }}
       {{- end }}
       initContainers:
+        {{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+        - name: {{ .Chart.Name }}-relay-config-render
+          image: "busybox:1.36"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              sed "s|\${KAFKA_SASL_MECHANISM}|$KAFKA_SASL_MECHANISM|g; s|\${KAFKA_SASL_USERNAME}|$KAFKA_SASL_USERNAME|g; s|\${KAFKA_SASL_PASSWORD}|$KAFKA_SASL_PASSWORD|g" /config-template/config.yml > /rendered-config/config.yml
+          env:
+            - name: KAFKA_SASL_MECHANISM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalKafka.sasl.existingSecret }}
+                  key: {{ default "mechanism" .Values.externalKafka.sasl.existingSecretKeys.mechanism }}
+            - name: KAFKA_SASL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalKafka.sasl.existingSecret }}
+                  key: {{ default "username" .Values.externalKafka.sasl.existingSecretKeys.username }}
+            - name: KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalKafka.sasl.existingSecret }}
+                  key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
+          volumeMounts:
+            - name: config
+              mountPath: /config-template
+              readOnly: true
+            - name: rendered-config
+              mountPath: /rendered-config
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+        {{- end }}
         - name: {{ .Chart.Name }}-relay-init
           image: "{{ template "relay.image" . }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
@@ -114,10 +152,17 @@ spec:
           volumeMounts:
             - name: credentials
               mountPath: /work/.relay
+            {{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+            - name: rendered-config
+              mountPath: /work/.relay/config.yml
+              subPath: config.yml
+              readOnly: true
+            {{- else }}
             - name: config
               mountPath: /work/.relay/config.yml
               subPath: config.yml
               readOnly: true
+            {{- end }}
 {{- if .Values.relay.init.volumeMounts }}
 {{ toYaml .Values.relay.init.volumeMounts | indent 12 }}
 {{- end }}
@@ -156,10 +201,17 @@ spec:
         volumeMounts:
           - name: credentials
             mountPath: /work/.relay
+          {{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+          - name: rendered-config
+            mountPath: /work/.relay/config.yml
+            subPath: config.yml
+            readOnly: true
+          {{- else }}
           - name: config
             mountPath: /work/.relay/config.yml
             subPath: config.yml
             readOnly: true
+          {{- end }}
           {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
           - name: {{ .Values.geodata.volumeName }}
             mountPath: {{ .Values.geodata.mountPath }}
@@ -210,6 +262,10 @@ spec:
           defaultMode: 0644
       - name: credentials
         emptyDir: {}
+      {{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+      - name: rendered-config
+        emptyDir: {}
+      {{- end }}
       {{- if and .Values.geodata.volumeName .Values.geodata.accountID }}
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -212,6 +212,11 @@ sentry.conf.py: |-
           "compression.type": {{ $sentryKafkaCompressionType | quote }},
       {{- end }}
           "socket.timeout.ms": {{ include "sentry.kafka.socket_timeout_ms" . }},
+      {{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
+          "sasl.mechanism": os.getenv("KAFKA_SASL_MECHANISM", ""),
+          "sasl.username": os.getenv("KAFKA_SASL_USERNAME", ""),
+          "sasl.password": os.getenv("KAFKA_SASL_PASSWORD", ""),
+      {{- else }}
       {{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
       {{- if not (eq "None" $sentryKafkaSaslMechanism) }}
           "sasl.mechanism": {{ $sentryKafkaSaslMechanism | quote }},
@@ -223,6 +228,7 @@ sentry.conf.py: |-
       {{- $sentryKafkaSaslPassword := include "sentry.kafka.sasl_password" . -}}
       {{- if not (eq "None" $sentryKafkaSaslPassword) }}
           "sasl.password": {{ $sentryKafkaSaslPassword | quote }},
+      {{- end }}
       {{- end }}
       {{- $sentryKafkaSecurityProtocol := include "sentry.kafka.security_protocol" . -}}
       {{- if not (eq "plaintext" $sentryKafkaSecurityProtocol) }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2977,6 +2977,12 @@ externalKafka:
     mechanism: None  # PLAIN,SCRAM-256,SCRAM-512
     username: None
     password: None
+    # (Optional) Use existing secret for SASL credentials instead of inline values
+    # existingSecret: ""
+    # existingSecretKeys:
+    #   mechanism: "mechanism"
+    #   username: "username"
+    #   password: "password"
   security:
     protocol: plaintext  # 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'
   socket:


### PR DESCRIPTION
## Summary
- Add support for configuring external Kafka SASL credentials via an existing Kubernetes secret (Optional feature)
- This allows users to avoid storing sensitive Kafka credentials in plain text in values.yaml

## Changes
- Add `externalKafka.sasl.existingSecret` and `existingSecretKeys` configuration options
- Inject `KAFKA_SASL_MECHANISM`, `KAFKA_SASL_USERNAME`, `KAFKA_SASL_PASSWORD` env vars from secret
- Add init container for Relay to render config with secret values

## Usage
~~~
externalKafka:
  sasl:
    existingSecret: "my-kafka-secret"
    existingSecretKeys:
      mechanism: "mechanism"
      username: "username"
      password: "password"
  security:
    protocol: SASL_SSL
~~~
