### PR TITLE
feat: upgrade to v26.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog below refers to the main `sentry` chart only.
 
 ## Upgrading to Chart 31.x.x
 
+> [!CAUTION]
+> `31.0.0` has issues with Snuba migration, please skip this release and upgrade
+> straight to `31.1.0` instead.
+
 **Breaking change:** the insecure default Sentry admin password (`user.password: aaaa`) has been removed. When `user.create` is `true` (the default), you must now set **one** of:
 
 - `user.existingSecret` (recommended): name of a Kubernetes Secret containing the admin password.
@@ -49,6 +53,10 @@ externalKafka:
 ```
 
 ## Upgrading to Chart 30.x.x
+
+> [!CAUTION]
+> `30.4.0` has issues with Snuba migration, please skip this release and upgrade
+> straight to `31.1.0` instead.
 
 **Breaking change:** HTTP health probe tuning for in-cluster traffic is no longer a single set of flat `probe*` values.
 

--- a/charts/sentry/CHANGELOG.md
+++ b/charts/sentry/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [31.0.0](https://github.com/sentry-kubernetes/charts/compare/sentry-v30.4.0...sentry-v31.0.0) (2026-05-06)
 
 
+> [!CAUTION]
+> This release has issues with Snuba migration if you're upgrading from previous version,
+> see [getsentry/self-hosted #4286](https://github.com/getsentry/self-hosted/issues/4286).
+>
+> Please skip this release and upgrade straight to `31.1.0` instead.
+>
+> This release is fine if you're doing a fresh install.
+
+
 ### ⚠ BREAKING CHANGES
 
 * require admin password and remove insecure default ([#2151](https://github.com/sentry-kubernetes/charts/issues/2151))
@@ -20,6 +29,15 @@
 * require admin password and remove insecure default ([#2151](https://github.com/sentry-kubernetes/charts/issues/2151)) ([c14b1bf](https://github.com/sentry-kubernetes/charts/commit/c14b1bf3b875fa4cfd59d179d55086ffbc17aa68))
 
 ## [30.4.0](https://github.com/sentry-kubernetes/charts/compare/sentry-v30.3.1...sentry-v30.4.0) (2026-05-03)
+
+
+> [!CAUTION]
+> This release has issues with Snuba migration if you're upgrading from previous version,
+> see [getsentry/self-hosted #4286](https://github.com/getsentry/self-hosted/issues/4286).
+>
+> Please skip this release and upgrade straight to `31.1.0` instead.
+>
+> This release is fine if you're doing a fresh install.
 
 
 ### Features

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 31.0.0
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 26.4.0
+appVersion: 26.4.2
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates


### PR DESCRIPTION
Diff: https://github.com/getsentry/self-hosted/compare/26.4.0...26.4.2
`getsentry/self-hosted` release notes: [`26.4.1`](https://github.com/getsentry/self-hosted/releases/tag/26.4.1) ; [`26.4.2`](https://github.com/getsentry/self-hosted/releases/tag/26.4.2)

---

:warning: There was an issue with a Snuba migration in `26.4.0`: https://github.com/getsentry/self-hosted/issues/4286
Sorry I didn't catch it earlier.

It's worth mentioning that in `26.4.1` and `26.4.2`, Snuba consumers will spam logs with `Failed to read directory /etc/sentry-options/values: No such file or directory (os error 2)`.
According to [this comment](https://github.com/getsentry/snuba/pull/7917#issuecomment-4379635023) it's harmless and I'm seeing no issues on my installation.
Altogether I think it's better than leaving a version with a migration issue.
