### PR TITLE
fix: ensure all workloads respect global nodeSelector, tolerations, sidecars, volumeMounts, and volumes

### DIFF
--- a/charts/sentry/templates/cleanerfs/cronjob-cleanerfs.yaml
+++ b/charts/sentry/templates/cleanerfs/cronjob-cleanerfs.yaml
@@ -83,6 +83,12 @@ spec:
             {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 12 }}
             {{- end }}
+{{- if .Values.cleanerfs.sidecars }}
+{{ toYaml .Values.cleanerfs.sidecars | indent 10 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 10 }}
+{{- end }}
           restartPolicy: Never
           volumes:
           - name: sentry-data
@@ -97,4 +103,10 @@ spec:
           {{- else }}
             emptyDir: {}
           {{ end }}
+{{- if .Values.cleanerfs.volumes }}
+{{ toYaml .Values.cleanerfs.volumes | indent 10 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/geoip/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/geoip/deployment-geoip-job.yaml
@@ -17,6 +17,20 @@ spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-geoip
       {{- end }}
+      {{- if .Values.geodata.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.geodata.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.geodata.tolerations }}
+      tolerations:
+{{ toYaml .Values.geodata.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
       initContainers:
         - name: init-create-geoip-dir
           image: busybox
@@ -45,9 +59,21 @@ spec:
 {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 12 }}
 {{- end }}
+{{- if .Values.geodata.sidecars }}
+{{ toYaml .Values.geodata.sidecars | indent 8 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 8 }}
+{{- end }}
       volumes:
       - name: {{ .Values.geodata.volumeName }}
         persistentVolumeClaim:
           claimName: data-sentry-geoip
+{{- if .Values.geodata.volumes }}
+{{ toYaml .Values.geodata.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
       restartPolicy: OnFailure
 {{- end }}

--- a/charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml
@@ -63,10 +63,16 @@ spec:
       {{- if $provisioning.nodeSelector }}
       nodeSelector:
 {{ toYaml $provisioning.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
       {{- if $provisioning.tolerations }}
       tolerations:
 {{ toYaml $provisioning.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
       initContainers:
         - name: wait-for-kafka
@@ -187,7 +193,25 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+{{- if $provisioning.volumeMounts }}
+{{ toYaml $provisioning.volumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 12 }}
+{{- end }}
+{{- if $provisioning.sidecars }}
+{{ toYaml $provisioning.sidecars | indent 8 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 8 }}
+{{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+{{- if $provisioning.volumes }}
+{{ toYaml $provisioning.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -47,13 +47,34 @@ spec:
           - containerPort: 5432
             name: pgbouncer
             protocol: TCP
+{{- if or .Values.pgbouncer.volumeMounts .Values.global.volumeMounts }}
+        volumeMounts:
+{{- end }}
+{{- if .Values.pgbouncer.volumeMounts }}
+{{ toYaml .Values.pgbouncer.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.pgbouncer.sidecars }}
+{{ toYaml .Values.pgbouncer.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
       {{- if .Values.pgbouncer.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.pgbouncer.nodeSelector | nindent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.global.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.pgbouncer.tolerations }}
       tolerations:
         {{ toYaml .Values.pgbouncer.tolerations | nindent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+        {{ toYaml .Values.global.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.pgbouncer.affinity }}
       affinity:
@@ -67,4 +88,13 @@ spec:
       priorityClassName: "{{ .Values.pgbouncer.priorityClassName }}"
       {{- end }}
       terminationGracePeriodSeconds: 10
+{{- if or .Values.pgbouncer.volumes .Values.global.volumes }}
+      volumes:
+{{- end }}
+{{- if .Values.pgbouncer.volumes }}
+{{ toYaml .Values.pgbouncer.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -226,6 +226,15 @@ spec:
 {{- if .Values.snuba.cleanup.env }}
 {{ toYaml .Values.snuba.cleanup.env | indent 12 }}
 {{- end }}
+{{- if or .Values.snuba.cleanup.volumeMounts .Values.global.volumeMounts }}
+            volumeMounts:
+{{- end }}
+{{- if .Values.snuba.cleanup.volumeMounts }}
+{{ toYaml .Values.snuba.cleanup.volumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 12 }}
+{{- end }}
             resources:
 {{ toYaml .Values.snuba.cleanup.resources | indent 14 }}
 {{- if .Values.snuba.cleanup.containerSecurityContext }}

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -156,6 +156,12 @@ spec:
           mountPath: /var/run/secrets/google
         {{ end }}
       {{- end }}
+{{- if .Values.symbolicator.api.sidecars }}
+{{ toYaml .Values.symbolicator.api.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
       {{- end }}
@@ -174,6 +180,9 @@ spec:
       {{ end }}
 {{- if .Values.symbolicator.api.volumes }}
 {{ toYaml .Values.symbolicator.api.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
 {{- end }}
       {{- if .Values.symbolicator.api.priorityClassName }}
       priorityClassName: "{{ .Values.symbolicator.api.priorityClassName }}"


### PR DESCRIPTION
## Summary

Six workload templates did not respect one or more of the `global.nodeSelector`, `global.tolerations`, `global.sidecars`, `global.volumeMounts`, and `global.volumes` values, making it impossible to apply cluster-wide scheduling or volume configuration consistently.

### Components fixed

| Template | Missing globals added |
|---|---|
| `kafka-provisioning/job-kafka-provisioning.yaml` | nodeSelector, tolerations, sidecars, volumeMounts, volumes |
| `pgbouncer/pgbouncer-deployment.yaml` | nodeSelector, tolerations, sidecars, volumeMounts, volumes |
| `geoip/deployment-geoip-job.yaml` | nodeSelector, tolerations, sidecars, volumes |
| `cleanerfs/cronjob-cleanerfs.yaml` | sidecars, volumes |
| `symbolicator/statefulset-symbolicator.yaml` | sidecars, volumes |
| `snuba/cleanup/cronjob-clickhouse-cleanup.yaml` | volumeMounts |

### Behavior

Follows the existing chart-wide pattern:
- **nodeSelector / tolerations**: component-specific value takes precedence; falls back to global if unset (`if`/`else if`)
- **sidecars / volumeMounts / volumes**: component-specific and global values are additive (both rendered)

### Testing

- `helm template` validates all six templates render correctly with globals set, with local overrides, and with default empty values
- No changes to existing behavior for templates that already respected these globals