### PR TITLE
fix: update externalClickhouse host and README for clickhouse namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea
 **.tgz
 
+clickhouse-keeper.yaml
+clickhouse-operator-values.yaml
+clickhouse.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 .idea
 **.tgz
-
 clickhouse-keeper.yaml
 clickhouse-operator-values.yaml
+.gitignore
 clickhouse.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 .idea
 **.tgz
-clickhouse-keeper.yaml
 clickhouse-operator-values.yaml
-.gitignore
+clickhouse-keeper.yaml
 clickhouse.yaml

--- a/README.md
+++ b/README.md
@@ -71,19 +71,20 @@ Ensure the operator pod is in `Running` state before proceeding.
 
 Below is a Minimum Viable Product (MVP) configuration for a single-node ClickHouse instance suitable for testing or small-scale deployments. For production, we recommend a high-availability setup with at least 3 Keeper nodes and 2 ClickHouse replicas.
 
-#### 1. Create ClickHouse Operator Secret
+#### 1. Create ClickHouse Secrets
 
-Create a secret for the `clickhouse_operator` user that the Altinity Operator uses to manage the ClickHouse cluster:
+Create a secret with credentials for both the `clickhouse_operator` user (used by the Altinity Operator to manage the cluster) and the `sentry` user (used by Sentry to access ClickHouse):
 
 ```bash
-kubectl -n clickhouse create secret generic clickhouse-operator-secret \
-  --from-literal=username=clickhouse_operator \
-  --from-literal=password='YourStrongOperatorPassword!'
+kubectl create ns clickhouse
+kubectl -n clickhouse create secret generic clickhouse-secret \
+  --from-literal=operator-password='YourStrongOperatorPassword!' \
+  --from-literal=sentry-password='YourStrongSentryPassword!'
 ```
 
 #### 2. ClickHouse Installation Manifest
 
-Save this as `clickhouse.yaml`. This example deploys a single-node cluster. The operator password is loaded from the secret created above.
+Save this as `clickhouse.yaml`. This example deploys a single-node cluster. Passwords for both the operator and Sentry are loaded from the secret created above.
 
 ```bash
 cat <<'EOF' > clickhouse.yaml
@@ -100,8 +101,9 @@ spec:
       clickhouse_operator/password: ""
       clickhouse_operator/networks/ip:
         - "0.0.0.0/0"
-      default/networks/ip:
-        - "0.0.0.0/0" # Required for Sentry pods to connect
+      sentry/password: ""
+      sentry/networks/ip:
+        - "0.0.0.0/0"
     files:
       config.d/secret.xml:
         <clickhouse>
@@ -109,6 +111,9 @@ spec:
             <clickhouse_operator>
               <password from_env="OPERATOR_PASSWORD" />
             </clickhouse_operator>
+            <sentry>
+              <password from_env="SENTRY_PASSWORD" />
+            </sentry>
           </users>
         </clickhouse>
   templates:
@@ -122,15 +127,20 @@ spec:
                 - name: OPERATOR_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: clickhouse-operator-secret
-                      key: password
+                      name: clickhouse-secret
+                      key: operator-password
+                - name: SENTRY_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: clickhouse-secret
+                      key: sentry-password
   defaults:
     templates:
       podTemplate: clickhouse-single-node
 EOF
 ```
 
-**Note on Network Access**: The `users/default/networks/ip` setting is crucial. By default, ClickHouse might restrict access. Setting it to `0.0.0.0/0` allows the Sentry pods (which have dynamic IPs) to connect.
+**Note on Network Access**: The `users/sentry/networks/ip` and `users/default/networks/ip` settings are crucial. By default, ClickHouse might restrict access. Setting them to `0.0.0.0/0` allows the Sentry pods (which have dynamic IPs) to connect.
 
 Apply the manifest and wait for ClickHouse to become ready:
 ```bash
@@ -191,15 +201,15 @@ spec:
 EOF
 ```
 
