### PR TITLE
docs: fix external-clickhouse.md

### DIFF
--- a/charts/sentry/docs/external-clickhouse.md
+++ b/charts/sentry/docs/external-clickhouse.md
@@ -89,6 +89,7 @@ spec:
         metadata:
           containers:
             - name: clickhouse-keeper
+              image: altinity/clickhouse-keeper:25.3.6.10034.altinitystable
         spec:
           affinity:
             podAntiAffinity:
@@ -115,6 +116,7 @@ spec:
     zookeeper:
       nodes:
         - host: keeper-clickhouse-keeper.sentry.svc.cluster.local
+          port: 2181
 ```
 
 ## Configuring Sentry Chart


### PR DESCRIPTION
Missing keeper port  & image

also I had to add, not sure if only for my case or not

```
      users:
        default/networks/ip:
          - "0.0.0.0/0"
          - "::/0"
        clickhouse_operator/networks/ip:
          - "0.0.0.0/0"
          - "::/0"
```