### PR TITLE
docs: improve ClickHouse and Keeper integration examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,16 @@ spec:
   templates:
     podTemplates:
       - name: keeper-pod
-        metadata:
+        spec:
           containers:
             - name: clickhouse-keeper
               image: altinity/clickhouse-keeper:25.3.6.10034.altinitystable
-        spec:
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:
                     matchLabels:
-                      app: clickhouse-keeper
+                      clickhouse-keeper.altinity.com/chk: clickhouse-keeper
                   topologyKey: kubernetes.io/hostname
     volumeClaimTemplates:
       - name: keeper-storage
@@ -164,16 +163,73 @@ spec:
               storage: 10Gi
 ```
 
+Wait for all 3 Keeper pods to be ready:
+```bash
+kubectl -n sentry get pods -l clickhouse-keeper.altinity.com/chk=clickhouse-keeper
+```
+
 If using a separate Keeper, update your `ClickHouseInstallation` config to reference it:
 
 ```yaml
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: sentry-clickhouse
+  namespace: sentry
 spec:
   configuration:
+    users:
+      default/networks/ip:
+        - "0.0.0.0/0"
+      clickhouse_operator/password: "clickhouse_operator_password"
+      clickhouse_operator/networks/ip:
+        - "0.0.0.0/0"
+    clusters:
+      - name: sentry-cluster
+        layout:
+          shardsCount: 1
+          replicasCount: 3
+        templates:
+          podTemplate: clickhouse
+          volumeClaimTemplate: data-volume
     zookeeper:
       nodes:
-        - host: keeper-clickhouse-keeper.sentry.svc.cluster.local
+        - host: chk-clickhouse-keeper-keeper-cluster-0-0.sentry.svc.cluster.local
           port: 2181
+        - host: chk-clickhouse-keeper-keeper-cluster-0-1.sentry.svc.cluster.local
+          port: 2181
+        - host: chk-clickhouse-keeper-keeper-cluster-0-2.sentry.svc.cluster.local
+          port: 2181
+  templates:
+    podTemplates:
+      - name: clickhouse
+        spec:
+          containers:
+            - name: clickhouse
+              image: altinity/clickhouse-server:25.3.6.10034.altinitystable
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      clickhouse.altinity.com/chi: sentry-clickhouse
+                  topologyKey: kubernetes.io/hostname
+    volumeClaimTemplates:
+      - name: data-volume
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+  defaults:
+    replicasUseFQDN: "true"
+    templates:
+      podTemplate: clickhouse
+      dataVolumeClaimTemplate: data-volume
 ```
+
+**Note**: The `clusterName` in your Sentry `values.yaml` must match the cluster name in the manifest above (`sentry-cluster`).
 
 ### Configuring Sentry Chart
 
@@ -192,13 +248,14 @@ The Altinity Operator creates services following this naming convention:
 ```bash
 cat <<'EOF' > values.yaml
 externalClickhouse:
-  host: "chi-sentry-clickhouse-single-node-0-0.sentry.svc.cluster.local"
+  host: "clickhouse-sentry-clickhouse.sentry.svc.cluster.local"
   tcpPort: 9000
   httpPort: 8123
   username: "default"
   password: "" # Set if you configured a password
   database: "default"
-  singleNode: true # Set to false if using a replicated cluster
+  singleNode: false # Set to false if using a replicated cluster
+  clusterName: "sentry-cluster" 
 EOF
 ```
 


### PR DESCRIPTION
- Fix Keeper podTemplate structure (metadata -> spec)
- Add instruction to wait for Keeper pods readiness
- Expand ClickHouseInstallation example with full configuration (users, clusters, templates, volumeClaimTemplates)
- Update ZooKeeper hosts to correct CHK cluster service names
- Update externalClickhouse parameters (host, singleNode, clusterName)


test with values:
```
user:
  existingSecret: sentry-admin-password