-If using a separate Keeper, update your `ClickHouseInstallation` config to reference it:
+Apply the Keeper manifest and wait for it to become ready:
+```bash
+kubectl apply -f clickhouse-keeper.yaml
+kubectl -n clickhouse get chk clickhouse-keeper -w
+```
 
-```yaml
-spec:
-  configuration:
-    zookeeper:
-      nodes:
-        - host: keeper-clickhouse-keeper.clickhouse.svc.cluster.local
-          port: 2181
+Wait until all Keeper pods are `Running`:
+```bash
+kubectl -n clickhouse get pods -l clickhouse-keeper.altinity.com/chk=clickhouse-keeper
 ```
 
 ```yaml
@@ -220,8 +230,9 @@ spec:
       clickhouse_operator/password: ""
       clickhouse_operator/networks/ip:
         - "0.0.0.0/0"
-      default/networks/ip:
-        - "0.0.0.0/0" # Required for Sentry pods to connect
+      sentry/password: ""
+      sentry/networks/ip:
+        - "0.0.0.0/0"
     zookeeper:
       keeper:
         name: clickhouse-keeper
@@ -233,6 +244,9 @@ spec:
             <clickhouse_operator>
               <password from_env="OPERATOR_PASSWORD" />
             </clickhouse_operator>
+            <sentry>
+              <password from_env="SENTRY_PASSWORD" />
+            </sentry>
           </users>
         </clickhouse>
   templates:
@@ -246,12 +260,28 @@ spec:
                 - name: OPERATOR_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: clickhouse-operator-secret
-                      key: password
+                      name: clickhouse-secret
+                      key: operator-password
+                - name: SENTRY_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: clickhouse-secret
+                      key: sentry-password
   defaults:
     templates:
       podTemplate: clickhouse-single-node
 EOF
+```
+
+Apply the manifests and wait for ClickHouse to become ready:
+```bash
+kubectl apply -f clickhouse.yaml
+kubectl -n clickhouse get chi sentry-clickhouse -w
+```
+
+Wait until the `status.status` field shows `Completed` and the ClickHouse pods are `Running`:
+```bash
+kubectl -n clickhouse get pods -l clickhouse.altinity.com/chi=sentry-clickhouse
 ```
 
 ### Configuring Sentry Chart
@@ -274,8 +304,9 @@ externalClickhouse:
   host: "clickhouse-sentry-clickhouse.clickhouse.svc.cluster.local"
   tcpPort: 9000
   httpPort: 8123
-  username: "default"
-  password: "" # Set if you configured a password
+  username: "sentry"
+  existingSecret: "clickhouse-secret"
+  existingSecretKey: "sentry-password"
   database: "default"
   singleNode: true # Set to false if using a replicated cluster
 EOF

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ configs:
     config.yaml:
       watch:
         namespaces:
-          - sentry
+          - clickhouse
 EOF
 
 helm repo add clickhouse-operator https://helm.altinity.com
 helm repo update
 helm upgrade --install clickhouse-operator clickhouse-operator/altinity-clickhouse-operator \
-  --version 0.26.0 \
+  --version 0.27.0 \
   --namespace clickhouse-operator \
   --create-namespace \
   -f clickhouse-operator-values.yaml \
@@ -81,14 +81,11 @@ apiVersion: clickhouse.altinity.com/v1
 kind: ClickHouseInstallation
 metadata:
   name: sentry-clickhouse
-  namespace: sentry # Replace with your namespace
+  namespace: clickhouse # Replace with your namespace
 spec:
   configuration:
     clusters:
       - name: single-node
-        layout:
-          shardsCount: 1
-          replicasCount: 1
     users:
       default/networks/ip:
         - "0.0.0.0/0" # Required for Sentry pods to connect
@@ -109,13 +106,13 @@ EOF
 
 Apply the manifest and wait for ClickHouse to become ready:
 ```bash
