### PR TITLE
feat: add minInsyncReplicas support for external Kafka topic provisioning

### DIFF
--- a/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
@@ -26,6 +26,7 @@
 {{- $topicOverrides := $provisioning.topicOverrides | default dict }}
 {{- $replicationFactor := int ($provisioning.replicationFactor | default 1) }}
 {{- $defaultPartitions := int ($provisioning.numPartitions | default 1) }}
+{{- $minInsyncReplicas := $provisioning.minInsyncReplicas | default "" }}
 
 {{- $clusterName := $topicctl.clusterName | default "sentry-kafka" }}
 {{- $environment := $topicctl.environment | default "default" }}
@@ -93,6 +94,9 @@ data:
     {{- $config := .config | default dict }}
     {{- if $override.config }}
     {{-   $config = mustMergeOverwrite (dict) $config $override.config }}
+    {{- end }}
+    {{- if and $minInsyncReplicas (not (hasKey $config "min.insync.replicas")) }}
+    {{-   $config = merge $config (dict "min.insync.replicas" ($minInsyncReplicas | toString)) }}
     {{- end }}
     ---
     meta:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3109,7 +3109,12 @@ externalKafka:
     #     config:
     #       "cleanup.policy": "compact,delete"
     #       "min.compaction.lag.ms": "3600000"
+    #       "min.insync.replicas": "2"
     replicationFactor: 3
+    # min.insync.replicas setting for provisioned topics.
+    # When set, adds "min.insync.replicas" to every topic's settings.
+    # Can be overridden per-topic via topicOverrides[].config["min.insync.replicas"].
+    # minInsyncReplicas: 1
     numPartitions: 1
     resources: {}
     nodeSelector: {}


### PR DESCRIPTION
Adds a new `externalKafka.provisioning.minInsyncReplicas` parameter that sets `min.insync.replicas` on all provisioned Kafka topics via topicctl.

### Changes

- **`values.yaml`**: Added `minInsyncReplicas` field under `externalKafka.provisioning`, with documentation comments. Also added an example of `"min.insync.replicas"` in the `topicOverrides` config sample.
- **`configmap-kafka-provisioning.yaml`**: Reads `minInsyncReplicas` from provisioning values and injects `min.insync.replicas` into every topic's `settings` block, unless the topic already has it defined via `topicOverrides`.

Fix https://github.com/sentry-kubernetes/charts/issues/2130
Fix https://github.com/sentry-kubernetes/charts/issues/2152

### Usage

```yaml
externalKafka:
  provisioning:
    enabled: true
    replicationFactor: 3
    minInsyncReplicas: 2
```

Per-topic override is also supported:

```yaml
topicOverrides:
  some-topic:
    config:
      "min.insync.replicas":"2"
```

### Why

When using an external Kafka cluster with `replicationFactor > 1`, it is a common best practice to set `min.insync.replicas` to ensure data durability. Previously there was no way to set this globally for all provisioned topics without manually adding it to every topic's config override.
