### PR TITLE
fix: set worker threads explicitly

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -338,6 +338,7 @@ sentry.conf.py: |-
       "http-chunked-input": {{ .Values.config.web.httpChunkedInput | ternary "True" "False" }},
       # the number of web workers
       'workers': {{ .Values.config.web.workers | int }},
+      'threads': {{ .Values.config.web.threads | int }},
       # Turn off memory reporting
       "memory-report": {{ .Values.config.web.memoryReport | ternary "True" "False" }},
       # Some stuff so uwsgi will cycle workers sensibly

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2778,6 +2778,7 @@ config:
     httpKeepalive: 15
     httpChunkedInput: true
     workers: 3
+    threads: 4
     memoryReport: false
     maxRequests: 100000
     maxRequestsDelta: 500


### PR DESCRIPTION
Aligns the config with the [self-hosted repo](https://github.com/getsentry/self-hosted/blob/7fa000f5dc8202ebd2a80285fefdd09d53c6a6a3/sentry/sentry.conf.example.py#L303). 

Without this, on machines with a higher amount of CPU cores, sentry would start an absurd amount of workers (20-30 in my case on an 8-core node), resulting in workers dying unexpectedly.