-kubectl create ns sentry
+kubectl create ns clickhouse
 kubectl apply -f clickhouse.yaml
-kubectl -n sentry get chi sentry-clickhouse -w
+kubectl -n clickhouse get chi sentry-clickhouse -w
 ```
 Wait until the `status.status` field shows `Completed` and the ClickHouse pods are `Running`:
 ```bash
-kubectl -n sentry get pods -l clickhouse.altinity.com/chi=sentry-clickhouse
+kubectl -n clickhouse get pods -l clickhouse.altinity.com/chi=sentry-clickhouse
 ```
 
 #### 2. (Optional) Separate ClickHouse Keeper
@@ -124,11 +121,12 @@ For more robust deployments, you should run ClickHouse Keeper separately.
 
 **Keeper Manifest (`keeper.yaml`)**:
 ```yaml
+cat <<'EOF' > clickhouse.yaml
 apiVersion: clickhouse-keeper.altinity.com/v1
 kind: ClickHouseKeeperInstallation
 metadata:
   name: clickhouse-keeper
-  namespace: sentry
+  namespace: clickhouse
 spec:
   configuration:
     clusters:
@@ -162,6 +160,7 @@ spec:
           resources:
             requests:
               storage: 10Gi
+EOF
 ```
 
 If using a separate Keeper, update your `ClickHouseInstallation` config to reference it:
@@ -171,8 +170,40 @@ spec:
   configuration:
     zookeeper:
       nodes:
-        - host: keeper-clickhouse-keeper.sentry.svc.cluster.local
+        - host: keeper-clickhouse-keeper.clickhouse.svc.cluster.local
           port: 2181
+```
+
+```yaml
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: sentry-clickhouse
+  namespace: clickhouse
+spec:
+  configuration:
+    clusters:
+      - name: cluster-node
+        layout:
+          shardsCount: 1
+          replicasCount: 3
+    users:
+      default/networks/ip:
+        - "0.0.0.0/0" # Required for Sentry pods to connect
+    zookeeper:
+      keeper:
+        name: clickhouse-keeper
+        namespace: clickhouse
+  templates:
+    podTemplates:
+      - name: clickhouse-single-node
+        spec:
+          containers:
+            - name: clickhouse
+              image: altinity/clickhouse-server:25.3.6.10034.altinitystable
+  defaults:
+    templates:
+      podTemplate: clickhouse-single-node
 ```
 
 ### Configuring Sentry Chart
@@ -181,7 +212,7 @@ Once your ClickHouse cluster is running, configure the Sentry Helm chart to use 
 
 **Find the ClickHouse service name** created by the operator:
 ```bash
-kubectl -n sentry get svc -l clickhouse.altinity.com/chi=sentry-clickhouse
+kubectl -n clickhouse get svc -l clickhouse.altinity.com/chi=sentry-clickhouse
 ```
 
 The Altinity Operator creates services following this naming convention:
@@ -192,7 +223,7 @@ The Altinity Operator creates services following this naming convention:
 ```bash
 cat <<'EOF' > values.yaml
 externalClickhouse:
-  host: "chi-sentry-clickhouse-single-node-0-0.sentry.svc.cluster.local"
+  host: "clickhouse-sentry-clickhouse.clickhouse.svc.cluster.local"
   tcpPort: 9000
   httpPort: 8123
   username: "default"

--- a/README.md
+++ b/README.md
@@ -73,18 +73,17 @@ Below is a Minimum Viable Product (MVP) configuration for a single-node ClickHou
 
 #### 1. Create ClickHouse Secrets
 
-Create a secret with credentials for both the `clickhouse_operator` user (used by the Altinity Operator to manage the cluster) and the `sentry` user (used by Sentry to access ClickHouse):
+Create a secret with credentials for the `sentry` user (used by Sentry to access ClickHouse):
 
 ```bash
 kubectl create ns clickhouse
 kubectl -n clickhouse create secret generic clickhouse-secret \
