### PR TITLE
fix: add topic scheduled-subscriptions-eap-items

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2913,6 +2913,7 @@ kafka:
       - name: snuba-dead-letter-generic-events
       - name: snuba-dead-letter-querylog
       - name: snuba-dead-letter-group-attributes
+      - name: snuba-dead-letter-items
       - name: ingest-attachments
       - name: ingest-attachments-dlq
       - name: ingest-transactions
@@ -2937,11 +2938,13 @@ kafka:
       - name: snuba-spans
       - name: snuba-eap-spans-commit-log
       - name: scheduled-subscriptions-eap-spans
+      - name: scheduled-subscriptions-eap-items
       - name: eap-spans-subscription-results
       - name: subscription-results-eap-items
       - name: snuba-items-commit-log
       - name: snuba-eap-mutations
       - name: snuba-lw-deletions-generic-events
+      - name: snuba-lw-deletions-eap-items
       - name: shared-resources-usage
       - name: snuba-profile-chunks
       - name: buffered-segments


### PR DESCRIPTION
## Summary

Fixes #2132

Adds three missing Kafka topics to the provisioning list so they are created by the main `sentry-kafka-provisioning` Job instead of being auto-created later by Snuba components with `replicationFactor: 1`.

## Problem

When installing the Sentry Helm chart with `kafka.provisioning.replicationFactor: 3` (or `externalKafka.provisioning.replicationFactor: 3`), most topics are created correctly with RF=3. However, the following three topics are **not** present in the provisioning list and are therefore created on-demand by Snuba consumers / schedulers with hardcoded or default `replicationFactor: 1`:

- `scheduled-subscriptions-eap-items`
- `snuba-dead-letter-items`
- `snuba-lw-deletions-eap-items`

This leads to:
- Reduced fault tolerance — if the single broker hosting these partitions fails, the topics become completely unavailable.
- Violation of the operator's expectation that `replicationFactor: 3` applies to **all** Sentry topics.

## Solution

Add the three missing topics to `kafka.provisioning.topics` in `charts/sentry/values.yaml`. Since the provisioning Job uses the global `replicationFactor` setting, these topics will now be created with the same replication factor as all other provisioned topics.
