### PR TITLE
feat(taskbroker): inject TASKBROKER_KAFKA_SASL_* env vars when using external Kafka

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -686,6 +686,83 @@ Set external Clickhouse password from existingSecret
   value: http://{{ template "sentry.fullname" . }}-snuba:{{ template "snuba.port" . }}
 {{- end -}}
 
+{{/*
+TaskBroker Kafka environment variables.
+The TaskBroker binary (Rust) reads Kafka config from TASKBROKER_KAFKA_* prefixed env vars,
+not the standard KAFKA_SASL_* vars used by Python-based Sentry/Snuba components.
+This helper auto-injects the required TASKBROKER_KAFKA_* and TASKBROKER_KAFKA_DEADLETTER_*
+env vars when externalKafka is configured with SASL authentication.
+See: https://github.com/sentry-kubernetes/charts/issues/2088
+*/}}
+{{- define "sentry.taskbroker.kafka.env" -}}
+{{- if not .Values.kafka.enabled }}
+{{- $securityProtocol := include "sentry.kafka.security_protocol" . -}}
+{{- $bootstrapServers := include "sentry.kafka.bootstrap_servers_string" . -}}
+- name: TASKBROKER_KAFKA_SECURITY_PROTOCOL
+  value: {{ $securityProtocol | quote }}
+- name: TASKBROKER_KAFKA_DEADLETTER_CLUSTER
+  value: {{ $bootstrapServers | quote }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SECURITY_PROTOCOL
+  value: {{ $securityProtocol | quote }}
+{{- if regexMatch "^SASL_" $securityProtocol }}
+{{- if .Values.externalKafka.sasl.existingSecret }}
+- name: TASKBROKER_KAFKA_SASL_MECHANISM
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "mechanism" .Values.externalKafka.sasl.existingSecretKeys.mechanism }}
+- name: TASKBROKER_KAFKA_SASL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "username" .Values.externalKafka.sasl.existingSecretKeys.username }}
+- name: TASKBROKER_KAFKA_SASL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SASL_MECHANISM
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "mechanism" .Values.externalKafka.sasl.existingSecretKeys.mechanism }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SASL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "username" .Values.externalKafka.sasl.existingSecretKeys.username }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SASL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
+{{- else }}
+{{- $saslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
+{{- $saslUsername := include "sentry.kafka.sasl_username" . -}}
+{{- $saslPassword := include "sentry.kafka.sasl_password" . -}}
+{{- if not (eq "None" $saslMechanism) }}
+- name: TASKBROKER_KAFKA_SASL_MECHANISM
+  value: {{ $saslMechanism | quote }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SASL_MECHANISM
+  value: {{ $saslMechanism | quote }}
+{{- end }}
+{{- if not (eq "None" $saslUsername) }}
+- name: TASKBROKER_KAFKA_SASL_USERNAME
+  value: {{ $saslUsername | quote }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SASL_USERNAME
+  value: {{ $saslUsername | quote }}
+{{- end }}
+{{- if not (eq "None" $saslPassword) }}
+- name: TASKBROKER_KAFKA_SASL_PASSWORD
+  value: {{ $saslPassword | quote }}
+- name: TASKBROKER_KAFKA_DEADLETTER_SASL_PASSWORD
+  value: {{ $saslPassword | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "uptimeChecker.env" -}}
 - name: UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -96,6 +96,7 @@ spec:
         - name: TASKBROKER_KAFKA_CLUSTER
           value: {{ include "sentry.kafka.bootstrap_servers_string" $root | quote }}
 {{ include "sentry.env" $root | indent 8 }}
+{{ include "sentry.taskbroker.kafka.env" $root | indent 8 }}
 {{- if $root.Values.sentry.taskBroker.env }}
 {{ toYaml $root.Values.sentry.taskBroker.env | indent 8 }}
 {{- end }}


### PR DESCRIPTION
## Summary

The TaskBroker component (written in Rust) uses its own `TASKBROKER_KAFKA_*` prefixed environment variables for Kafka configuration, unlike the Python-based Sentry/Snuba components that use `KAFKA_SASL_*`. When an external Kafka cluster with SASL authentication is configured, TaskBroker fails to authenticate because the required `TASKBROKER_KAFKA_*` env vars are never set.

This PR adds a new Helm template helper `sentry.taskbroker.kafka.env` that automatically injects the correct `TASKBROKER_KAFKA_*` and `TASKBROKER_KAFKA_DEADLETTER_*` environment variables into the TaskBroker StatefulSet when external Kafka is enabled.

## Changes

### `templates/_helper.tpl`
- Added the `sentry.taskbroker.kafka.env` template helper that:
  - Only activates when the built-in Kafka is disabled (`kafka.enabled: false`), i.e. an external Kafka cluster is in use
  - Sets `TASKBROKER_KAFKA_SECURITY_PROTOCOL` and `TASKBROKER_KAFKA_DEADLETTER_SECURITY_PROTOCOL` from the configured security protocol
  - Sets `TASKBROKER_KAFKA_DEADLETTER_CLUSTER` to the external bootstrap servers
  - When the security protocol starts with `SASL_`:
    - If `externalKafka.sasl.existingSecret` is set, reads SASL mechanism, username, and password from the referenced Kubernetes Secret (for both the main cluster and deadletter)
    - Otherwise, injects SASL mechanism, username, and password directly from `values.yaml` (for both the main cluster and deadletter)

### `templates/sentry/taskbroker/statefulset-taskbroker.yaml`
- Included the new `sentry.taskbroker.kafka.env` helper in the TaskBroker container's environment variables

## How it works

The helper reuses the existing shared Kafka helpers (`sentry.kafka.security_protocol`, `sentry.kafka.sasl_mechanism`, etc.) to derive values, then maps them to the `TASKBROKER_KAFKA_*` naming convention that the Rust-based TaskBroker binary expects. This ensures consistency with the rest of the chart while accommodating TaskBroker's different env var prefix requirement.

The deadletter cluster configuration mirrors the main cluster configuration, as both point to the same external Kafka instance.

values:
```
externalKafka:
  cluster:
    - host: "rc1a-xxxxxx.mdb.yandexcloud.net"
      port: 9092
    - host: "rc1b-xxxxx.mdb.yandexcloud.net"
      port: 9092
    - host: "rc1d-xxxxx.mdb.yandexcloud.net"
      port: 9092
  sasl:
    mechanism: "SCRAM-SHA-512"
    username: "sentry"
    password: "xxxxx"
  security:
    protocol: "SASL_PLAINTEXT"
  provisioning:
    enabled: true
    replicationFactor: 3
    numPartitions: 1
```

env:
```
kubectl get pod sentry-taskbroker-long-0 -n sentry -o jsonpath='{range .spec.containers[*]}Container: {.name}{"\n"}{range .env[*]}  {.name}={.value}{"\n"}{end}{"\n"}{end}'
Container: taskbroker
  TASKBROKER_KAFKA_TOPIC=taskworker-long
  TASKBROKER_KAFKA_CONSUMER_GROUP=taskworker-long
  TASKBROKER_DB_PATH=/opt/sqlite/taskbroker-activations.sqlite
  TASKBROKER_KAFKA_CLUSTER=rc1a-xxx.mdb.yandexcloud.net:9092,rc1b-xxx.mdb.yandexcloud.net:9092,rc1d-xxxx.mdb.yandexcloud.net:9092
  SNUBA=http://sentry-snuba:1218
  VROOM=http://sentry-vroom:8085
  SENTRY_SECRET_KEY=
  POSTGRES_PASSWORD=
  POSTGRES_USER=postgres
  POSTGRES_NAME=sentry
  POSTGRES_HOST=sentry-sentry-postgresql
  POSTGRES_PORT=5432
  TASKBROKER_KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
  TASKBROKER_KAFKA_DEADLETTER_CLUSTER=rc1a-xxxx.mdb.yandexcloud.net:9092,rc1b-xxxx.mdb.yandexcloud.net:9092,rc1d-xxx.mdb.yandexcloud.net:9092
  TASKBROKER_KAFKA_DEADLETTER_SECURITY_PROTOCOL=SASL_PLAINTEXT
  TASKBROKER_KAFKA_SASL_MECHANISM=SCRAM-SHA-512
  TASKBROKER_KAFKA_DEADLETTER_SASL_MECHANISM=SCRAM-SHA-512
  TASKBROKER_KAFKA_SASL_USERNAME=sentry
  TASKBROKER_KAFKA_DEADLETTER_SASL_USERNAME=sentry
  TASKBROKER_KAFKA_SASL_PASSWORD=xxxxx
  TASKBROKER_KAFKA_DEADLETTER_SASL_PASSWORD=xxxxxx
```

pods:
```
k get pod -n sentry
NAME                                                              READY   STATUS      RESTARTS      AGE
sentry-billing-metrics-consumer-64b8cfd6cc-4g69w                  1/1     Running     0             13m
sentry-generic-metrics-consumer-68fd7c4cf5-fvrs9                  1/1     Running     0             13m
sentry-ingest-consumer-attachments-6ddbf767c9-9pk7j               1/1     Running     0             13m
sentry-ingest-consumer-events-dbccb5779-glstv                     1/1     Running     0             13m
sentry-ingest-consumer-transactions-854cc5c4b7-kf8kx              1/1     Running     0             13m
sentry-ingest-feedback-f564699f9-8jplk                            1/1     Running     0             13m
sentry-ingest-monitors-5b8777bbbc-j5vs9                           1/1     Running     0             13m
sentry-ingest-occurrences-5ffcd89f4d-6h55l                        1/1     Running     0             13m
sentry-ingest-replay-recordings-99cd7dc48-sb6zb                   1/1     Running     0             13m
sentry-issue-occurrence-consumer-fcdb76b8c-4sn4b                  1/1     Running     0             13m
sentry-kafka-provisioning-fs9sj                                   0/1     Completed   0             56m
sentry-metrics-consumer-66c464bb7-vcdzm                           1/1     Running     0             13m
sentry-monitors-clock-tasks-55b44bb8-rtw4g                        1/1     Running     0             13m
sentry-monitors-clock-tick-84dd754749-dwrjc                       1/1     Running     0             13m
sentry-post-process-forward-errors-85d5885778-9sgtm               1/1     Running     0             13m
sentry-post-process-forward-issue-platform-777dbd4d8f-sdcmm       1/1     Running     0             13m
sentry-post-process-forward-transactions-7456759bcf-w2p2q         1/1     Running     0             13m
sentry-process-segments-66dc9f56d-xtvql                           1/1     Running     0             13m
sentry-process-spans-67569856f9-mn9q6                             1/1     Running     0             13m
sentry-relay-5dcd65d654-kqbzk                                     1/1     Running     0             13m
sentry-sentry-postgresql-0                                        1/1     Running     0             29m
sentry-sentry-redis-master-0                                      1/1     Running     0             29m
sentry-sentry-redis-replicas-0                                    1/1     Running     0             29m
sentry-snuba-api-669cbdbff5-vtcmj                                 1/1     Running     0             29m
sentry-snuba-consumer-5f5cb857fc-vnsr9                            1/1     Running     0             13m
sentry-snuba-eap-items-consumer-59ddb8c46c-vb2m9                  1/1     Running     0             13m
sentry-snuba-generic-metrics-counters-consumer-7cc4586c4c-tqfd8   1/1     Running     0             13m
sentry-snuba-generic-metrics-distributions-consumer-79bb45fgk5t   1/1     Running     0             13m
sentry-snuba-generic-metrics-gauges-consumer-876f6ffb5-qm497      1/1     Running     0             13m
sentry-snuba-generic-metrics-sets-consumer-b4b5f4b55-wdnd8        1/1     Running     0             13m
sentry-snuba-group-attributes-consumer-7c598b9d67-phdll           1/1     Running     0             13m
sentry-snuba-metrics-consumer-6cf7d46676-xp6fq                    1/1     Running     0             13m
sentry-snuba-outcomes-billing-consumer-5b76dc4db8-m6prd           1/1     Running     0             13m
sentry-snuba-outcomes-consumer-6b49bd6b5b-9pbq6                   1/1     Running     0             13m
sentry-snuba-replacer-6849785c8d-t986k                            1/1     Running     0             13m
sentry-snuba-replays-consumer-644fb4fdb9-7lb8r                    1/1     Running     0             13m
sentry-snuba-subscription-consumer-eap-items-5b544dc8dd-9vm25     1/1     Running     0             13m
sentry-snuba-subscription-consumer-events-76bddc865f-mbmj8        1/1     Running     0             13m
sentry-snuba-subscription-consumer-generic-metrics-counterb2wgg   1/1     Running     0             13m
sentry-snuba-subscription-consumer-generic-metrics-distribxjl6p   1/1     Running     0             13m
sentry-snuba-subscription-consumer-generic-metrics-gauges-d75hq   1/1     Running     0             13m
sentry-snuba-subscription-consumer-generic-metrics-sets-66qkqv9   1/1     Running     0             13m
sentry-snuba-subscription-consumer-metrics-6b948fd68-ldxnc        1/1     Running     0             13m
sentry-snuba-subscription-consumer-transactions-5f5584cf79kj22s   1/1     Running     0             13m
sentry-snuba-transactions-consumer-799c5f6499-swfb2               1/1     Running     0             13m
sentry-subscription-consumer-events-dfc674cff-nn7jx               1/1     Running     0             13m
sentry-subscription-consumer-generic-metrics-6cf756ff48-rdqck     1/1     Running     0             13m
sentry-subscription-consumer-metrics-6b6557f45b-p4lsw             1/1     Running     0             13m
sentry-subscription-consumer-results-eap-items-5c5b6ff6d7-xpv5k   1/1     Running     0             13m
sentry-subscription-consumer-transactions-7bb4c879d7-r4fp9        1/1     Running     0             13m
sentry-symbolicator-api-0                                         2/2     Running     0             29m
sentry-taskbroker-default-0                                       1/1     Running     0             29m
sentry-taskbroker-ingest-0                                        1/1     Running     0             29m
sentry-taskbroker-long-0                                          1/1     Running     0             29m
sentry-taskbroker-products-0                                      1/1     Running     0             29m
sentry-taskscheduler-59b8987bbf-ktfxz                             1/1     Running     1 (28m ago)   29m
sentry-taskworker-default-7bd5cd668c-ztp7v                        1/1     Running     1 (28m ago)   29m
sentry-taskworker-ingest-56466cd9f9-5smpz                         1/1     Running     2 (27m ago)   29m
sentry-taskworker-long-75948c547-v8p2m                            1/1     Running     2 (27m ago)   29m
sentry-taskworker-products-56d59449dc-mqvll                       1/1     Running     1 (28m ago)   29m
sentry-uptime-results-fd688d84f-ltbhq                             1/1     Running     0             13m
sentry-web-7746968564-gpl6m                                       1/1     Running     2 (26m ago)   29m
```