### PR TITLE
feat(taskworker): add maxChildTaskCount value to prevent OOMKill from memory growth

### DIFF
--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -106,6 +106,10 @@ spec:
           - "--rpc-host={{ template "sentry.fullname" $root }}-taskbroker-{{ $worker.brokerName }}:50051"
           - "--num-brokers={{ default $root.Values.sentry.taskBroker.replicas $worker.brokerReplicas }}"
           - "--health-check-file-path=/tmp/health.txt"
+          {{- $maxChildTaskCount := default $root.Values.sentry.taskWorker.maxChildTaskCount $worker.maxChildTaskCount }}
+          {{- if $maxChildTaskCount }}
+          - "--max-child-task-count={{ $maxChildTaskCount }}"
+          {{- end }}
         env:
         - name: C_FORCE_ROOT
           value: "true"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -424,6 +424,9 @@ sentry:
     enabled: true
     replicas: 1
     concurrency: 4
+    # maxChildTaskCount -- Number of tasks child processes execute before restarting.
+    # Helps prevent memory growth over time. See: https://github.com/getsentry/self-hosted/pull/4279
+    maxChildTaskCount: ~
     autoscaling:
       enabled: false
       minReplicas: 1


### PR DESCRIPTION
## Problem

Taskworker child processes accumulate memory over time leading to OOMKill. This is a known issue reported in [getsentry/self-hosted#4265](https://github.com/getsentry/self-hosted/issues/4265).

The Sentry CLI already supports `--max-child-task-count` which restarts child processes after N tasks, preventing memory from growing unboundedly.

## Solution

Adds `maxChildTaskCount` field to `taskWorker` values (and per-worker override via `workers[].maxChildTaskCount`), passed as `--max-child-task-count` to the taskworker command.

The flag is optional — if not set, behaviour is unchanged.

## Usage

```yaml
sentry:
  taskWorker:
    maxChildTaskCount: 10000
```

Or per-worker:

```yaml
sentry:
  taskWorker:
    workers:
      - name: ingest
        brokerName: ingest
        maxChildTaskCount: 5000
```

## References

- Fix applied to self-hosted docker-compose: https://github.com/getsentry/self-hosted/pull/4279
- Issue: https://github.com/getsentry/self-hosted/issues/4265