-  --from-literal=operator-password='YourStrongOperatorPassword!' \
   --from-literal=sentry-password='YourStrongSentryPassword!'
 ```
 
 #### 2. ClickHouse Installation Manifest
 
-Save this as `clickhouse.yaml`. This example deploys a single-node cluster. Passwords for both the operator and Sentry are loaded from the secret created above.
+Save this as `clickhouse.yaml`. This example deploys a single-node cluster. The Sentry user password is loaded from the secret created above. The operator manages its own `clickhouse_operator` user automatically — do not define it in `users.d/secret.xml`.
 
 ```bash
 cat <<'EOF' > clickhouse.yaml
@@ -98,21 +97,17 @@ spec:
     clusters:
       - name: single-node
     users:
-      clickhouse_operator/password: ""
       clickhouse_operator/networks/ip:
-        - "0.0.0.0/0"
-      sentry/password: ""
-      sentry/networks/ip:
         - "0.0.0.0/0"
     files:
       users.d/secret.xml:
         <clickhouse>
           <users>
-            <clickhouse_operator>
-              <password from_env="OPERATOR_PASSWORD" />
-            </clickhouse_operator>
             <sentry>
               <password from_env="SENTRY_PASSWORD" />
+              <networks>
+                <ip>0.0.0.0/0</ip>
+              </networks>
             </sentry>
           </users>
         </clickhouse>
@@ -124,11 +119,6 @@ spec:
             - name: clickhouse
               image: altinity/clickhouse-server:25.3.6.10034.altinitystable
               env:
-                - name: OPERATOR_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: clickhouse-secret
-                      key: operator-password
                 - name: SENTRY_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -140,7 +130,7 @@ spec:
 EOF
 ```
 
-**Note on Network Access**: The `users/sentry/networks/ip` and `users/default/networks/ip` settings are crucial. By default, ClickHouse might restrict access. Setting them to `0.0.0.0/0` allows the Sentry pods (which have dynamic IPs) to connect.
+**Note on Network Access**: The `sentry/networks/ip` setting is crucial. By default, ClickHouse might restrict access. Setting it to `0.0.0.0/0` allows the Sentry pods (which have dynamic IPs) to connect. Do not define the `clickhouse_operator` user in `users.d/secret.xml` — the Altinity Operator manages it automatically.
 
 Apply the manifest and wait for ClickHouse to become ready:
 ```bash
@@ -226,11 +216,7 @@ spec:
           shardsCount: 1
           replicasCount: 3
     users:
-      clickhouse_operator/password: ""
       clickhouse_operator/networks/ip:
-        - "0.0.0.0/0"
-      sentry/password: ""
-      sentry/networks/ip:
         - "0.0.0.0/0"
     zookeeper:
       keeper:
@@ -240,11 +226,11 @@ spec:
       users.d/secret.xml:
         <clickhouse>
           <users>
-            <clickhouse_operator>
-              <password from_env="OPERATOR_PASSWORD" />
-            </clickhouse_operator>
             <sentry>
               <password from_env="SENTRY_PASSWORD" />
+              <networks>
+                <ip>0.0.0.0/0</ip>
+              </networks>
             </sentry>
           </users>
         </clickhouse>
@@ -256,11 +242,6 @@ spec:
             - name: clickhouse
               image: altinity/clickhouse-server:25.3.6.10034.altinitystable
               env:
-                - name: OPERATOR_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: clickhouse-secret
-                      key: operator-password
                 - name: SENTRY_PASSWORD
                   valueFrom:
                     secretKeyRef:

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ kubectl -n clickhouse get svc -l clickhouse.altinity.com/chi=sentry-clickhouse
 ```
 
 The Altinity Operator creates services following this naming convention:
-- `clickhouse-sentry-clickhouse` — main load-balanced service (recommended for single-node setups)
-- `chi-sentry-clickhouse-single-node-0-0` — per-pod service for shard 0, replica 0
+- `clickhouse-sentry-clickhouse` — main load-balanced service
+- `chi-sentry-clickhouse-cluster-node-0-0` — per-pod service for shard 0, replica 0
 
 **Create your `values.yaml`** using the service name from the command above:
 ```bash
