### PR TITLE
fix(snuba): emit JSON booleans for ClickHouse secure/verify

### DIFF
--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -36,9 +36,9 @@ settings.py: |
     {
       "host": env("CLICKHOUSE_HOST", {{ include "sentry.clickhouse.host" . | quote }}),
       "port": int({{ include "sentry.clickhouse.port" . }}),
-      "secure": env("CLICKHOUSE_SECURE", False),
+      "secure": env("CLICKHOUSE_SECURE", "False").lower() in ("1", "true"),
       "ca_certs": env("CLICKHOUSE_CA_CERTS", None),
-      "verify": env("CLICKHOUSE_VERIFY", False),
+      "verify": env("CLICKHOUSE_VERIFY", "False").lower() in ("1", "true"),
       "user":  env("CLICKHOUSE_USER", "default"),
       "password": env("CLICKHOUSE_PASSWORD", ""),
       "max_connections": int(os.environ.get("CLICKHOUSE_MAX_CONNECTIONS", 100)),


### PR DESCRIPTION
### Summary

Fix Snuba cluster settings so `secure` and `verify` are real JSON booleans in the generated config, not Python string literals like `"True"`. That matches what Snuba’s rust-consumer expects and avoids `CrashLoopBackOff` when using external ClickHouse with TLS.

### Problem

With `externalClickhouse.secure: true` (and optionally `verify: true`), Snuba consumers can fail during rust-consumer config load with:

`invalid type: string "True", expected a boolean`

See [sentry-kubernetes/charts#2122](https://github.com/sentry-kubernetes/charts/issues/2122).

### Solution

Adjust `charts/sentry/templates/snuba/_helper-snuba.tpl` so the embedded cluster config uses values that deserialize as booleans in JSON (for example `true` / `false`), instead of values that end up as the string `"True"` / `"False"`.

### Testing

- [x] `helm template` (or equivalent) for a release with `externalClickhouse.secure: true` and confirm the rendered Snuba settings contain JSON booleans for `secure` / `verify`.
- [x] Deploy / smoke: Snuba rust-consumer pods (for example `sentry-snuba-eap-items-consumer`) start without the deserialization panic.

### Related

Fixes [sentry-kubernetes/charts#2122](https://github.com/sentry-kubernetes/charts/issues/2122).


```
k get pod -n test
NAME                                                              READY   STATUS    RESTARTS      AGE
sentry-billing-metrics-consumer-5ddbf75888-gvd48                  1/1     Running   0             16m
sentry-generic-metrics-consumer-69c6bbdbcd-c729c                  1/1     Running   0             16m
sentry-ingest-consumer-attachments-6669567b58-mtnzg               1/1     Running   0             16m
sentry-ingest-consumer-events-587c8fb768-kch6r                    1/1     Running   0             16m
sentry-ingest-consumer-transactions-7dfc49d496-k7bz5              1/1     Running   0             16m
sentry-ingest-feedback-68bd7fb594-ggnvm                           1/1     Running   0             16m
sentry-ingest-monitors-7d9b74f8fd-mzqpw                           1/1     Running   0             16m
sentry-ingest-occurrences-65d6fb4875-gbnsm                        1/1     Running   0             15m
sentry-ingest-replay-recordings-b99496b5f-58qst                   1/1     Running   0             15m
sentry-issue-occurrence-consumer-65fbb7f4c6-g6dp6                 1/1     Running   0             15m
sentry-kafka-controller-0                                         1/1     Running   0             46m
sentry-kafka-controller-1                                         1/1     Running   1 (43m ago)   46m
sentry-kafka-controller-2                                         1/1     Running   0             46m
sentry-metrics-consumer-646fff967d-rhrdd                          1/1     Running   0             15m
sentry-monitors-clock-tasks-85467b6547-x74xw                      1/1     Running   0             15m
sentry-monitors-clock-tick-59cd6c6556-ll2rt                       1/1     Running   0             15m
sentry-post-process-forward-errors-68d8c89fc5-cfv75               1/1     Running   0             15m
sentry-post-process-forward-issue-platform-c5cc567cb-52ksr        1/1     Running   0             15m
sentry-post-process-forward-transactions-5bb6ff79fd-httmt         1/1     Running   0             15m
sentry-process-segments-7fd4576685-2fph5                          1/1     Running   0             15m
sentry-process-spans-75bfccb4b4-pg9mf                             1/1     Running   0             15m
sentry-relay-5dbcd4697b-ljglz                                     1/1     Running   0             15m
sentry-sentry-postgresql-0                                        1/1     Running   0             46m
sentry-sentry-redis-master-0                                      1/1     Running   0             46m
sentry-sentry-redis-replicas-0                                    1/1     Running   6 (40m ago)   46m
sentry-snuba-api-85797884dd-78mq8                                 1/1     Running   0             46m
sentry-snuba-consumer-57875cd7c6-4vx6r                            1/1     Running   0             15m
sentry-snuba-eap-items-consumer-84cbf9d7b6-x9485                  1/1     Running   1 (15m ago)   15m
sentry-snuba-generic-metrics-counters-consumer-78dc9696bb-bdkm8   1/1     Running   0             15m
sentry-snuba-generic-metrics-distributions-consumer-6959f4w6snt   1/1     Running   0             15m
sentry-snuba-generic-metrics-gauges-consumer-654549d5cb-tmd6b     1/1     Running   0             15m
sentry-snuba-generic-metrics-sets-consumer-558865f4c4-qzphz       1/1     Running   0             15m
sentry-snuba-group-attributes-consumer-7b67dfcd54-jjc5x           1/1     Running   0             15m
sentry-snuba-metrics-consumer-5cdfb7c7fc-nlf7l                    1/1     Running   0             15m
sentry-snuba-outcomes-billing-consumer-66c9845957-rtl46           1/1     Running   0             15m
sentry-snuba-outcomes-consumer-57f8b87845-wf7rb                   1/1     Running   0             15m
sentry-snuba-replacer-77988ff95-9k9v8                             1/1     Running   0             15m
sentry-snuba-replays-consumer-7cd6547484-sdvj9                    1/1     Running   0             15m
sentry-snuba-subscription-consumer-eap-items-57f79567ff-bkrvk     1/1     Running   0             15m
sentry-snuba-subscription-consumer-events-6dfbc6cbd6-qlngg        1/1     Running   0             15m
sentry-snuba-subscription-consumer-generic-metrics-countert7k5g   1/1     Running   0             15m
sentry-snuba-subscription-consumer-generic-metrics-distribch27w   1/1     Running   0             15m
sentry-snuba-subscription-consumer-generic-metrics-gauges-k2bgs   1/1     Running   0             15m
sentry-snuba-subscription-consumer-generic-metrics-sets-5fhdtgz   1/1     Running   0             15m
sentry-snuba-subscription-consumer-metrics-f9dfcc4bf-8cv7v        1/1     Running   0             15m
sentry-snuba-subscription-consumer-transactions-6f678fd8fbzcdg2   1/1     Running   0             15m
sentry-snuba-transactions-consumer-57678659f4-bsfww               1/1     Running   0             15m
sentry-subscription-consumer-events-685b4b5fcd-jfhsv              1/1     Running   0             15m
sentry-subscription-consumer-generic-metrics-84c5cf9569-q89lk     1/1     Running   0             15m
sentry-subscription-consumer-metrics-7cd9b4f7d5-6q8v8             1/1     Running   0             15m
sentry-subscription-consumer-results-eap-items-64d8944f68-rdlj9   1/1     Running   0             15m
sentry-subscription-consumer-transactions-5c96b8f6d6-wk8v8        1/1     Running   0             15m
sentry-symbolicator-api-0                                         2/2     Running   0             46m
sentry-taskbroker-default-0                                       1/1     Running   3 (40m ago)   46m
sentry-taskbroker-ingest-0                                        1/1     Running   9 (25m ago)   46m
sentry-taskbroker-long-0                                          1/1     Running   6 (37m ago)   46m
sentry-taskbroker-products-0                                      1/1     Running   5 (40m ago)   46m
sentry-taskscheduler-7c96c5dcf4-zgb8p                             1/1     Running   5 (41m ago)   46m
sentry-taskworker-default-66b9dcbd79-m64vq                        1/1     Running   6 (41m ago)   46m
sentry-taskworker-ingest-8456dd8f69-zvmx5                         1/1     Running   6 (41m ago)   46m
sentry-taskworker-long-84bb9f6dbf-tg6h2                           1/1     Running   5 (41m ago)   46m
sentry-taskworker-products-766bb66bc7-swvhv                       1/1     Running   2 (40m ago)   46m
sentry-uptime-results-598bbcb754-4wzrr                            1/1     Running   0             15m
sentry-web-f9ff6bc95-2fbml                                        1/1     Running   6 (41m ago)   46m
```