externalClickhouse:
  host: "clickhouse-sentry-clickhouse.sentry.svc.cluster.local"
  tcpPort: 9000
  httpPort: 8123
  username: "default"
  password: ""
  database: "default"
  singleNode: false
  clusterName: "sentry-cluster"
```

pods:
```
k get pod -n sentry
NAME                                                              READY   STATUS    RESTARTS      AGE
chi-sentry-clickhouse-sentry-cluster-0-0-0                        1/1     Running   0             52m
chi-sentry-clickhouse-sentry-cluster-0-1-0                        1/1     Running   0             51m
chi-sentry-clickhouse-sentry-cluster-0-2-0                        1/1     Running   0             50m
chk-clickhouse-keeper-keeper-cluster-0-0-0                        1/1     Running   0             53m
chk-clickhouse-keeper-keeper-cluster-0-1-0                        1/1     Running   0             53m
chk-clickhouse-keeper-keeper-cluster-0-2-0                        1/1     Running   0             53m
my-sentry-billing-metrics-consumer-78c64547cf-s4x4k               1/1     Running   0             6m28s
my-sentry-generic-metrics-consumer-58b88586cc-pfx2j               1/1     Running   0             6m27s
my-sentry-ingest-consumer-attachments-5487868765-ntt9c            1/1     Running   0             6m27s
my-sentry-ingest-consumer-events-86474c7fb9-frcq8                 1/1     Running   0             6m26s
my-sentry-ingest-consumer-transactions-64bf88479c-4c7qp           1/1     Running   0             6m25s
my-sentry-ingest-feedback-55dbb765d5-pffg5                        1/1     Running   0             6m24s
my-sentry-ingest-monitors-86db84bd9-b4gjz                         1/1     Running   0             6m23s
my-sentry-ingest-occurrences-67c8745d96-97rcz                     1/1     Running   0             6m22s
my-sentry-ingest-replay-recordings-5f67ddfb4-gdksl                1/1     Running   0             6m22s
my-sentry-issue-occurrence-consumer-65b7b5dd49-r9xfc              1/1     Running   0             6m2s
my-sentry-kafka-controller-0                                      1/1     Running   0             47m
my-sentry-kafka-controller-1                                      1/1     Running   0             47m
my-sentry-kafka-controller-2                                      1/1     Running   0             47m
my-sentry-metrics-consumer-6997bd7cb9-jkpqs                       1/1     Running   0             6m21s
my-sentry-monitors-clock-tasks-5579c89944-zw24k                   1/1     Running   0             6m20s
my-sentry-monitors-clock-tick-9455f7cff-x9dtf                     1/1     Running   0             6m19s
my-sentry-post-process-forward-errors-76bfdc8f49-rz5kg            1/1     Running   0             6m19s
my-sentry-post-process-forward-issue-platform-76bb9856-h4stp      1/1     Running   0             6m18s
my-sentry-post-process-forward-transactions-6bc79b46f8-5zxjr      1/1     Running   0             6m17s
my-sentry-process-segments-84964dfd77-959r6                       1/1     Running   0             6m16s
my-sentry-process-spans-59ffc64c74-jq5ms                          1/1     Running   0             6m15s
my-sentry-relay-7bc9f8bdb5-bv5xs                                  1/1     Running   0             5m53s
my-sentry-sentry-postgresql-0                                     1/1     Running   0             47m
my-sentry-sentry-redis-master-0                                   1/1     Running   0             47m
my-sentry-sentry-redis-replicas-0                                 1/1     Running   1 (45m ago)   47m
my-sentry-snuba-api-9784955c9-7kwm2                               1/1     Running   0             47m
my-sentry-snuba-consumer-64d69474b9-h4cpb                         1/1     Running   0             6m15s
my-sentry-snuba-eap-items-consumer-f48d47b9c-88rx9                1/1     Running   0             6m9s
my-sentry-snuba-generic-metrics-counters-consumer-75c7bcf57snhv   1/1     Running   0             6m9s
my-sentry-snuba-generic-metrics-distributions-consumer-84d9rqrc   1/1     Running   0             6m8s
my-sentry-snuba-generic-metrics-gauges-consumer-6c469774c-ggjkw   1/1     Running   0             6m7s
my-sentry-snuba-generic-metrics-sets-consumer-754fc9f585-h7wx6    1/1     Running   0             6m6s
my-sentry-snuba-group-attributes-consumer-846dc94dfc-4978k        1/1     Running   0             6m5s
my-sentry-snuba-metrics-consumer-6c9c64dc6b-4pngd                 1/1     Running   0             6m5s
my-sentry-snuba-outcomes-billing-consumer-5d65f5748b-wcz7z        1/1     Running   0             6m4s
my-sentry-snuba-outcomes-consumer-779bf98974-5fl8q                1/1     Running   0             6m1s
my-sentry-snuba-replacer-bf6445fd6-bpszf                          1/1     Running   0             6m
my-sentry-snuba-replays-consumer-7968b8c85f-22dgr                 1/1     Running   0             6m3s
my-sentry-snuba-subscription-consumer-eap-items-6f645f569dxjn8x   1/1     Running   0             5m59s
my-sentry-snuba-subscription-consumer-events-d58c48b45-4t9j4      1/1     Running   0             5m59s
my-sentry-snuba-subscription-consumer-generic-metrics-counr8lv2   1/1     Running   0             5m58s
my-sentry-snuba-subscription-consumer-generic-metrics-distnk4p5   1/1     Running   0             5m57s
my-sentry-snuba-subscription-consumer-generic-metrics-gaugdcw8b   1/1     Running   0             5m56s
my-sentry-snuba-subscription-consumer-generic-metrics-setsxhbs2   1/1     Running   0             5m55s
my-sentry-snuba-subscription-consumer-metrics-8597fd59c8-87twd    1/1     Running   0             5m54s
my-sentry-snuba-subscription-consumer-transactions-77665dcxc8lr   1/1     Running   0             5m54s
my-sentry-snuba-transactions-consumer-5f9ccdccf7-tjktv            1/1     Running   0             6m2s
my-sentry-subscription-consumer-events-56c59f6b68-fzg7t           1/1     Running   0             6m14s
my-sentry-subscription-consumer-generic-metrics-6c76cd66f6pttmn   1/1     Running   0             6m13s
my-sentry-subscription-consumer-metrics-774b6759dd-l977g          1/1     Running   0             6m12s
my-sentry-subscription-consumer-results-eap-items-bf7dbf7cdd8cs   1/1     Running   0             6m12s
my-sentry-subscription-consumer-transactions-7fd47d8bdd-dz7wr     1/1     Running   0             6m11s
my-sentry-taskbroker-default-0                                    1/1     Running   0             47m
my-sentry-taskbroker-ingest-0                                     1/1     Running   7 (38m ago)   47m
my-sentry-taskbroker-long-0                                       1/1     Running   7 (38m ago)   47m
my-sentry-taskbroker-products-0                                   1/1     Running   2 (45m ago)   47m
my-sentry-taskscheduler-d5965655c-grwnc                           1/1     Running   2 (45m ago)   47m
my-sentry-taskworker-default-5c86d56784-j5zj2                     1/1     Running   2 (45m ago)   47m
my-sentry-taskworker-ingest-cb6cf5766-mdcsb                       1/1     Running   1 (46m ago)   47m
my-sentry-taskworker-long-7589ccb674-r4krp                        1/1     Running   2 (45m ago)   47m
my-sentry-taskworker-products-5497df5d74-7zkj5                    1/1     Running   1 (46m ago)   47m
my-sentry-uptime-results-7b4bdbddb6-gvpz5                         1/1     Running   0             6m10s
my-sentry-web-584c769988-h6rd2                                    1/1     Running   2 (45m ago)   47m
```