### PR TITLE
feat: add global.volumeMounts support across chart workloads

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -129,6 +129,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | global.nodeSelector | object | `{}` |  |
 | global.sidecars | list | `[]` |  |
 | global.tolerations | list | `[]` |  |
+| global.volumeMounts | list | `[]` |  |
 | global.volumes | list | `[]` |  |
 | google | object | `{}` |  |
 | hooks.activeDeadlineSeconds | int | `600` |  |

--- a/charts/sentry/templates/cleanerfs/cronjob-cleanerfs.yaml
+++ b/charts/sentry/templates/cleanerfs/cronjob-cleanerfs.yaml
@@ -80,6 +80,9 @@ spec:
             volumeMounts:
             - mountPath: {{ .Values.filestore.filesystem.path }}
               name: sentry-data
+            {{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 12 }}
+            {{- end }}
           restartPolicy: Never
           volumes:
           - name: sentry-data

--- a/charts/sentry/templates/geoip/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/geoip/deployment-geoip-job.yaml
@@ -42,6 +42,9 @@ spec:
           volumeMounts:
             - name: {{ .Values.geodata.volumeName }}
               mountPath: {{ .Values.geodata.mountPath }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 12 }}
+{{- end }}
       volumes:
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -172,6 +172,9 @@ spec:
         volumeMounts:
 {{ toYaml .Values.hooks.dbCheck.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         env:
 {{- if .Values.hooks.dbCheck.env }}
 {{ toYaml .Values.hooks.dbCheck.env | indent 8 }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -99,6 +99,9 @@ spec:
 {{- if .Values.hooks.dbInit.volumeMounts }}
 {{ toYaml .Values.hooks.dbInit.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
 {{- if .Values.hooks.dbInit.containerSecurityContext }}

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -110,6 +110,9 @@ spec:
 {{- if .Values.hooks.snubaInit.volumeMounts }}
 {{ toYaml .Values.hooks.snubaInit.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
 {{- if .Values.hooks.snubaInit.containerSecurityContext }}

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -101,6 +101,9 @@ spec:
 {{- if .Values.hooks.snubaInit.volumeMounts }}
 {{ toYaml .Values.hooks.snubaInit.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
 {{- if .Values.hooks.snubaMigrate.containerSecurityContext }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -119,6 +119,9 @@ spec:
 {{- if .Values.hooks.dbInit.volumeMounts }}
 {{ toYaml .Values.hooks.dbInit.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
 {{- if .Values.hooks.dbInit.containerSecurityContext }}

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -168,6 +168,9 @@ spec:
 {{- if .Values.relay.volumeMounts }}
 {{ toYaml .Values.relay.volumeMounts | indent 10 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 10 }}
+{{- end }}
         livenessProbe:
           failureThreshold: {{ .Values.relay.probeFailureThreshold }}
           httpGet:

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -109,6 +109,9 @@ spec:
 {{- if .Values.sentry.cleanup.volumeMounts }}
 {{ toYaml .Values.sentry.cleanup.volumeMounts | indent 12 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 12 }}
+{{- end }}
             resources:
 {{ toYaml .Values.sentry.cleanup.resources | indent 14 }}
 {{- if .Values.sentry.cleanup.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -158,6 +158,9 @@ spec:
 {{- if .Values.sentry.ingestConsumerAttachments.volumeMounts }}
 {{ toYaml .Values.sentry.ingestConsumerAttachments.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumerAttachments.resources | indent 12 }}
 {{- if .Values.sentry.ingestConsumerAttachments.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -158,6 +158,9 @@ spec:
 {{- if .Values.sentry.ingestConsumerEvents.volumeMounts }}
 {{ toYaml .Values.sentry.ingestConsumerEvents.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumerEvents.resources | indent 12 }}
 {{- if .Values.sentry.ingestConsumerEvents.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -139,6 +139,9 @@ spec:
 {{- if .Values.sentry.ingestFeedback.volumeMounts }}
 {{ toYaml .Values.sentry.ingestFeedback.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestFeedback.resources | indent 12 }}
 {{- if .Values.sentry.ingestFeedback.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -143,6 +143,9 @@ spec:
 {{- if .Values.sentry.ingestMonitors.volumeMounts }}
 {{ toYaml .Values.sentry.ingestMonitors.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestMonitors.resources | indent 12 }}
 {{- if .Values.sentry.ingestMonitors.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -138,6 +138,9 @@ spec:
 {{- if .Values.sentry.monitorsClockTasks.volumeMounts }}
 {{ toYaml .Values.sentry.monitorsClockTasks.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.monitorsClockTasks.resources | indent 12 }}
 {{- if .Values.sentry.monitorsClockTasks.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -138,6 +138,9 @@ spec:
 {{- if .Values.sentry.monitorsClockTick.volumeMounts }}
 {{ toYaml .Values.sentry.monitorsClockTick.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.monitorsClockTick.resources | indent 12 }}
 {{- if .Values.sentry.monitorsClockTick.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -139,6 +139,9 @@ spec:
 {{- if .Values.sentry.ingestOccurrences.volumeMounts }}
 {{ toYaml .Values.sentry.ingestOccurrences.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestOccurrences.resources | indent 12 }}
 {{- if .Values.sentry.ingestOccurrences.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -143,6 +143,9 @@ spec:
 {{- if .Values.sentry.ingestProfiles.volumeMounts }}
 {{ toYaml .Values.sentry.ingestProfiles.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestProfiles.resources | indent 12 }}
 {{- if .Values.sentry.ingestProfiles.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -143,6 +143,9 @@ spec:
 {{- if .Values.sentry.ingestReplayRecordings.volumeMounts }}
 {{ toYaml .Values.sentry.ingestReplayRecordings.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestReplayRecordings.resources | indent 12 }}
 {{- if .Values.sentry.ingestReplayRecordings.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -159,6 +159,9 @@ spec:
 {{- if .Values.sentry.ingestConsumerTransactions.volumeMounts }}
 {{ toYaml .Values.sentry.ingestConsumerTransactions.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.ingestConsumerTransactions.resources | indent 12 }}
 {{- if .Values.sentry.ingestConsumerTransactions.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -139,6 +139,9 @@ spec:
 {{- if .Values.sentry.billingMetricsConsumer.volumeMounts }}
 {{ toYaml .Values.sentry.billingMetricsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.billingMetricsConsumer.resources | indent 12 }}
 {{- if .Values.sentry.billingMetricsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -87,6 +87,9 @@ spec:
         volumeMounts:
 {{ toYaml .Values.metrics.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
 {{- if .Values.metrics.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -149,6 +149,9 @@ spec:
 {{- if .Values.sentry.metricsConsumer.volumeMounts }}
 {{ toYaml .Values.sentry.metricsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.metricsConsumer.resources | indent 12 }}
 {{- if .Values.sentry.metricsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -149,6 +149,9 @@ spec:
 {{- if .Values.sentry.genericMetricsConsumer.volumeMounts }}
 {{ toYaml .Values.sentry.genericMetricsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.genericMetricsConsumer.resources | indent 12 }}
 {{- if .Values.sentry.genericMetricsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -136,6 +136,9 @@ spec:
 {{- if .Values.sentry.postProcessForwardErrors.volumeMounts }}
 {{ toYaml .Values.sentry.postProcessForwardErrors.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForwardErrors.resources | indent 12 }}
 {{- if .Values.sentry.postProcessForwardErrors.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -144,6 +144,9 @@ spec:
 {{- if .Values.sentry.postProcessForwardTransactions.volumeMounts }}
 {{ toYaml .Values.sentry.postProcessForwardTransactions.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.postProcessForwardTransactions.resources | indent 12 }}
 {{- if .Values.sentry.postProcessForwardTransactions.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -135,6 +135,9 @@ spec:
 {{- if .Values.sentry.processSegments.volumeMounts }}
 {{ toYaml .Values.sentry.processSegments.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.processSegments.resources | indent 12 }}
 {{- if .Values.sentry.processSegments.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -135,6 +135,9 @@ spec:
 {{- if .Values.sentry.processSpans.volumeMounts }}
 {{ toYaml .Values.sentry.processSpans.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.processSpans.resources | indent 12 }}
 {{- if .Values.sentry.processSpans.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -127,6 +127,9 @@ spec:
 {{- if .Values.sentry.subscriptionConsumerEvents.volumeMounts }}
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerEvents.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerEvents.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -145,6 +145,9 @@ spec:
 {{- if .Values.sentry.subscriptionConsumerGenericMetrics.volumeMounts }}
 {{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerGenericMetrics.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerGenericMetrics.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -145,6 +145,9 @@ spec:
 {{- if .Values.sentry.subscriptionConsumerMetrics.volumeMounts }}
 {{ toYaml .Values.sentry.subscriptionConsumerMetrics.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerMetrics.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerMetrics.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -127,6 +127,9 @@ spec:
 {{- if .Values.sentry.subscriptionConsumerResultsEapItems.volumeMounts }}
 {{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerResultsEapItems.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerResultsEapItems.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -128,6 +128,9 @@ spec:
 {{- if .Values.sentry.subscriptionConsumerTransactions.volumeMounts }}
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.subscriptionConsumerTransactions.resources | indent 12 }}
 {{- if .Values.sentry.subscriptionConsumerTransactions.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -113,6 +113,9 @@ spec:
 {{- if $root.Values.sentry.taskBroker.volumeMounts }}
 {{ toYaml $root.Values.sentry.taskBroker.volumeMounts | indent 8 }}
 {{- end }}
+{{- if $root.Values.global.volumeMounts }}
+{{ toYaml $root.Values.global.volumeMounts | indent 8 }}
+{{- end }}
 {{- if $root.Values.sentry.taskBroker.sidecars }}
 {{ toYaml $root.Values.sentry.taskBroker.sidecars | indent 6 }}
 {{- end }}

--- a/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
@@ -120,6 +120,9 @@ spec:
 {{- if .Values.sentry.taskScheduler.volumeMounts }}
 {{ toYaml .Values.sentry.taskScheduler.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
 {{- if .Values.sentry.taskScheduler.sidecars }}
 {{ toYaml .Values.sentry.taskScheduler.sidecars | indent 6 }}
 {{- end }}

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -140,6 +140,9 @@ spec:
 {{- if $root.Values.sentry.taskWorker.volumeMounts }}
 {{ toYaml $root.Values.sentry.taskWorker.volumeMounts | indent 8 }}
 {{- end }}
+{{- if $root.Values.global.volumeMounts }}
+{{ toYaml $root.Values.global.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           exec:
             command:

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -135,6 +135,9 @@ spec:
 {{- if .Values.sentry.uptimeResults.volumeMounts }}
 {{ toYaml .Values.sentry.uptimeResults.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.sentry.uptimeResults.resources | indent 12 }}
 {{- if .Values.sentry.uptimeResults.containerSecurityContext }}

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -103,6 +103,9 @@ spec:
 {{- if .Values.vroom.volumeMounts }}
 {{ toYaml .Values.vroom.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: {{ .Values.vroom.probeFailureThreshold }}
           httpGet:

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -141,6 +141,9 @@ spec:
 {{- if .Values.sentry.web.volumeMounts }}
 {{ toYaml .Values.sentry.web.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: {{ .Values.sentry.web.probeFailureThreshold }}
           httpGet:

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -98,6 +98,9 @@ spec:
 {{- if .Values.snuba.api.volumeMounts }}
 {{ toYaml .Values.snuba.api.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -155,6 +155,9 @@ spec:
 {{- if .Values.snuba.consumer.volumeMounts }}
 {{ toYaml .Values.snuba.consumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.consumer.resources | indent 12 }}
 {{- if .Values.snuba.consumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.eapItemsConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.eapItemsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.eapItemsConsumer.resources | indent 12 }}
 {{- if .Values.snuba.eapItemsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.genericMetricsCountersConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.genericMetricsCountersConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.genericMetricsCountersConsumer.resources | indent 12 }}
 {{- if .Values.snuba.genericMetricsCountersConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.genericMetricsDistributionConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.genericMetricsDistributionConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.genericMetricsDistributionConsumer.resources | indent 12 }}
 {{- if .Values.snuba.genericMetricsDistributionConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.genericMetricsGaugesConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.genericMetricsGaugesConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.genericMetricsGaugesConsumer.resources | indent 12 }}
 {{- if .Values.snuba.genericMetricsGaugesConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.genericMetricsSetsConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.genericMetricsSetsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.genericMetricsSetsConsumer.resources | indent 12 }}
 {{- if .Values.snuba.genericMetricsSetsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -155,6 +155,9 @@ spec:
 {{- if .Values.snuba.groupAttributesConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.groupAttributesConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.groupAttributesConsumer.resources | indent 12 }}
 {{- if .Values.snuba.groupAttributesConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.issueOccurrenceConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.issueOccurrenceConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.issueOccurrenceConsumer.resources | indent 12 }}
 {{- if .Values.snuba.issueOccurrenceConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.metricsConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.metricsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.metricsConsumer.resources | indent 12 }}
 {{- if .Values.snuba.metricsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -160,6 +160,9 @@ spec:
 {{- if .Values.snuba.outcomesBillingConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.outcomesBillingConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.outcomesBillingConsumer.resources | indent 12 }}
 {{- if .Values.snuba.outcomesBillingConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -153,6 +153,9 @@ spec:
 {{- if .Values.snuba.outcomesConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.outcomesConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.outcomesConsumer.resources | indent 12 }}
 {{- if .Values.snuba.outcomesConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.profilingChunksConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.profilingChunksConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.profilingChunksConsumer.resources | indent 12 }}
 {{- if .Values.snuba.profilingChunksConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.profilingFunctionsConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.profilingFunctionsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.profilingFunctionsConsumer.resources | indent 12 }}
 {{- if .Values.snuba.profilingFunctionsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.profilingProfilesConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.profilingProfilesConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.profilingProfilesConsumer.resources | indent 12 }}
 {{- if .Values.snuba.profilingProfilesConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -127,6 +127,9 @@ spec:
 {{- if .Values.snuba.replacer.volumeMounts }}
 {{ toYaml .Values.snuba.replacer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.replacer.resources | indent 12 }}
 {{- if .Values.snuba.replacer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -160,6 +160,9 @@ spec:
 {{- if .Values.snuba.replaysConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.replaysConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.replaysConsumer.resources | indent 12 }}
 {{- if .Values.snuba.replaysConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -129,6 +129,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerEapItems.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerEapItems.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerEapItems.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerEapItems.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -129,6 +129,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerEvents.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerEvents.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerEvents.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -130,6 +130,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsCounters.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsCounters.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsCounters.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsCounters.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -130,6 +130,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsDistributions.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsDistributions.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsDistributions.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsDistributions.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -130,6 +130,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsGauges.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsGauges.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsGauges.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsGauges.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -130,6 +130,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsSets.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsSets.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerGenericMetricsSets.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerGenericMetricsSets.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -131,6 +131,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerMetrics.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerMetrics.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerMetrics.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerMetrics.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -130,6 +130,9 @@ spec:
 {{- if .Values.snuba.subscriptionConsumerTransactions.volumeMounts }}
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.subscriptionConsumerTransactions.resources | indent 12 }}
 {{- if .Values.snuba.subscriptionConsumerTransactions.containerSecurityContext }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -156,6 +156,9 @@ spec:
 {{- if .Values.snuba.transactionsConsumer.volumeMounts }}
 {{ toYaml .Values.snuba.transactionsConsumer.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.snuba.transactionsConsumer.resources | indent 12 }}
 {{- if .Values.snuba.transactionsConsumer.containerSecurityContext }}

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -101,6 +101,9 @@ spec:
 {{- if .Values.symbolicator.api.volumeMounts }}
 {{ toYaml .Values.symbolicator.api.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -102,6 +102,9 @@ spec:
 {{- if .Values.symbolicator.api.volumeMounts }}
 {{ toYaml .Values.symbolicator.api.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
@@ -96,6 +96,9 @@ spec:
 {{- if .Values.uptimeChecker.volumeMounts }}
 {{ toYaml .Values.uptimeChecker.volumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.uptimeChecker.resources | indent 12 }}
 {{- if .Values.uptimeChecker.containerSecurityContext }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -14,6 +14,7 @@ global:
   nodeSelector: {}
   tolerations: []
   sidecars: []
+  volumeMounts: []
   volumes: []
 
 # Profiles correspond to COMPOSE_PROFILES in the original self-hosted docker-compose.yml.


### PR DESCRIPTION
Added support for `global.volumeMounts` in the Sentry chart.

I needed a way to add the same volume mounts across workloads without patching templates one by one in a fork.  
So this change does 3 things:

- adds `global.volumeMounts: []` to `charts/sentry/values.yaml`
- documents it in `charts/sentry/README.md`
- wires it into templates that already define `volumeMounts`, similar to existing global knobs (`global.volumes`, `global.sidecars`, etc.).

Default is empty, so this should not change behavior for existing users.

If you want, I can split this into smaller PRs, but I kept it together to make rollout consistent across templates.