### PR TITLE
fix: incorrect component labels on uptime-results and snuba eap-items deployments

### DIFF
--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- include "sentry.component.labels" (dict "component" "sentry-subscription-consumer-eap-spans" "ctx" .) | nindent 4 }}
+    {{- include "sentry.component.labels" (dict "component" "sentry-uptime-results" "ctx" .) | nindent 4 }}
   {{- if .Values.asHook }}
   {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-eap-spans" "ctx" .) | nindent 4 }}
+    {{- include "sentry.component.labels" (dict "component" "snuba-subscription-consumer-eap-items" "ctx" .) | nindent 4 }}
   {{- if .Values.asHook }}
   {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:


### PR DESCRIPTION
## Summary

- Fix copy-paste labeling bugs where deployment metadata `component` labels were set to `sentry-subscription-consumer-eap-spans` instead of the correct component name
- `deployment-sentry-uptime-results.yaml`: metadata component label changed from `sentry-subscription-consumer-eap-spans` to `sentry-uptime-results`
- `deployment-snuba-subscription-consumer-eap-items.yaml`: metadata component label changed from `snuba-subscription-consumer-eap-spans` to `snuba-subscription-consumer-eap-items`

## Details

Both templates were likely created by copying the EAP spans subscription consumer template. The pod template labels and all other identifiers (deployment name, role, selector) were updated correctly, but the deployment-level `metadata.labels` component was missed in both cases.