### PR TITLE
feat: upgrade to v26.4.0

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 30.3.0
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 26.2.1
+appVersion: 26.4.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -426,7 +426,6 @@ sentry.conf.py: |-
               "organizations:insights-initial-modules",
               "organizations:insights-addon-modules",
               "organizations:insights-modules-use-eap",
-              "organizations:standalone-span-ingestion",
               "organizations:starfish-mobile-appstart",
               "organizations:on-demand-metrics-extraction",
               "projects:span-metrics-extraction",

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -426,7 +426,7 @@ sentry:
     concurrency: 4
     # maxChildTaskCount -- Number of tasks child processes execute before restarting.
     # Helps prevent memory growth over time. See: https://github.com/getsentry/self-hosted/pull/4279
-    maxChildTaskCount: ~
+    maxChildTaskCount: 10000
     autoscaling:
       enabled: false
       minReplicas: 1


### PR DESCRIPTION
https://github.com/getsentry/self-hosted/compare/26.2.1...26.4.1

---

`taskWorker.maxChildTaskCount` now has a default value of `10000`: https://github.com/getsentry/self-hosted/commit/8811bbf91e7aa03af367f0ffdefa65667ed12770

I did not bump to `v26.4.1` because there is a small issue with Snuba consumers, it doesn't seems to affect normal operation but it will spam logs, see https://github.com/getsentry/self-hosted/issues/4306.