### PR TITLE
fix: increase hooks.activeDeadlineSeconds to 1200

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ After deployment, you can verify the connection by checking the logs of the `snu
 ```
 helm repo add sentry https://sentry-kubernetes.github.io/charts
 helm repo update
-helm install my-sentry sentry/sentry -f values.yaml --wait --timeout=1000s
+helm install -n sentry my-sentry sentry/sentry -f values.yaml --wait --timeout=1500s
 ```
 
 ## Values

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2094,7 +2094,7 @@ hooks:
   enabled: true
   preUpgrade: false
   removeOnSuccess: true
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 1200
   shareProcessNamespace: false
   dbCheck:
     enabled: true


### PR DESCRIPTION
Increase default `hooks.activeDeadlineSeconds` from `600` to `1200` in `charts/sentry/values.yaml` and update README command example.

## Why
`my-sentry-snuba-migrate` was failing with:
- `DeadlineExceeded`
- `Job was active longer than specified deadline`

The issue was observed on a cluster running 3 ClickHouse replicas + 3 ClickHouse Keeper nodes. With this topology, `snuba migrations migrate --force` takes longer than the previous 10‑minute deadline, causing the job to be killed by Kubernetes.

## Changes
- `charts/sentry/values.yaml`: `hooks.activeDeadlineSeconds: 600 -> 1200`
- `README.md`: updated example to include `-n sentry` and `--timeout=1500s`
