### PR TITLE
fix: harden shell scripts with set -euo pipefail

### DIFF
--- a/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
@@ -42,7 +42,7 @@ metadata:
 data:
   wait-for-kafka.sh: |
     #!/bin/bash
-    set -e
+    set -euo pipefail
     {{- range $brokers }}
     timeout=120; until nc -z {{ .host }} {{ .port }} 2>/dev/null; do
       timeout=$((timeout - 2)); [ $timeout -le 0 ] && echo "Timed out waiting for {{ .host }}:{{ .port }}" && exit 1;
@@ -53,7 +53,7 @@ data:
 
   provision.sh: |
     #!/bin/bash
-    set -e
+    set -euo pipefail
     export CLIENT_CONF="${CLIENT_CONF:-/tmp/client.properties}"
     if [ ! -f "$CLIENT_CONF" ]; then
       echo "security.protocol={{ $securityProtocol }}" > "$CLIENT_CONF"

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -75,7 +75,7 @@ spec:
             args:
               - "-c"
               - |
-                set -e
+                set -euo pipefail
                 echo "Starting ClickHouse cleanup with retention period of {{ .Values.snuba.cleanup.retentionDays }} days"
                 echo "Connecting to ClickHouse at $CLICKHOUSE_HOST:$CLICKHOUSE_PORT"
 


### PR DESCRIPTION
## Summary

- Replace `set -e` with `set -euo pipefail` in Kafka provisioning and ClickHouse cleanup scripts to fail fast on unset variables and pipeline errors.

## Motivation

Using only `set -e` has known pitfalls:

- **Unset variables** silently expand to empty strings, causing silent bugs or dangerous commands (e.g., `rm -rf $UNSET_VAR/`).
- **Pipeline failures** — only the exit code of the last command is checked; earlier commands in a pipeline can fail silently.

`set -euo pipefail` addresses all three:

| Flag | Effect |
|------|--------|
| `-e` | Exit immediately if a command exits with non-zero status |
| `-u` | Treat unset variables as an error |
| `-o pipefail` | Pipeline returns the exit code of the last command that failed (not just the last command) |

## Changes

### `templates/kafka-provisioning/configmap-kafka-provisioning.yaml`

- `wait-for-kafka.sh`: `set -e` → `set -euo pipefail`
- `provision.sh`: `set -e` → `set -euo pipefail`

### `templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml`

- ClickHouse cleanup script: `set -e` → `set -euo pipefail`
