### PR TITLE
fix: add missing -- separator before consumer CLI options to prevent pod crashloops

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -110,6 +110,9 @@ spec:
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerAttachments.logLevel }}"
           {{- end }}
+          {{- if or .Values.sentry.ingestConsumerAttachments.maxPollIntervalMs .Values.sentry.ingestConsumerAttachments.concurrency .Values.sentry.ingestConsumerAttachments.maxBatchSize .Values.sentry.ingestConsumerAttachments.maxBatchTimeMs }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.ingestConsumerAttachments.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxPollIntervalMs }}"

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -110,6 +110,9 @@ spec:
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerEvents.logLevel }}"
           {{- end }}
+          {{- if or .Values.sentry.ingestConsumerEvents.maxBatchSize .Values.sentry.ingestConsumerEvents.inputBlockSize .Values.sentry.ingestConsumerEvents.maxBatchTimeMs .Values.sentry.ingestConsumerEvents.concurrency }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.ingestConsumerEvents.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerEvents.maxBatchSize }}"

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -108,6 +108,7 @@ spec:
           - "/tmp/health.txt"
           {{- end }}
           {{- if .Values.sentry.ingestMonitors.maxPollIntervalMs }}
+          - "--"
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.ingestMonitors.maxPollIntervalMs }}"
           {{- end }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -108,6 +108,7 @@ spec:
           - "/tmp/health.txt"
           {{- end }}
           {{- if .Values.sentry.ingestReplayRecordings.maxPollIntervalMs }}
+          - "--"
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.ingestReplayRecordings.maxPollIntervalMs }}"
           {{- end }}

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -111,6 +111,9 @@ spec:
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerTransactions.logLevel }}"
           {{- end }}
+          {{- if or .Values.sentry.ingestConsumerTransactions.maxBatchSize .Values.sentry.ingestConsumerTransactions.inputBlockSize .Values.sentry.ingestConsumerTransactions.maxBatchTimeMs .Values.sentry.ingestConsumerTransactions.concurrency }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.ingestConsumerTransactions.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.ingestConsumerTransactions.maxBatchSize }}"

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -109,6 +109,9 @@ spec:
           - "--log-level"
           - "{{ .Values.sentry.metricsConsumer.logLevel }}"
           {{- end }}
+          {{- if or .Values.sentry.metricsConsumer.maxPollIntervalMs .Values.sentry.metricsConsumer.concurrency }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.metricsConsumer.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.metricsConsumer.maxPollIntervalMs }}"

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -109,6 +109,9 @@ spec:
           - "--log-level"
           - "{{ .Values.sentry.genericMetricsConsumer.logLevel }}"
           {{- end }}
+          {{- if or .Values.sentry.genericMetricsConsumer.maxPollIntervalMs .Values.sentry.genericMetricsConsumer.concurrency }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.genericMetricsConsumer.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.genericMetricsConsumer.maxPollIntervalMs }}"

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -111,6 +111,7 @@ spec:
           {{- if .Values.sentry.postProcessForwardTransactions.processes }}
           - "--mode"
           - "multiprocess"