@@ -308,7 +308,8 @@ externalClickhouse:
   existingSecret: "clickhouse-secret"
   existingSecretKey: "sentry-password"
   database: "default"
-  singleNode: true # Set to false if using a replicated cluster
+  singleNode: false
+  clusterName: cluster-node
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,15 @@ kubectl -n clickhouse get pods -l clickhouse.altinity.com/chi=sentry-clickhouse
 
 Once your ClickHouse cluster is running, configure the Sentry Helm chart to use it.
 
+**Create the ClickHouse secret in the Sentry namespace** (Kubernetes secrets are namespace-scoped, so the secret must exist in the same namespace as the Sentry pods).
+
+**Important**: The `sentry-password` value must match the one used in the `clickhouse-secret` in the `clickhouse` namespace (created in step 1), as this is the actual password for the `sentry` user in ClickHouse.
+
+```bash
+kubectl -n sentry create secret generic clickhouse-secret \
+  --from-literal=sentry-password='YourStrongSentryPassword!'
+```
+
 **Find the ClickHouse service name** created by the operator:
 ```bash
 kubectl -n clickhouse get svc -l clickhouse.altinity.com/chi=sentry-clickhouse

--- a/README.md
+++ b/README.md
@@ -71,9 +71,19 @@ Ensure the operator pod is in `Running` state before proceeding.
 
 Below is a Minimum Viable Product (MVP) configuration for a single-node ClickHouse instance suitable for testing or small-scale deployments. For production, we recommend a high-availability setup with at least 3 Keeper nodes and 2 ClickHouse replicas.
 
-#### 1. ClickHouse Installation Manifest
+#### 1. Create ClickHouse Operator Secret
 
-Save this as `clickhouse.yaml`. This example deploys a single-node cluster.
+Create a secret for the `clickhouse_operator` user that the Altinity Operator uses to manage the ClickHouse cluster:
+
+```bash
+kubectl -n clickhouse create secret generic clickhouse-operator-secret \
+  --from-literal=username=clickhouse_operator \
+  --from-literal=password='YourStrongOperatorPassword!'
+```
+
+#### 2. ClickHouse Installation Manifest
+
+Save this as `clickhouse.yaml`. This example deploys a single-node cluster. The operator password is loaded from the secret created above.
 
 ```bash
 cat <<'EOF' > clickhouse.yaml
@@ -87,8 +97,20 @@ spec:
     clusters:
       - name: single-node
     users:
+      clickhouse_operator/password: ""
+      clickhouse_operator/networks/ip:
+        - "0.0.0.0/0"
       default/networks/ip:
         - "0.0.0.0/0" # Required for Sentry pods to connect
+    files:
+      config.d/secret.xml:
+        <clickhouse>
+          <users>
+            <clickhouse_operator>
+              <password from_env="OPERATOR_PASSWORD" />
+            </clickhouse_operator>
+          </users>
+        </clickhouse>
   templates:
     podTemplates:
       - name: clickhouse-single-node
@@ -96,6 +118,12 @@ spec:
           containers:
             - name: clickhouse
               image: altinity/clickhouse-server:25.3.6.10034.altinitystable
+              env:
+                - name: OPERATOR_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: clickhouse-operator-secret
+                      key: password
   defaults:
     templates:
       podTemplate: clickhouse-single-node
