### PR TITLE
feat(kafka): update existing topic partitions and configs during provisioning

### DIFF
--- a/charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml
@@ -180,6 +180,36 @@ spec:
                 ${kafka_provisioning_commands[i]}
               done
               echo "Provisioning succeeded"
+
+              COMMON_OPTS="--bootstrap-server {{ $bootstrapServersString }} --command-config ${CLIENT_CONF}"
+
+              echo "Checking existing topic partitions and configs..."
+              {{- range $topics }}
+              {{- $partitions := .partitions | default $defaultPartitions }}
+              CURRENT_PARTITIONS=$(/opt/kafka/bin/kafka-topics.sh $COMMON_OPTS --describe --topic "{{ .name }}" 2>/dev/null | head -1 | sed -n 's/.*PartitionCount: \([0-9]*\).*/\1/p')
+              if [ -n "$CURRENT_PARTITIONS" ] && [ "{{ $partitions }}" -gt "$CURRENT_PARTITIONS" ]; then
+                echo "  [ALTER] {{ .name }}: increasing partitions from $CURRENT_PARTITIONS to {{ $partitions }}"
+                /opt/kafka/bin/kafka-topics.sh $COMMON_OPTS --alter --topic "{{ .name }}" --partitions "{{ $partitions }}"
+              fi
+              {{- if .config }}
+              CURRENT_CONFIGS=$(/opt/kafka/bin/kafka-configs.sh $COMMON_OPTS --entity-type topics --entity-name "{{ .name }}" --describe 2>/dev/null || echo "")
+              NEEDS_UPDATE=false
+              {{- range $key, $value := .config }}
+              if ! echo "$CURRENT_CONFIGS" | grep -q '{{ $key }}={{ $value }}'; then
+                NEEDS_UPDATE=true
+              fi
+              {{- end }}
+              if [ "$NEEDS_UPDATE" = true ]; then
+                echo "  [CONFIG] {{ .name }}: applying config updates"
+                {{- $scratch := dict "args" (list) }}
+                {{- range $key, $value := .config }}
+                {{- $_ := set $scratch "args" (append (index $scratch "args") (printf "%s=[%s]" $key $value)) }}
+                {{- end }}
+                /opt/kafka/bin/kafka-configs.sh $COMMON_OPTS --entity-type topics --entity-name "{{ .name }}" --alter --add-config '{{ join "," (index $scratch "args") }}' || echo "  [CONFIG] {{ .name }}: WARNING - config update failed"
+              fi
+              {{- end }}
+              {{- end }}
+              echo "Update complete"
           {{- if $provisioning.resources }}
           resources:
 {{ toYaml $provisioning.resources | indent 12 }}


### PR DESCRIPTION
## What

Extends the external Kafka provisioning Job to update existing topics, not just
create them. After the initial `--create --if-not-exists` pass, a second pass now:

- **Increases partition counts** when the desired value in `values.yaml` exceeds the
  live topic's current partition count.
- **Applies topic-level config changes** (e.g. `retention.ms`, `cleanup.policy`,
  `min.compaction.lag.ms`) when the live config differs from the desired state.

## Why

Previously, the provisioning Job was create-only — if a topic already existed, any
configuration drift (partition count, cleanup policy, compaction lag, etc.) was
silently ignored. Operators had to manually alter topics via Kafka CLI. This change
makes the Job idempotent and convergent: it drives topics toward the desired state
on every `helm upgrade`.

## Details

- Partition increases use `kafka-topics.sh --alter --partitions`.
- Detection is done by comparing `--describe` output against desired values; updates
  are skipped when already in sync.