### PR TITLE
feat(cache): add cache.enabled flag, deprecate sourcemaps.enabled

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.7.0
-digest: sha256:b1db91770a93016ac2b0ad35c779b4a0f268cf65d06de9558ac3fbe03185035f
-generated: "2026-02-25T13:11:28.901973313+01:00"
+digest: sha256:db3349bfd8df7edf86fd67be5b6a4b369b3dd76a1c5548c860e855c89bcd8e4f
+generated: "2026-05-05T17:50:54.803225971+06:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates
     version: 0.9.3
-    condition: sourcemaps.enabled
+    condition: cache.enabled,sourcemaps.enabled
   - name: redis
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 17.11.3

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1125,7 +1125,8 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.transactionsConsumer.resources | object | `{}` |  |
 | snuba.transactionsConsumer.securityContext | object | `{}` |  |
 | snuba.transactionsConsumer.topologySpreadConstraints | list | `[]` |  |
-| sourcemaps.enabled | bool | `false` |  |
+| sourcemaps.enabled | bool | `false` | DEPRECATED: use cache.enabled instead |
+| cache.enabled | bool | `false` | Enable Django CACHES (memcached) |
 | symbolicator.api.affinity | object | `{}` |  |
 | symbolicator.api.autoscaling.enabled | bool | `false` |  |
 | symbolicator.api.autoscaling.maxReplicas | int | `5` |  |
@@ -1352,10 +1353,12 @@ Its also important having `connect_to_reserved_ips: true` in the symbolicator co
 
 #### Source Maps
 
-To get javascript source map processing working, you need to activate sourcemaps, which in turn activates the memcached dependency:
+> **Deprecated:** `sourcemaps.enabled` is deprecated and will be removed in a future release. Use `cache.enabled` instead.
+
+To get javascript source map processing working, you need to enable the Django cache (memcached), which is also used by 60+ Sentry components for caching:
 
 ```yaml
-sourcemaps:
+cache:
   enabled: true
 ```
 

--- a/charts/sentry/templates/NOTES.txt
+++ b/charts/sentry/templates/NOTES.txt
@@ -3,3 +3,8 @@
 
 {{ template "sentry.kafka.bootstrap_servers_string" . }}
 {{ end -}}
+
+{{- if .Values.sourcemaps.enabled }}
+WARNING: sourcemaps.enabled is deprecated and will be removed in a future release.
+         Use cache.enabled instead.
+{{- end }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -95,7 +95,7 @@ sentry.conf.py: |-
       power = UNITS.index(unit) + 1
       return float(text[:-1])*(BYTE_MULTIPLIER**power)
 
-  {{- if .Values.sourcemaps.enabled }}
+  {{- if or .Values.cache.enabled .Values.sourcemaps.enabled }}
   CACHES = {
       "default": {
           "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3090,7 +3090,12 @@ externalKafka:
     nodeSelector: {}
     tolerations: []
 
+# DEPRECATED: sourcemaps.enabled is deprecated and will be removed in a future release.
+# Use cache.enabled instead. See cache.enabled below.
 sourcemaps:
+  enabled: false
+
+cache:
   enabled: false
 
 redis:


### PR DESCRIPTION
## Summary

- Add new `cache.enabled` flag to control Django CACHES (memcached) independently from sourcemaps
- Deprecate `sourcemaps.enabled` — it will be removed in a future release
- Add deprecation warning in NOTES.txt shown during `helm install/upgrade`

## Motivation

In Sentry source code, Django `CACHES` (memcached) is used by 60+ components: models, API authentication, ingest, integrations, quotas, alerts, and more. Previously, CACHES was tied to `sourcemaps.enabled`, which was misleading — the cache serves far more than just source maps.

## Changes

| File | Change |
|---|---|
| `values.yaml` | Added `cache.enabled: false` flag, added deprecation comment on `sourcemaps.enabled` |
| `_helper-sentry.tpl` | Updated condition: `or .Values.cache.enabled .Values.sourcemaps.enabled` |
| `Chart.yaml` | Updated memcached condition: `cache.enabled,sourcemaps.enabled` |
| `NOTES.txt` | Added deprecation warning when `sourcemaps.enabled` is used |
| `README.md` | Updated parameters table and Source Maps section |

## Backward Compatibility

- `sourcemaps.enabled: true` — continues to work as before, memcached is deployed
- `cache.enabled: true` — memcached is deployed, CACHES enabled for all Sentry components
- Both `false` — memcached is not deployed (current default behavior preserved)

## Usage

```yaml
# Recommended (new)
cache:
  enabled: true

# Deprecated (still works, shows warning)
sourcemaps:
  enabled: true
```