@@ -115,7 +143,7 @@ Wait until the `status.status` field shows `Completed` and the ClickHouse pods a
 kubectl -n clickhouse get pods -l clickhouse.altinity.com/chi=sentry-clickhouse
 ```
 
-#### 2. (Optional) Separate ClickHouse Keeper
+#### 3. (Optional) Separate ClickHouse Keeper
 
 For more robust deployments, you should run ClickHouse Keeper separately.
 
@@ -189,12 +217,24 @@ spec:
           shardsCount: 1
           replicasCount: 3
     users:
+      clickhouse_operator/password: ""
+      clickhouse_operator/networks/ip:
+        - "0.0.0.0/0"
       default/networks/ip:
         - "0.0.0.0/0" # Required for Sentry pods to connect
     zookeeper:
       keeper:
         name: clickhouse-keeper
         namespace: clickhouse
+    files:
+      config.d/secret.xml:
+        <clickhouse>
+          <users>
+            <clickhouse_operator>
+              <password from_env="OPERATOR_PASSWORD" />
+            </clickhouse_operator>
+          </users>
+        </clickhouse>
   templates:
     podTemplates:
       - name: clickhouse-single-node
@@ -202,6 +242,12 @@ spec:
           containers:
             - name: clickhouse
               image: altinity/clickhouse-server:25.3.6.10034.altinitystable
+              env:
+                - name: OPERATOR_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: clickhouse-operator-secret
+                      key: password
   defaults:
     templates:
       podTemplate: clickhouse-single-node

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ spec:
       sentry/networks/ip:
         - "0.0.0.0/0"
     files:
-      config.d/secret.xml:
+      users.d/secret.xml:
         <clickhouse>
           <users>
             <clickhouse_operator>
@@ -238,7 +238,7 @@ spec:
         name: clickhouse-keeper
         namespace: clickhouse
     files:
-      config.d/secret.xml:
+      users.d/secret.xml:
         <clickhouse>
           <users>
             <clickhouse_operator>

--- a/README.md
+++ b/README.md
@@ -2,30 +2,6 @@
 
 Sentry is a cross-platform crash reporting and aggregation platform.
 
-This repository aims to support Sentry >=10 and move out from the deprecated Helm charts official repo.
-
-Big thanks to the maintainers of the [deprecated chart](https://github.com/helm/charts/tree/master/stable/sentry). This work has been partly inspired by it.
-
-## Sentry Admin Secret
-
-Before installing Sentry, you must create a secret for the admin password:
-
-1. Create the secret:
-
-```bash
-kubectl create namespace sentry
-kubectl create secret generic sentry-admin-password \
-  --from-literal=admin-password='YourStrongPassword123!' \
-  --namespace sentry
-```
-
-2. Set in `values.yaml`:
-
-```yaml
-user:
-  existingSecret: sentry-admin-password
-```
-
 ## External ClickHouse Configuration
 
 ### Background
@@ -305,6 +281,24 @@ EOF
 ### Verification
 
 After deployment, you can verify the connection by checking the logs of the `snuba-api` or `snuba-consumer` pods, or by ensuring that Sentry is processing events correctly.
+
+## Sentry Admin Secret
+
+Before installing Sentry, create the namespace and secret for the admin password:
+
+```bash
+kubectl create namespace sentry
+kubectl create secret generic sentry-admin-password \
+  --from-literal=admin-password='YourStrongPassword123!' \
+  --namespace sentry
+```
+
+Set in `values.yaml`:
+
+```yaml
+user:
+  existingSecret: sentry-admin-password
+```
 
 ## How this chart works
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For more robust deployments, you should run ClickHouse Keeper separately.
 
 **Keeper Manifest (`keeper.yaml`)**:
 ```yaml
-cat <<'EOF' > clickhouse.yaml
+cat <<'EOF' > clickhouse-keeper.yaml
 apiVersion: clickhouse-keeper.altinity.com/v1
 kind: ClickHouseKeeperInstallation
 metadata:
@@ -175,6 +175,7 @@ spec:
 ```
 
 ```yaml
