### PR TITLE
chore: uncomment env and sidecars fields to enable automated validation in future

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -117,7 +117,7 @@ vroom:
   securityContext: {}
   containerSecurityContext: {}
   # priorityClassName: ""
-  # topologySpreadConstraints: []
+  topologySpreadConstraints: []
   service:
     annotations: {}
   tolerations: []
@@ -153,7 +153,7 @@ vroom:
     # Only available with autoscaling/v2
     behavior: {}
   sidecars: []
-  # topologySpreadConstraints: []
+  topologySpreadConstraints: []
   volumes: []
   volumeMounts: []
 
@@ -177,7 +177,7 @@ uptimeChecker:
   # podLabels: {}
 
   sidecars: []
-  # topologySpreadConstraints: []
+  topologySpreadConstraints: []
   volumes: []
   volumeMounts: []
 
@@ -237,7 +237,7 @@ relay:
     resources: {}
     # additionalArgs: []
     # credentialsSubcommand: ""
-    # env: []
+    env: []
     volumes: []
     volumeMounts: []
   # cache:
@@ -2082,9 +2082,9 @@ snuba:
     # affinity: {}
     # nodeSelector: {}
     tolerations: []
-    # env: []
+    env: []
     volumes: []
-    # sidecars: []
+    sidecars: []
     # containerSecurityContext: {}
     # securityContext: {}
     annotations: {}
@@ -2269,7 +2269,7 @@ symbolicator:
 
     volumes: []
     volumeMounts: []
-    # sidecars: []
+    sidecars: []
 
 auth:
   register: true

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -153,7 +153,6 @@ vroom:
     # Only available with autoscaling/v2
     behavior: {}
   sidecars: []
-  topologySpreadConstraints: []
   volumes: []
   volumeMounts: []
 

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -234,7 +234,7 @@ relay:
   volumeMounts: []
   init:
     resources: {}
-    # additionalArgs: []
+    additionalArgs: []
     # credentialsSubcommand: ""
     env: []
     volumes: []

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -92,7 +92,7 @@ serviceAccount:
 
 vroom:
   annotations: {}
-  # args: []
+  args: []
   replicas: 1
   env: []
   # HTTP probes: liveness tolerates brief blips; readiness is stricter so Service endpoints drop faster.
@@ -158,7 +158,7 @@ vroom:
 
 uptimeChecker:
   annotations: {}
-  # args: []
+  args: []
   replicas: 1
   env: []
   resources: {}
@@ -185,7 +185,7 @@ relay:
   annotations: {}
   strategyType: RollingUpdate
   replicas: 1
-  # args: []
+  args: []
   mode: managed
   env: []
   # HTTP probes: liveness tolerates brief blips; readiness is stricter so Service endpoints drop faster.


### PR DESCRIPTION
Uncomment `env`,  `sidecars` , `topologySpreadConstraints`, `args`, `additionalArgs` fields to enable automated schema validation in the future.

No functional changes — all fields remain empty arrays by default.

## Verification

Template output is functionally identical:

```
diff template_default.txt template_sidecars.txt | cut -d ":" -f 1
134c134
<   kraft-cluster-id
---
>   kraft-cluster-id
150c150
<   postgres-password
---
>   postgres-password
3954c3954
<   key
---
>   key
```

Only trailing whitespace differences.
