### PR TITLE
feat: Add optional memory-based autoscaling to all HPA components

### DIFF
--- a/charts/sentry/templates/relay/hpa-relay.yaml
+++ b/charts/sentry/templates/relay/hpa-relay.yaml
@@ -28,6 +28,15 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.relay.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.relay.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: ContainerResource
+    containerResource:
+      container: {{ .Chart.Name }}-relay
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.relay.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
   {{- else }}
   metrics:
   - type: Resource
@@ -36,6 +45,14 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.relay.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.relay.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.relay.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.relay.autoscaling.behavior }}

--- a/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
@@ -23,6 +23,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestConsumerAttachments.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-consumer-attachments
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -31,6 +40,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestConsumerAttachments.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerAttachments.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.sentry.ingestConsumerAttachments.autoscaling.behavior }}

--- a/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
@@ -23,6 +23,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestConsumerEvents.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-consumer-events
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -31,6 +40,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestConsumerEvents.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerEvents.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.sentry.ingestConsumerEvents.autoscaling.behavior }}

--- a/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
@@ -24,6 +24,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestConsumerTransactions.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-consumer-transactions
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -32,6 +41,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestConsumerTransactions.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestConsumerTransactions.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.sentry.ingestConsumerTransactions.autoscaling.behavior }}

--- a/charts/sentry/templates/sentry/taskworker/hpa-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/hpa-taskworker.yaml
@@ -14,6 +14,7 @@
 {{- $minReplicas := default $globalAutoscaling.minReplicas $workerAutoscaling.minReplicas }}
 {{- $maxReplicas := default $globalAutoscaling.maxReplicas $workerAutoscaling.maxReplicas }}
 {{- $targetCPU := default $globalAutoscaling.targetCPUUtilizationPercentage $workerAutoscaling.targetCPUUtilizationPercentage }}
+{{- $targetMemory := default $globalAutoscaling.targetMemoryUtilizationPercentage $workerAutoscaling.targetMemoryUtilizationPercentage }}
 {{- $behavior := default $globalAutoscaling.behavior $workerAutoscaling.behavior }}
 ---
 apiVersion: {{ template "sentry.autoscaling.apiVersion" $root }}
@@ -40,6 +41,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ $targetCPU }}
+    {{- if $targetMemory }}
+    - type: ContainerResource
+      containerResource:
+        container: taskworker
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $targetMemory }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -48,6 +58,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ $targetCPU }}
+    {{- if $targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $targetMemory }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" $root) "autoscaling/v2" }}
   {{- with $behavior }}

--- a/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
@@ -24,6 +24,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.vroom.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-vroom
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.vroom.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -32,6 +41,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.vroom.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.vroom.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.vroom.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.vroom.autoscaling.behavior }}

--- a/charts/sentry/templates/sentry/web/hpa-web.yaml
+++ b/charts/sentry/templates/sentry/web/hpa-web.yaml
@@ -23,6 +23,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.web.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-web
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.web.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -31,6 +40,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.sentry.web.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.web.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.web.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.sentry.web.autoscaling.behavior }}

--- a/charts/sentry/templates/snuba/hpa-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/hpa-snuba-api.yaml
@@ -23,6 +23,15 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.snuba.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-snuba
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.snuba.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- else }}
   metrics:
     - type: Resource
@@ -31,6 +40,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.snuba.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.snuba.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.snuba.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
   {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
   {{- with .Values.snuba.api.autoscaling.behavior }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -135,6 +135,7 @@ vroom:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
+    # targetMemoryUtilizationPercentage: 50
     # Only available with autoscaling/v2
     behavior: {}
   sidecars: []
@@ -202,6 +203,7 @@ relay:
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
+    # targetMemoryUtilizationPercentage: 50
     # Only available with autoscaling/v2
     behavior: {}
   sidecars: []
@@ -304,6 +306,7 @@ sentry:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
       # Only available with autoscaling/v2
       behavior: {}
     sidecars: []
@@ -391,6 +394,7 @@ sentry:
       minReplicas: 1
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
       # Only available with autoscaling/v2
       behavior: {}
     env: []
@@ -457,6 +461,7 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
       # Only available with autoscaling/v2
       behavior: {}
     sidecars: []
@@ -499,6 +504,7 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
       # Only available with autoscaling/v2
       behavior: {}
     sidecars: []
@@ -541,6 +547,7 @@ sentry:
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
       # Only available with autoscaling/v2
       behavior: {}
     sidecars: []
@@ -1236,6 +1243,7 @@ snuba:
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
       # Only available with autoscaling/v2
       behavior: {}
     sidecars: []


### PR DESCRIPTION

## Summary

Adds optional memory-based horizontal pod autoscaling alongside the existing CPU-based scaling for all HPA-enabled components in the Sentry chart. This change is fully backward-compatible.

if `targetMemoryUtilizationPercentage` is not defined in the user's values, the rendered manifests are byte-identical to before.

## Changes

- **`values.yaml`** -- Added commented-out `# targetMemoryUtilizationPercentage: 50` to all 8 autoscaling sections:
  - `vroom.autoscaling`
  - `relay.autoscaling`
  - `sentry.web.autoscaling`
  - `sentry.taskWorker.autoscaling`
  - `sentry.ingestConsumerAttachments.autoscaling`
  - `sentry.ingestConsumerEvents.autoscaling`
  - `sentry.ingestConsumerTransactions.autoscaling`
  - `snuba.api.autoscaling`

- **HPA templates** (8 files) -- Added conditional memory metric block to both `ContainerResource` (k8s >= 1.27) and `Resource` (older k8s) code paths:
  - `templates/relay/hpa-relay.yaml`
  - `templates/sentry/web/hpa-web.yaml`
  - `templates/sentry/vroom/hpa-vroom.yaml`
  - `templates/sentry/taskworker/hpa-taskworker.yaml`
  - `templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml`
  - `templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml`
  - `templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml`
  - `templates/snuba/hpa-snuba-api.yaml`

## Backward Compatibility

This change is **fully backward-compatible** and introduces no breaking changes:

- No new required fields -- `targetMemoryUtilizationPercentage` is entirely optional

## Usage

To enable memory-based scaling for a component, set `targetMemoryUtilizationPercentage` in your values override:
```
relay:
  autoscaling:
    targetMemoryUtilizationPercentage: 80

sentry:
  web:
    autoscaling:
      targetMemoryUtilizationPercentage: 80
  taskWorker:
    autoscaling:
      targetMemoryUtilizationPercentage: 80
  ingestConsumerAttachments:
    autoscaling:
      targetMemoryUtilizationPercentage: 80
  ingestConsumerEvents:
    autoscaling:
      targetMemoryUtilizationPercentage: 80

snuba:
  api:
    autoscaling:
      targetMemoryUtilizationPercentage: 80
```