### PR TITLE
fix(taskworker): extend liveness probe initial delay to prevent CrashLoopBackOff (#2128)

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -448,7 +448,7 @@ sentry:
     priorityClassName: ""
     tolerations: []
     livenessProbe:
-      initialDelaySeconds: 10
+      initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 5
     # workers[].resources -- Optional per-worker container resources; merged over taskWorker.resources (worker keys win).


### PR DESCRIPTION
## Summary

Increase `taskWorker.livenessProbe.initialDelaySeconds` from `10` to `30` to prevent `CrashLoopBackOff` on taskworker pods.

## Problem Description

Pods `sentry-taskworker-default` and `sentry-taskworker-products` were stuck in `CrashLoopBackOff`, restarting indefinitely after ~40 seconds of runtime.

| Pod | Status | Restarts |
|-----|--------|----------|
| `sentry-taskworker-default-*` | **CrashLoopBackOff** | 12+ |
| `sentry-taskworker-products-*` | **CrashLoopBackOff** | 11+ |

Other taskworkers (`ingest`, `long`) also experienced initial restarts but occasionally stabilized, while `default` and `products` never recovered.

## Root Cause

The taskworker container uses a file-based liveness probe:

```yaml
livenessProbe:
  exec:
    command:
      - rm
      - /tmp/health.txt
```

The container starts with `--health-check-file-path=/tmp/health.txt`, which *should* create this file during initialization, but in practice the file is created too late (or never in time).

With the previous settings:
- `initialDelaySeconds: 10`
- `periodSeconds: 10`
- `failureThreshold: 3`

…the container was killed after only **~40 seconds** (`10 + 3 × 10 = 40s`), which was not enough for the worker to fully initialize and create the health check file.

Kubelet events confirmed the failure:

```
Liveness probe failed: rm: cannot remove '/tmp/health.txt': No such file or directory
```

## Fix

Increase `initialDelaySeconds` from `10` to `30` in the `sentry.taskWorker.livenessProbe` block in `values.yaml`.

This gives taskworker containers sufficient time to:
1. Connect to the taskbroker gRPC endpoint
2. Spawn child worker processes
3. Create the `/tmp/health.txt` health check file

**Changed file:** `charts/sentry/values.yaml`

```diff
   taskWorker:
     ...
     livenessProbe:
-      initialDelaySeconds: 10
+      initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 5
```

## Related Issue

Fixes #2128
