### PR TITLE
docs: add Sentry admin secret setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ This repository aims to support Sentry >=10 and move out from the deprecated Hel
 
 Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/charts/tree/master/stable/sentry). This work has been partly inspired by it.
 
+## Sentry Admin Secret
+
+Before installing Sentry, you must create a secret for the admin password:
+
+1. Create the secret:
+
+```bash
+kubectl create namespace sentry
+kubectl create secret generic sentry-admin-password \
+  --from-literal=admin-password='YourStrongPassword123!' \
+  --namespace sentry
+```
+
+2. Set in `values.yaml`:
+
+```yaml
+user:
+  existingSecret: sentry-admin-password
+```
+
 ## External ClickHouse Configuration
 
 ### Background


### PR DESCRIPTION
## Summary

- Add documentation section to README explaining how to create a Kubernetes secret for the Sentry admin password before installing the chart
- Remove hardcoded default admin password in favor of `user.existingSecret` approach for improved security