### PR TITLE
fix: correctly capture sentry createuser exit code in user-create hook

### DIFF
--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -89,11 +89,12 @@ spec:
               --no-input \
               --superuser \
               --email "{{ .Values.user.email }}" \
-              --password "$ADMIN_PASSWORD" || true; \
-            if [ $? -eq 0 ] || [ $? -eq 3 ]; then \
-              exit 0; \
-            else \
-              exit 1; \
+              --password "$ADMIN_PASSWORD"
+            exit_code=$?
+            if [ $exit_code -eq 0 ] || [ $exit_code -eq 3 ]; then
+              exit 0
+            else
+              exit $exit_code
             fi
         env:
 {{ include "sentry.env" . | indent 8 }}


### PR DESCRIPTION
The previous code used `|| true`, which reset `$?` to 0 before it could
be checked, making the exit code guard a no-op. Capture the exit code
immediately after the command and propagate the actual code on failure.
Without this fix, any non-zero exit code from sentry createuser (other than 3)
would silently be treated as success, masking failures.
