### PR TITLE
docs: add kafka broker config options for message size limits

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2821,6 +2821,17 @@ kafka:
   enabled: true
   image:
     repository: bitnamilegacy/kafka
+  ## Kafka broker configuration.
+  ## These values are passed directly to the bitnami/kafka chart as `config`.
+  ## Ref: https://github.com/bitnami/charts/tree/main/bitnami/kafka#kafka-broker-configuration
+  ##
+  ## Increase message.max.bytes and replica.fetch.max.bytes if you see
+  ## "Broker: Message size too large" errors.
+  ## replica.fetch.max.bytes should always be >= message.max.bytes.
+  ##
+  # config:
+  #   message.max.bytes: "50000000"
+  #   replica.fetch.max.bytes: "50000000"
   provisioning:
     ## Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers.
     # Note that existing topics will remain with replicationFactor: 1 when updated.


### PR DESCRIPTION
Add a `kafka.config` section to `values.yaml` that allows users to set
arbitrary Kafka broker configuration properties. These values are passed
directly to the `bitnami/kafka` subchart as its
[`config`](https://github.com/bitnami/charts/tree/main/bitnami/kafka#kafka-broker-configuration)
parameter and end up in `server.properties`.

## Motivation

Sentry components like `process-spans` and `replays` can produce large
Kafka messages that exceed the default broker limit, causing crashes with:

```
arroyo.errors.TransportError: KafkaError{code=MSG_SIZE_TOO_LARGE,val=10,
str="Broker: Message size too large"}
```

Users need a way to increase `message.max.bytes` and
`replica.fetch.max.bytes` without patching the chart or using
`overrideConfiguration`.

Closes #2108

## Changes

- Added commented-out `kafka.config` block with `message.max.bytes` and
  `replica.fetch.max.bytes` examples (~48 MB each)
- Added inline comments explaining each property and when to adjust them

## Usage

```yaml
kafka:
  config:
    message.max.bytes: "50000000"
    replica.fetch.max.bytes: "50000000"
```

Any other Kafka broker properties supported by the bitnami chart can be
added under `kafka.config` as well.

