### PR TITLE
feat: add concurrency, maxBatchSize, maxBatchTimeMs support for process-spans and process-segments consumers

### DIFF
--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -105,6 +105,21 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          {{- if or .Values.sentry.processSegments.concurrency .Values.sentry.processSegments.maxBatchSize .Values.sentry.processSegments.maxBatchTimeMs }}
+          - "--"
+          {{- end }}
+          {{- if .Values.sentry.processSegments.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.processSegments.concurrency }}"
+          {{- end }}
+          {{- if .Values.sentry.processSegments.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.processSegments.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.sentry.processSegments.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.sentry.processSegments.maxBatchTimeMs }}"
+          {{- end }}
         {{- if .Values.sentry.processSegments.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -105,6 +105,21 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          {{- if or .Values.sentry.processSpans.concurrency .Values.sentry.processSpans.maxBatchSize .Values.sentry.processSpans.maxBatchTimeMs }}
+          - "--"
+          {{- end }}
+          {{- if .Values.sentry.processSpans.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.processSpans.concurrency }}"
+          {{- end }}
+          {{- if .Values.sentry.processSpans.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.processSpans.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.sentry.processSpans.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.sentry.processSpans.maxBatchTimeMs }}"
+          {{- end }}
         {{- if .Values.sentry.processSpans.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1117,6 +1117,7 @@ sentry:
   processSegments:
     enabled: true
     replicas: 1
+    # concurrency: 4
     env: []
     resources: {}
     #  requests:
@@ -1138,10 +1139,13 @@ sentry:
       periodSeconds: 320
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
+    # maxBatchSize: "500"
+    # maxBatchTimeMs: "1000"
 
   processSpans:
     enabled: true
     replicas: 1
+    # concurrency: 4
     env: []
     resources: {}
     #  requests:
@@ -1163,6 +1167,8 @@ sentry:
       periodSeconds: 320
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
+    # maxBatchSize: "500"
+    # maxBatchTimeMs: "1000"
 
   subscriptionConsumerGenericMetrics:
     enabled: true


### PR DESCRIPTION
## Problem

`sentry-process-spans` and `sentry-process-segments` consumers were added to the chart without support for configuring consumer-specific CLI flags.

Other consumers (e.g. `genericMetricsConsumer`, `metricsConsumer`) already expose equivalent parameters, but these two were never updated to match.

## Solution

Adds `concurrency`, `maxBatchSize`, and `maxBatchTimeMs` values for both consumers, passed as consumer-specific arguments after the `--` separator.

Flags were verified against the running binary:
- `process-segments`
```
$ sentry run consumer process-segments --consumer-group process-segments -- --help
Usage: process-segments [OPTIONS]

Options:
  --skip-produce
  --processes INTEGER
  --input-block-size INTEGER
  --output-block-size INTEGER
  --max-batch-size INTEGER     Maximum number of messages to batch before
                               flushing.
  --max-batch-time-ms INTEGER  Maximum time (in milliseconds) to wait before
                               flushing a batch.
  --help                       Show this message and exit.
```
- `process-spans`
```
$ sentry run consumer process-spans --consumer-group process-spans -- --help
Usage: process-spans [OPTIONS]

Options:
  --processes INTEGER
  --input-block-size INTEGER
  --output-block-size INTEGER
  --max-batch-size INTEGER     Maximum number of messages to batch before
                               flushing.
  --max-batch-time-ms INTEGER  Maximum time (in milliseconds) to wait before
                               flushing a batch.
  --flusher-processes INTEGER  Maximum number of processes for the span
                               flusher. Defaults to 1.
  --help                       Show this message and exit.
```

## Changes

- `templates/deployment-sentry-process-segments.yaml` — emit `--` separator and conditionally pass `--processes`, `--max-batch-size`, `--max-batch-time-ms`
- `templates/deployment-sentry-process-spans.yaml` — same
- `values.yaml` — add commented-out `concurrency`, `maxBatchSize`, `maxBatchTimeMs` keys to both consumer sections, matching the style of sibling consumers