### PR TITLE
feat: move external kafka provisioning scripts from inline args to ConfigMap to avoid ARG_MAX limit

### DIFF
--- a/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
@@ -1,0 +1,134 @@
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.provisioning.enabled }}
+{{- $provisioning := .Values.externalKafka.provisioning }}
+{{- $sasl := .Values.externalKafka.sasl | default dict }}
+{{- $saslEnabled := and $sasl.mechanism (ne $sasl.mechanism "None") }}
+{{- $saslFromSecret := $sasl.existingSecret }}
+{{- $securityProtocol := .Values.externalKafka.security.protocol | default "PLAINTEXT" | upper }}
+
+{{/* Build bootstrap servers from cluster or host/port */}}
+{{- $brokers := list }}
+{{- if .Values.externalKafka.cluster }}
+{{- range .Values.externalKafka.cluster }}
+{{- $brokers = append $brokers (dict "host" .host "port" (int .port)) }}
+{{- end }}
+{{- else }}
+{{- $brokers = append $brokers (dict "host" .Values.externalKafka.host "port" (int .Values.externalKafka.port)) }}
+{{- end }}
+
+{{- $bootstrapServers := list }}
+{{- range $brokers }}
+{{- $bootstrapServers = append $bootstrapServers (printf "%s:%d" .host .port) }}
+{{- end }}
+{{- $bootstrapServersString := join "," $bootstrapServers }}
+
+{{/* Get topic list from externalKafka.provisioning.topics or fall back to kafka.provisioning.topics */}}
+{{- $topics := $provisioning.topics | default .Values.kafka.provisioning.topics }}
+{{- $replicationFactor := int ($provisioning.replicationFactor | default 1) }}
+{{- $defaultPartitions := int ($provisioning.numPartitions | default 1) }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-kafka-provisioning-scripts
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/component: kafka-provisioning
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
+data:
+  wait-for-kafka.sh: |
+    #!/bin/bash
+    set -ec
+    {{- range $brokers }}
+    timeout=120; until nc -z {{ .host }} {{ .port }} 2>/dev/null; do
+      timeout=$((timeout - 2)); [ $timeout -le 0 ] && echo "Timed out waiting for {{ .host }}:{{ .port }}" && exit 1;
+      sleep 2;
+    done;
+    {{- end }}
+    echo "Kafka is available";
+
+  provision.sh: |
+    #!/bin/bash
+    set -ec
+    export CLIENT_CONF="${CLIENT_CONF:-/tmp/client.properties}"
+    if [ ! -f "$CLIENT_CONF" ]; then
+      echo "security.protocol={{ $securityProtocol }}" > "$CLIENT_CONF"
+      {{- if $saslFromSecret }}
+      echo "sasl.mechanism=${KAFKA_SASL_MECHANISM}" >> "$CLIENT_CONF"
+      case "${KAFKA_SASL_MECHANISM}" in
+        PLAIN)
+          LOGIN_MODULE="org.apache.kafka.common.security.plain.PlainLoginModule"
+          ;;
+        *)
+          LOGIN_MODULE="org.apache.kafka.common.security.scram.ScramLoginModule"
+          ;;
+      esac
+      echo "sasl.jaas.config=${LOGIN_MODULE} required username=\"${KAFKA_SASL_USERNAME}\" password=\"${KAFKA_SASL_PASSWORD}\";" >> "$CLIENT_CONF"
+      {{- else if $saslEnabled }}
+      echo "sasl.mechanism={{ $sasl.mechanism }}" >> "$CLIENT_CONF"
+      {{- if and $sasl.username $sasl.password }}
+      {{- if eq $sasl.mechanism "PLAIN" }}
+      echo "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{ $sasl.username }}\" password=\"{{ $sasl.password }}\";" >> "$CLIENT_CONF"
+      {{- else }}
+      echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{{ $sasl.username }}\" password=\"{{ $sasl.password }}\";" >> "$CLIENT_CONF"
+      {{- end }}
+      {{- end }}
+      {{- end }}
+    fi
+
+    kafka_provisioning_commands=(
+      {{- range $topics }}
+      "/opt/kafka/bin/kafka-topics.sh \
+        --create \
+        --if-not-exists \
+        --bootstrap-server {{ $bootstrapServersString }} \
+        --replication-factor {{ $replicationFactor }} \
+        --partitions {{ .partitions | default $defaultPartitions }} \
+        {{- range $key, $value := .config }}
+        --config {{ $key }}={{ $value }} \
+        {{- end }}
+        --command-config ${CLIENT_CONF} \
+        --topic {{ .name }}"
+      {{- end }}
+    )
+
+    echo "Starting provisioning of ${#kafka_provisioning_commands[@]} topics"
+    for ((i=0; i < ${#kafka_provisioning_commands[@]}; i++)); do
+      ${kafka_provisioning_commands[i]}
+    done
+    echo "Provisioning succeeded"
+
+    COMMON_OPTS="--bootstrap-server {{ $bootstrapServersString }} --command-config ${CLIENT_CONF}"
+
+    echo "Checking existing topic partitions and configs..."
+    {{- range $topics }}
+    {{- $partitions := .partitions | default $defaultPartitions }}
+    CURRENT_PARTITIONS=$(/opt/kafka/bin/kafka-topics.sh $COMMON_OPTS --describe --topic "{{ .name }}" 2>/dev/null | head -1 | sed -n 's/.*PartitionCount: \([0-9]*\).*/\1/p')
+    if [ -n "$CURRENT_PARTITIONS" ] && [ "{{ $partitions }}" -gt "$CURRENT_PARTITIONS" ]; then
+      echo "  [ALTER] {{ .name }}: increasing partitions from $CURRENT_PARTITIONS to {{ $partitions }}"
+      /opt/kafka/bin/kafka-topics.sh $COMMON_OPTS --alter --topic "{{ .name }}" --partitions "{{ $partitions }}"
+    fi
+    {{- if .config }}
+    CURRENT_CONFIGS=$(/opt/kafka/bin/kafka-configs.sh $COMMON_OPTS --entity-type topics --entity-name "{{ .name }}" --describe 2>/dev/null || echo "")
+    NEEDS_UPDATE=false
+    {{- range $key, $value := .config }}
+    if ! echo "$CURRENT_CONFIGS" | grep -q '{{ $key }}={{ $value }}'; then
+      NEEDS_UPDATE=true
+    fi
+    {{- end }}
+    if [ "$NEEDS_UPDATE" = true ]; then
+      echo "  [CONFIG] {{ .name }}: applying config updates"
+      {{- $scratch := dict "args" (list) }}
+      {{- range $key, $value := .config }}
+      {{- $_ := set $scratch "args" (append (index $scratch "args") (printf "%s=[%s]" $key $value)) }}
+      {{- end }}
+      /opt/kafka/bin/kafka-configs.sh $COMMON_OPTS --entity-type topics --entity-name "{{ .name }}" --alter --add-config '{{ join "," (index $scratch "args") }}' || echo "  [CONFIG] {{ .name }}: WARNING - config update failed"
+    fi
+    {{- end }}
+    {{- end }}
+    echo "Update complete"
+{{- end }}

--- a/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
@@ -42,7 +42,7 @@ metadata:
 data:
   wait-for-kafka.sh: |
     #!/bin/bash
-    set -ec
+    set -e
     {{- range $brokers }}
     timeout=120; until nc -z {{ .host }} {{ .port }} 2>/dev/null; do
       timeout=$((timeout - 2)); [ $timeout -le 0 ] && echo "Timed out waiting for {{ .host }}:{{ .port }}" && exit 1;
@@ -53,7 +53,7 @@ data:
 
   provision.sh: |
     #!/bin/bash
-    set -ec
+    set -e
     export CLIENT_CONF="${CLIENT_CONF:-/tmp/client.properties}"
     if [ ! -f "$CLIENT_CONF" ]; then
       echo "security.protocol={{ $securityProtocol }}" > "$CLIENT_CONF"

--- a/charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml
@@ -1,11 +1,6 @@
 {{- if and (not .Values.kafka.enabled) .Values.externalKafka.provisioning.enabled }}
 {{- $provisioning := .Values.externalKafka.provisioning }}
-{{- $sasl := .Values.externalKafka.sasl | default dict }}
-{{- $saslEnabled := and $sasl.mechanism (ne $sasl.mechanism "None") }}
-{{- $saslFromSecret := $sasl.existingSecret }}
-{{- $securityProtocol := .Values.externalKafka.security.protocol | default "PLAINTEXT" | upper }}
 
-{{/* Build bootstrap servers from cluster or host/port */}}
 {{- $brokers := list }}
 {{- if .Values.externalKafka.cluster }}
 {{- range .Values.externalKafka.cluster }}
@@ -14,17 +9,6 @@
 {{- else }}
 {{- $brokers = append $brokers (dict "host" .Values.externalKafka.host "port" (int .Values.externalKafka.port)) }}
 {{- end }}
-
-{{- $bootstrapServers := list }}
-{{- range $brokers }}
-{{- $bootstrapServers = append $bootstrapServers (printf "%s:%d" .host .port) }}
-{{- end }}
-{{- $bootstrapServersString := join "," $bootstrapServers }}
-
-{{/* Get topic list from externalKafka.provisioning.topics or fall back to kafka.provisioning.topics */}}
-{{- $topics := $provisioning.topics | default .Values.kafka.provisioning.topics }}
-{{- $replicationFactor := int ($provisioning.replicationFactor | default 1) }}
-{{- $defaultPartitions := int ($provisioning.numPartitions | default 1) }}
 
 {{- $image := printf "%s:%s" ($provisioning.image.repository | default "apache/kafka") ($provisioning.image.tag | default "3.7.1") }}
 
@@ -89,20 +73,14 @@ spec:
             runAsUser: 1000
           command:
             - /bin/bash
-          args:
-            - -ec
-            - |
-              {{- range $brokers }}
-              timeout=120; until nc -z {{ .host }} {{ .port }} 2>/dev/null; do
-                timeout=$((timeout - 2)); [ $timeout -le 0 ] && echo "Timed out waiting for {{ .host }}:{{ .port }}" && exit 1;
-                sleep 2;
-              done;
-              {{- end }}
-              echo "Kafka is available";
+            - /scripts/wait-for-kafka.sh
           {{- if $provisioning.resources }}
           resources:
 {{ toYaml $provisioning.resources | indent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
       containers:
         - name: kafka-provisioning
           image: {{ $image }}
@@ -116,111 +94,34 @@ spec:
             runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
-          {{- if $saslFromSecret }}
+          {{- if .Values.externalKafka.sasl.existingSecret }}
           env:
             - name: KAFKA_SASL_MECHANISM
               valueFrom:
                 secretKeyRef:
-                  name: {{ $sasl.existingSecret }}
-                  key: {{ ($sasl.existingSecretKeys).mechanism | default "mechanism" }}
+                  name: {{ .Values.externalKafka.sasl.existingSecret }}
+                  key: {{ (.Values.externalKafka.sasl.existingSecretKeys).mechanism | default "mechanism" }}
             - name: KAFKA_SASL_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ $sasl.existingSecret }}
-                  key: {{ ($sasl.existingSecretKeys).username | default "username" }}
+                  name: {{ .Values.externalKafka.sasl.existingSecret }}
+                  key: {{ (.Values.externalKafka.sasl.existingSecretKeys).username | default "username" }}
             - name: KAFKA_SASL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $sasl.existingSecret }}
-                  key: {{ ($sasl.existingSecretKeys).password | default "password" }}
+                  name: {{ .Values.externalKafka.sasl.existingSecret }}
+                  key: {{ (.Values.externalKafka.sasl.existingSecretKeys).password | default "password" }}
           {{- end }}
           command:
             - /bin/bash
-          args:
-            - -ec
-            - |
-              export CLIENT_CONF="${CLIENT_CONF:-/tmp/client.properties}"
-              if [ ! -f "$CLIENT_CONF" ]; then
-                echo "security.protocol={{ $securityProtocol }}" > "$CLIENT_CONF"
-                {{- if $saslFromSecret }}
-                echo "sasl.mechanism=${KAFKA_SASL_MECHANISM}" >> "$CLIENT_CONF"
-                case "${KAFKA_SASL_MECHANISM}" in
-                  PLAIN)
-                    LOGIN_MODULE="org.apache.kafka.common.security.plain.PlainLoginModule"
-                    ;;
-                  *)
-                    LOGIN_MODULE="org.apache.kafka.common.security.scram.ScramLoginModule"
-                    ;;
-                esac
-                echo "sasl.jaas.config=${LOGIN_MODULE} required username=\"${KAFKA_SASL_USERNAME}\" password=\"${KAFKA_SASL_PASSWORD}\";" >> "$CLIENT_CONF"
-                {{- else if $saslEnabled }}
-                echo "sasl.mechanism={{ $sasl.mechanism }}" >> "$CLIENT_CONF"
-                {{- if and $sasl.username $sasl.password }}
-                {{- if eq $sasl.mechanism "PLAIN" }}
-                echo "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{ $sasl.username }}\" password=\"{{ $sasl.password }}\";" >> "$CLIENT_CONF"
-                {{- else }}
-                echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{{ $sasl.username }}\" password=\"{{ $sasl.password }}\";" >> "$CLIENT_CONF"
-                {{- end }}
-                {{- end }}
-                {{- end }}
-              fi
-
-              kafka_provisioning_commands=(
-                {{- range $topics }}
-                "/opt/kafka/bin/kafka-topics.sh \
-                  --create \
-                  --if-not-exists \
-                  --bootstrap-server {{ $bootstrapServersString }} \
-                  --replication-factor {{ $replicationFactor }} \
-                  --partitions {{ .partitions | default $defaultPartitions }} \
-                  {{- range $key, $value := .config }}
-                  --config {{ $key }}={{ $value }} \
-                  {{- end }}
-                  --command-config ${CLIENT_CONF} \
-                  --topic {{ .name }}"
-                {{- end }}
-              )
-
-              echo "Starting provisioning of ${#kafka_provisioning_commands[@]} topics"
-              for ((i=0; i < ${#kafka_provisioning_commands[@]}; i++)); do
-                ${kafka_provisioning_commands[i]}
-              done
-              echo "Provisioning succeeded"
-
-              COMMON_OPTS="--bootstrap-server {{ $bootstrapServersString }} --command-config ${CLIENT_CONF}"
-
-              echo "Checking existing topic partitions and configs..."
-              {{- range $topics }}
-              {{- $partitions := .partitions | default $defaultPartitions }}
-              CURRENT_PARTITIONS=$(/opt/kafka/bin/kafka-topics.sh $COMMON_OPTS --describe --topic "{{ .name }}" 2>/dev/null | head -1 | sed -n 's/.*PartitionCount: \([0-9]*\).*/\1/p')
-              if [ -n "$CURRENT_PARTITIONS" ] && [ "{{ $partitions }}" -gt "$CURRENT_PARTITIONS" ]; then
-                echo "  [ALTER] {{ .name }}: increasing partitions from $CURRENT_PARTITIONS to {{ $partitions }}"
-                /opt/kafka/bin/kafka-topics.sh $COMMON_OPTS --alter --topic "{{ .name }}" --partitions "{{ $partitions }}"
-              fi
-              {{- if .config }}
-              CURRENT_CONFIGS=$(/opt/kafka/bin/kafka-configs.sh $COMMON_OPTS --entity-type topics --entity-name "{{ .name }}" --describe 2>/dev/null || echo "")
-              NEEDS_UPDATE=false
-              {{- range $key, $value := .config }}
-              if ! echo "$CURRENT_CONFIGS" | grep -q '{{ $key }}={{ $value }}'; then
-                NEEDS_UPDATE=true
-              fi
-              {{- end }}
-              if [ "$NEEDS_UPDATE" = true ]; then
-                echo "  [CONFIG] {{ .name }}: applying config updates"
-                {{- $scratch := dict "args" (list) }}
-                {{- range $key, $value := .config }}
-                {{- $_ := set $scratch "args" (append (index $scratch "args") (printf "%s=[%s]" $key $value)) }}
-                {{- end }}
-                /opt/kafka/bin/kafka-configs.sh $COMMON_OPTS --entity-type topics --entity-name "{{ .name }}" --alter --add-config '{{ join "," (index $scratch "args") }}' || echo "  [CONFIG] {{ .name }}: WARNING - config update failed"
-              fi
-              {{- end }}
-              {{- end }}
-              echo "Update complete"
+            - /scripts/provision.sh
           {{- if $provisioning.resources }}
           resources:
 {{ toYaml $provisioning.resources | indent 12 }}
           {{- end }}
           volumeMounts:
+            - name: scripts
+              mountPath: /scripts
             - name: tmp
               mountPath: /tmp
 {{- if $provisioning.volumeMounts }}
@@ -236,6 +137,10 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 8 }}
 {{- end }}
       volumes:
+        - name: scripts
+          configMap:
+            name: {{ .Release.Name }}-kafka-provisioning-scripts
+            defaultMode: 0755
         - name: tmp
           emptyDir: {}
 {{- if $provisioning.volumes }}


### PR DESCRIPTION
**Summary**

Fixes https://github.com/sentry-kubernetes/charts/issues/2141

Move external Kafka topic provisioning scripts (wait-for-kafka.sh and provision.sh) from inline args in the pod spec to a ConfigMap mounted as files. This change only affects **external Kafka** topic provisioning (`externalKafka.provisioning.enabled: true`) — the built-in Kafka chart is not affected.

This resolves the argument list too long error that occurs when the generated provisioning script exceeds the Linux kernel ARG_MAX limit (~128 KB).

**Problem**

When using `externalKafka.provisioning.enabled: true`, the provisioning script is passed to the container as a command-line argument via the `args` field. With ~109 Kafka topics defined in the chart, the generated script is already ~114 KB — near the ARG_MAX limit. Adding any additional parameters (e.g., `--config min.insync.replicas=2`) increases the script size by ~500-700 bytes per topic, exceeding the limit and causing the pod to fail with:
```
exec /bin/bash: argument list too long
```

**Solution**

- Create a ConfigMap (`configmap-kafka-provisioning.yaml`) containing both scripts as data entries
- Mount the ConfigMap into the container at `/scripts` with `defaultMode: 0755`
- Run scripts via `command: [/bin/bash, /scripts/provision.sh]` instead of inline args
- The ConfigMap is created as a Helm hook with `hook-weight: -5` so it exists before the Job (`hook-weight: 0`)
- The ConfigMap size limit in Kubernetes is 1 MB, which is more than sufficient for the provisioning scripts.

**Changes**

| File | Change |
|------|--------|
| `charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml` | New — ConfigMap with `wait-for-kafka.sh` and `provision.sh` scripts for external Kafka topic creation |
| `charts/sentry/templates/kafka-provisioning/job-kafka-provisioning.yaml` | Modified — removed inline scripts from args, added ConfigMap volume and volumeMounts |
