### PR TITLE
fix: uncomment tolerations and fix type from {} to [] for snuba cleanup and cleanerfs

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1246,7 +1246,7 @@ sentry:
     # podLabels: {}
     # affinity: {}
     # nodeSelector: {}
-    # tolerations: {}
+    tolerations: []
 
   # Sentry settings of connections to Kafka
   kafka:
@@ -2749,7 +2749,7 @@ cleanerfs:
 # podLabels: {}
 # affinity: {}
 # nodeSelector: {}
-# tolerations: {}
+tolerations: []
 
 config:
   # No YAML Extension Config Given


### PR DESCRIPTION
### Problem

Two remaining `tolerations` fields in `values.yaml` were:
1. Commented out (`# tolerations: {}`)
2. Using wrong type (`{}` — map instead of `[]` — list)

Kubernetes `tolerations` spec requires a list (array), not a map. Using `{}` as default is incorrect and may cause type errors when users override the value with a list.

### Changes

| Component | File | Line | Before | After |
|-----------|------|------|--------|-------|
| `sentry.snuba.cleanup` | `values.yaml` | 1249 | `# tolerations: {}` | `tolerations: []` |
| `cleanerfs` | `values.yaml` | 2752 | `# tolerations: {}` | `tolerations: []` |

### Why `[]` instead of `{}`

- Kubernetes API defines `tolerations` as `[]corev1.Toleration` (a list)
- All other 71 `tolerations` entries in `values.yaml` already use `[]`
- Helm templates use `toYaml` which must serialize a list, not a map

### Notes

- No functional change to default behavior — both `[]` and `{}` evaluate to falsy in Go templates, so the `tolerations` block is not rendered unless explicitly set by the user
