### PR TITLE
Include user to securityContext as sane default for symbolicator

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2209,7 +2209,10 @@ symbolicator:
     resources: {}
     affinity: {}
     nodeSelector: {}
-    securityContext: {}
+    securityContext:
+      fsGroup: 65532
+      runAsGroup: 65532
+      runAsUser: 65532
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
@@ -2221,7 +2224,7 @@ symbolicator:
       bind: "0.0.0.0:3021"
       logging:
         level: "warn"
-      metrics:
+      merics:
         statsd: null
         prefix: "symbolicator"
       sentry_dsn: null


### PR DESCRIPTION
Fixes #2117

Now deploying symbolicator with enabled true gives you a crashloopbackoff on the symbolicator.