### PR TITLE
feat(sentry): add HPA for ingest-occurrences consumer

### DIFF
--- a/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
@@ -1,0 +1,60 @@
+{{- if has "feature-complete" .Values.profiles }}
+{{- if and .Values.sentry.ingestOccurrences.enabled .Values.sentry.ingestOccurrences.autoscaling.enabled }}
+apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "sentry.fullname" . }}-sentry-ingest-occurrences
+  labels:
+    {{- include "sentry.component.labels" (dict "component" "ingest-occurrences" "ctx" .) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" . }}-ingest-occurrences
+  minReplicas: {{ .Values.sentry.ingestOccurrences.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.sentry.ingestOccurrences.autoscaling.maxReplicas }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v1" }}
+  targetCPUUtilizationPercentage: {{ .Values.sentry.ingestOccurrences.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion }}
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-occurrences
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestOccurrences.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestOccurrences.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .Chart.Name }}-ingest-occurrences
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestOccurrences.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- else }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestOccurrences.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.sentry.ingestOccurrences.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.sentry.ingestOccurrences.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+  {{- if eq (include "sentry.autoscaling.apiVersion" .) "autoscaling/v2" }}
+  {{- with .Values.sentry.ingestOccurrences.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Add HorizontalPodAutoscaler template for the `ingest-occurrences` consumer, following the same pattern as other ingest consumer HPAs (events, transactions, attachments)
- The autoscaling configuration already exists in `values.yaml` under `sentry.ingestOccurrences.autoscaling` — this adds the missing HPA template to make it functional

## Changes
- `charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml` (new)
