### PR TITLE
feat: allow to skip nodestore install via init container

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -792,7 +792,7 @@ sentry.conf.py: |-
 Init container for installing sentry-nodestore-s3 package
 */}}
 {{- define "sentry.initContainer.nodestore-s3" -}}
-{{- if .Values.nodestore.backend }}
+{{- if and .Values.nodestore.backend .Values.nodestore.installViaInitContainer }}
 - name: install-nodestore-s3
   image: "{{ template "sentry.image" . }}"
   imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
@@ -815,7 +815,7 @@ Init container for installing sentry-nodestore-s3 package
 Volume definition for sentry plugins
 */}}
 {{- define "sentry.volume.nodestore-s3" -}}
-{{- if .Values.nodestore.backend }}
+{{- if and .Values.nodestore.backend .Values.nodestore.installViaInitContainer }}
 - name: sentry-plugins
   emptyDir: {}
 {{- end }}
@@ -825,7 +825,7 @@ Volume definition for sentry plugins
 Volume mount for sentry plugins
 */}}
 {{- define "sentry.volumeMount.nodestore-s3" -}}
-{{- if .Values.nodestore.backend }}
+{{- if and .Values.nodestore.backend .Values.nodestore.installViaInitContainer }}
 - name: sentry-plugins
   mountPath: /sentry-plugins
 {{- end }}
@@ -862,8 +862,10 @@ Environment variable for Python path to include plugins
 */}}
 {{- define "sentry.env.nodestore-s3" -}}
 {{- if .Values.nodestore.backend }}
+{{- if .Values.nodestore.installViaInitContainer }}
 - name: PYTHONPATH
   value: "/sentry-plugins"
+{{- end }}
 {{- if .Values.nodestore.s3.setAwsChecksumCalculationVar }}
 - name: AWS_REQUEST_CHECKSUM_CALCULATION
   value: when_required

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2638,6 +2638,8 @@ nodestore:
   # Set to "s3" to enable S3-based node storage
   # When backend is empty (default), nodestore-s3 is NOT installed
   backend: ""
+  # Use init container to install nodestore-s3 package on startup. If false, you need to build a custom image with nodestore-s3 pre-installed.
+  installViaInitContainer: true
   # Optional environment variables for the init container that installs nodestore-s3
   initContainer:
     env: []


### PR DESCRIPTION
Currently, nodestore is downloaded and installed every time the Sentry component is restarted. This allow to skip install via initContainer (you should rebuild sentry image)

Closing https://github.com/sentry-kubernetes/charts/issues/2080