+cat <<'EOF' > clickhouse.yaml
 apiVersion: clickhouse.altinity.com/v1
 kind: ClickHouseInstallation
 metadata:
@@ -204,6 +205,7 @@ spec:
   defaults:
     templates:
       podTemplate: clickhouse-single-node
+EOF
 ```
 
 ### Configuring Sentry Chart

--- a/README.md
+++ b/README.md
@@ -178,11 +178,10 @@ spec:
   templates:
     podTemplates:
       - name: keeper-pod
-        metadata:
+        spec:
           containers:
             - name: clickhouse-keeper
               image: altinity/clickhouse-keeper:25.3.6.10034.altinitystable
-        spec:
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -212,7 +211,7 @@ Wait until all Keeper pods are `Running`:
 kubectl -n clickhouse get pods -l clickhouse-keeper.altinity.com/chk=clickhouse-keeper
 ```
 
-```yaml
+```bash
 cat <<'EOF' > clickhouse.yaml
 apiVersion: clickhouse.altinity.com/v1
 kind: ClickHouseInstallation

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2796,7 +2796,7 @@ externalClickhouse:
   ## External ClickHouse configuration (required).
   ## Hostname or ip address of external clickhouse
   ##
-  host: "clickhouse"
+  host: "clickhouse-sentry-clickhouse.clickhouse.svc.cluster.local"
   tcpPort: 9000
   httpPort: 8123
   username: default

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -32,7 +32,7 @@ user:
   password: ""
 
   ## set this value to an existingSecret name to create the admin user with the password in the secret
-  # existingSecret: sentry-admin-password
+  existingSecret: sentry-admin-password
 
   ## set this value to an existingSecretKey which holds the password to be used for sentry admin user default key is `admin-password`
   # existingSecretKey: admin-password
@@ -2799,18 +2799,16 @@ externalClickhouse:
   host: "clickhouse-sentry-clickhouse.clickhouse.svc.cluster.local"
   tcpPort: 9000
   httpPort: 8123
-  username: default
-  password: ""
+  username: sentry
+  existingSecret: "clickhouse-secret"
+  existingSecretKey: "sentry-password"
   database: default
-  singleNode: true
-  # existingSecret: secret-name
-  ## set existingSecretKey if key name inside existingSecret is different from 'postgres-password'
-  # existingSecretKey: secret-key-name
+  singleNode: false
   ## Cluster name, can be found in config
   ## (https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-remote-servers)
   ## or by executing `select * from system.clusters`
   ##
-  # clusterName: test_shard_localhost
+  clusterName: cluster-node
   ## Optional: separate distributed cluster name (defaults to clusterName)
   ## Use this when your ClickHouse distributed queries need a different cluster name
   ##


### PR DESCRIPTION
## Summary

- Update ClickHouse documentation to use dedicated `clickhouse` namespace instead of `sentry`
- Upgrade clickhouse-operator version from `0.26.0` to `0.27.0`
- Add complete ClickHouseInstallation example with cluster layout and ClickHouse Keeper reference
- Fix default `externalClickhouse.host` in `values.yaml` to use fully qualified service name

## Changes

### README.md
- Changed all namespace references from `sentry` to `clickhouse` for ClickHouse components
- Updated `watch.namespaces` in clickhouse-operator values to `clickhouse`
- Bumped clickhouse-operator Helm chart version to `0.27.0`
- Removed `layout` block from the initial simple ClickHouseInstallation example
- Added a new complete ClickHouseInstallation example with 3 replicas and ClickHouse Keeper reference
- Wrapped ClickHouseKeeperInstallation example in a `cat <<'EOF'` block for consistency
- Updated service hostname in `externalClickhouse.host` example to match new naming convention

### values.yaml
- Updated default `externalClickhouse.host` from `"clickhouse"` to `"clickhouse-sentry-clickhouse.clickhouse.svc.cluster.local"`