### PR TITLE
feat: add topicOverrides support for per-topic partition and config customization in Kafka provisioning

### DIFF
--- a/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
@@ -23,6 +23,7 @@
 
 {{/* Get topic list from externalKafka.provisioning.topics or fall back to kafka.provisioning.topics */}}
 {{- $topics := $provisioning.topics | default .Values.kafka.provisioning.topics }}
+{{- $topicOverrides := $provisioning.topicOverrides | default dict }}
 {{- $replicationFactor := int ($provisioning.replicationFactor | default 1) }}
 {{- $defaultPartitions := int ($provisioning.numPartitions | default 1) }}
 
@@ -85,20 +86,28 @@ data:
 
   topics.yaml: |
     {{- range $topics }}
+    {{- $topicName := .name }}
+    {{- $override := index $topicOverrides $topicName | default dict }}
+    {{- $partitions := $override.partitions | default .partitions | default $defaultPartitions }}
+    {{- $topicPlacementStrategy := $override.placementStrategy | default .placementStrategy | default $placementStrategy }}
+    {{- $config := .config | default dict }}
+    {{- if $override.config }}
+    {{-   $config = mustMergeOverwrite (dict) $config $override.config }}
+    {{- end }}
     ---
     meta:
-      name: {{ .name }}
+      name: {{ $topicName }}
       cluster: {{ $clusterName }}
       environment: {{ $environment }}
       region: {{ $region }}
     spec:
-      partitions: {{ .partitions | default $defaultPartitions }}
+      partitions: {{ $partitions }}
       replicationFactor: {{ $replicationFactor }}
       placement:
-        strategy: {{ .placementStrategy | default $placementStrategy }}
-      {{- if .config }}
+        strategy: {{ $topicPlacementStrategy }}
+      {{- if $config }}
       settings:
-        {{- range $key, $value := .config }}
+        {{- range $key, $value := $config }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3090,6 +3090,19 @@ externalKafka:
       region: "default"
       placementStrategy: "any"
     # topics: []  # If empty, uses kafka.provisioning.topics
+    # topicOverrides allows overriding partitions/config for specific topics without re-declaring all topics.
+    # Keys must match topic names from kafka.provisioning.topics (or externalKafka.provisioning.topics if set).
+    # Any field omitted here falls back to the topic's own value, then to provisioning defaults (numPartitions, placementStrategy).
+    # topicOverrides:
+    #   ingest-events:
+    #     partitions: 12
+    #   events:
+    #     partitions: 6
+    #   snuba-commit-log:
+    #     partitions: 3
+    #     config:
+    #       "cleanup.policy": "compact,delete"
+    #       "min.compaction.lag.ms": "3600000"
     replicationFactor: 3
     numPartitions: 1
     resources: {}


### PR DESCRIPTION
## Summary

Add `topicOverrides` support to the Kafka provisioning ConfigMap, allowing per-topic customization of partitions, placement strategy, and topic config without needing to re-declare the entire topic list.

## Motivation

When using `externalKafka.provisioning.topics` (or the default `kafka.provisioning.topics`), all topics share the same `numPartitions` and `placementStrategy` defaults. Previously, to customize a single topic you had to copy and maintain the full topic list. This change introduces a lightweight override mechanism.

## Changes

- **`configmap-kafka-provisioning.yaml`**: Added logic to look up per-topic overrides from `topicOverrides` map and merge them with topic-level and global defaults (partitions, placementStrategy, config).
- **`values.yaml`**: Added documented `topicOverrides` section under `externalKafka.provisioning` with commented-out examples.

## Usage Example

```yaml
externalKafka:
  provisioning:
    topicOverrides:
      buffered-segments:
        partitions: 12
      cdc:
        partitions: 12
        placementStrategy: "any"
        config:
          "min.compaction.lag.ms": "3600000"
```

## Override Resolution Order

For each topic field (`partitions`, `placementStrategy`, `config`):

1. `topicOverrides.<topicName>.<field>` (highest priority)
2. Topic-level value from the topics list
3. Global provisioning defaults (`numPartitions`, `placementStrategy`)

For `config`, maps are deep-merged (`mustMergeOverwrite`), so override config is merged on top of the topic's base config.