### PR TITLE
fix: volumeMounts on deployment-uptime-checker and db-check-job

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -168,13 +168,16 @@ spec:
               fi
             done
             echo "Kafka is up"
-{{- if .Values.hooks.dbCheck.volumeMounts }}
+            
+{{- if or .Values.hooks.dbCheck.volumeMounts .Values.global.volumeMounts }}
         volumeMounts:
+{{- if .Values.hooks.dbCheck.volumeMounts }}
 {{ toYaml .Values.hooks.dbCheck.volumeMounts | indent 8 }}
 {{- end }}
 {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 8 }}
 {{- end }}
+{{- end}}
         env:
 {{- if .Values.hooks.dbCheck.env }}
 {{ toYaml .Values.hooks.dbCheck.env | indent 8 }}

--- a/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
@@ -93,11 +93,14 @@ spec:
 {{- if .Values.uptimeChecker.env }}
 {{ toYaml .Values.uptimeChecker.env | indent 8 }}
 {{- end }}
+{{- if or .Values.uptimeChecker.volumeMounts .Values.global.volumeMounts }}
+        volumeMounts:
 {{- if .Values.uptimeChecker.volumeMounts }}
 {{ toYaml .Values.uptimeChecker.volumeMounts | indent 8 }}
 {{- end }}
 {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
 {{- end }}
         resources:
 {{ toYaml .Values.uptimeChecker.resources | indent 12 }}
@@ -114,6 +117,7 @@ spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}-uptime-checker
       {{- end }}
+{{- if or .Values.uptimeChecker.volumes .Values.global.volumes }}
       volumes:
 {{- if .Values.uptimeChecker.volumes }}
 {{ toYaml .Values.uptimeChecker.volumes | indent 6 }}
@@ -121,6 +125,7 @@ spec:
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}
 {{- end }}
+{{- end}}
       {{- if .Values.uptimeChecker.priorityClassName }}
       priorityClassName: "{{ .Values.uptimeChecker.priorityClassName }}"
       {{- end }}


### PR DESCRIPTION
` volumeMounts:` was missing in deployment-uptime-checker.yaml