+          - "--"
           - "--processes"
           - "{{ .Values.sentry.postProcessForwardTransactions.processes }}"
           {{- end }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -105,6 +105,9 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          {{- if or .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize }}"

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -105,6 +105,9 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          {{- if or .Values.sentry.subscriptionConsumerMetrics.maxBatchSize .Values.sentry.subscriptionConsumerMetrics.concurrency }}
+          - "--"
+          {{- end }}
           {{- if .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.maxBatchSize }}"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -477,9 +477,9 @@ sentry:
   ingestConsumerAttachments:
     enabled: true
     replicas: 1
-    # concurrency: 4
-    # maxBatchTimeMs: 20000
-    # maxPollIntervalMs: 30000
+    concurrency: 4
+    maxBatchTimeMs: 20000
+    maxPollIntervalMs: 30000
     env: []
     resources: {}
     #  requests:
@@ -491,7 +491,7 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # maxBatchSize: ""
+    maxBatchSize: "3"
     # logLevel: info
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
@@ -519,7 +519,7 @@ sentry:
   ingestConsumerEvents:
     enabled: true
     replicas: 1
-    # concurrency: 4
+    concurrency: 4
     env: []
     resources: {}
     #  requests:
@@ -531,10 +531,10 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # maxBatchSize: ""
+    maxBatchSize: "1"
     # logLevel: "info"
-    # inputBlockSize: ""
-    # maxBatchTimeMs: ""
+    inputBlockSize: "1"
+    maxBatchTimeMs: "750"
 
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
@@ -562,7 +562,7 @@ sentry:
   ingestConsumerTransactions:
     enabled: true
     replicas: 1
-    # concurrency: 4
+    concurrency: 4
     env: []
     resources: {}
     #  requests:
@@ -574,10 +574,10 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # maxBatchSize: ""
+    maxBatchSize: "1"
     # logLevel: "info"
-    # inputBlockSize: ""
-    # maxBatchTimeMs: ""
+    inputBlockSize: "1"
+    maxBatchTimeMs: "750"
 
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
@@ -614,7 +614,7 @@ sentry:
     nodeSelector: {}
     securityContext: {}
     containerSecurityContext: {}
-    # maxPollIntervalMs: 30000
+    maxPollIntervalMs: 30000
     tolerations: []
     # podLabels: {}
     # it's better to use prometheus adapter and scale based on
@@ -747,7 +747,7 @@ sentry:
     nodeSelector: {}
     securityContext: {}
     containerSecurityContext: {}
-    # maxPollIntervalMs: 30000
+    maxPollIntervalMs: 30000
     tolerations: []
     # podLabels: {}
     # it's better to use prometheus adapter and scale based on
@@ -869,7 +869,8 @@ sentry:
   genericMetricsConsumer:
     enabled: true
     replicas: 1
-    # concurrency: 4
+    concurrency: 4
+    maxPollIntervalMs: "30000"
     env: []
     resources: {}
     #  requests:
@@ -881,7 +882,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # maxPollIntervalMs: ""
     # logLevel: "info"
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
@@ -906,7 +906,8 @@ sentry:
   metricsConsumer:
     enabled: true
     replicas: 1
-    # concurrency: 4
+    concurrency: 4
+    maxPollIntervalMs: "30000"
     env: []
     resources: {}
     #  requests:
@@ -919,7 +920,6 @@ sentry:
     tolerations: []
     # podLabels: {}
     # logLevel: "info"
-    # maxPollIntervalMs: ""
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -1064,7 +1064,7 @@ sentry:
   postProcessForwardTransactions:
     enabled: true
     replicas: 1
-    # processes: 1
+    processes: 1
     env: []
     resources: {}
     #  requests:
@@ -1165,7 +1165,8 @@ sentry:
   subscriptionConsumerGenericMetrics:
     enabled: true
     replicas: 1
-    # concurrency: 1
+    concurrency: 1
+    maxBatchSize: "3"
     env: []
     resources: {}
     #  requests:
@@ -1191,7 +1192,8 @@ sentry:
   subscriptionConsumerMetrics:
     enabled: true
     replicas: 1
-    # concurrency: 1
+    concurrency: 1
+    maxBatchSize: "3"
     env: []
     resources: {}
     #  requests:


### PR DESCRIPTION
## Summary

Add missing `--` separator before consumer CLI options (`--concurrency`, `--max-batch-size`, `--max-poll-interval-ms`, etc.) in all affected deployment templates. Without this separator, the Sentry CLI treats these flags as positional arguments, causing consumer pods to crash with `CrashLoopBackOff`.

Also enables previously commented-out default values for `concurrency`, `maxBatchSize`, `maxBatchTimeMs`, `maxPollIntervalMs`, and `inputBlockSize` in `values.yaml`, which were non-functional without the `--` separator.

## Changes

**Templates — add `--` separator before consumer-specific flags:**
- `ingest-consumer-attachments`
- `ingest-consumer-events`
- `ingest-consumer-transactions`
- `ingest-monitors`
- `ingest-replay-recordings`
- `generic-metrics-consumer`
- `metrics-consumer`
- `post-process-forwarder-transactions`
- `subscription-consumer-generic-metrics`
- `subscription-consumer-metrics`

**`values.yaml` — uncomment and set default values:**
- `concurrency` enabled across all consumers
- `maxBatchSize`, `maxBatchTimeMs`, `inputBlockSize` set for ingest consumers
- `maxPollIntervalMs` set for monitors, replay-recordings, and metrics consumers
- `processes` enabled for `postProcessForwardTransactions`
- `maxBatchSize` added for subscription consumers

Closes #2137
