### PR TITLE
feat: bump Sentry appVersion to 26.5.0

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 31.3.1
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 26.4.2
+appVersion: 26.5.0
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2796,7 +2796,7 @@ externalClickhouse:
   ## External ClickHouse configuration (required).
   ## Hostname or ip address of external clickhouse
   ##
-  host: "clickhouse-sentry-clickhouse.sentry.svc.cluster.local"
+  host: "clickhouse"
   tcpPort: 9000
   httpPort: 8123
   username: default

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2796,7 +2796,7 @@ externalClickhouse:
   ## External ClickHouse configuration (required).
   ## Hostname or ip address of external clickhouse
   ##
-  host: "clickhouse"
+  host: "clickhouse-sentry-clickhouse.sentry.svc.cluster.local"
   tcpPort: 9000
   httpPort: 8123
   username: default


### PR DESCRIPTION
- Bump `appVersion` from `26.4.2` to `26.5.0` in `charts/sentry/Chart.yaml`
- Update default external ClickHouse host from `clickhouse` to `clickhouse-sentry-clickhouse.sentry.svc.cluster.local` in `charts/sentry/values.yaml`