### PR TITLE
chore: uncomment podLabels fields to enable automated validation in future

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -121,7 +121,7 @@ vroom:
   service:
     annotations: {}
   tolerations: []
-  # podLabels: {}
+  podLabels: {}
   persistence:
     enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir
     ## If 'lookupVolumeName' is set to true, Helm will attempt to retrieve
@@ -173,7 +173,7 @@ uptimeChecker:
   service:
     annotations: {}
   tolerations: []
-  # podLabels: {}
+  podLabels: {}
 
   sidecars: []
   topologySpreadConstraints: []
@@ -218,7 +218,7 @@ relay:
   service:
     annotations: {}
   tolerations: []
-  # podLabels: {}
+  podLabels: {}
   # priorityClassName: ""
   autoscaling:
     enabled: false
@@ -324,7 +324,7 @@ sentry:
     service:
       annotations: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # Mount and use custom CA
     # customCA:
     #   secretName: custom-ca
@@ -491,7 +491,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # maxBatchSize: "3"
     # logLevel: info
     # it's better to use prometheus adapter and scale based on
@@ -531,7 +531,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # maxBatchSize: "1"
     # logLevel: "info"
     # inputBlockSize: "1"
@@ -574,7 +574,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # maxBatchSize: "1"
     # logLevel: "info"
     # inputBlockSize: "1"
@@ -617,7 +617,7 @@ sentry:
     containerSecurityContext: {}
     # maxPollIntervalMs: 30000
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -647,7 +647,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -681,7 +681,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -715,7 +715,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -750,7 +750,7 @@ sentry:
     containerSecurityContext: {}
     # maxPollIntervalMs: 30000
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -784,7 +784,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -815,7 +815,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -846,7 +846,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # it's better to use prometheus adapter and scale based on
     # the size of the rabbitmq queue
     autoscaling:
@@ -881,7 +881,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # maxPollIntervalMs: "30000"
     # logLevel: "info"
     # it's better to use prometheus adapter and scale based on
@@ -918,7 +918,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # logLevel: "info"
     # maxPollIntervalMs: "30000"
     # it's better to use prometheus adapter and scale based on
@@ -952,7 +952,7 @@ sentry:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -975,7 +975,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1000,7 +1000,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1025,7 +1025,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1050,7 +1050,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1076,7 +1076,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1101,7 +1101,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1127,7 +1127,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1155,7 +1155,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1184,7 +1184,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1211,7 +1211,7 @@ sentry:
     securityContext: {}
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     sidecars: []
     topologySpreadConstraints: []
     volumes: []
@@ -1242,7 +1242,7 @@ sentry:
     serviceAccount: {}
     # priorityClassName: ""
     annotations: {}
-    # podLabels: {}
+    podLabels: {}
     # affinity: {}
     # nodeSelector: {}
     tolerations: []
@@ -1292,7 +1292,7 @@ snuba:
     service:
       annotations: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
 
     autoscaling:
       enabled: false
@@ -1318,7 +1318,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1351,7 +1351,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1384,7 +1384,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     maxBatchSize: "3"
@@ -1418,7 +1418,7 @@ snuba:
     containerSecurityContext: {}
     # maxPollIntervalMs: 30000
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     maxBatchSize: "3"
@@ -1451,7 +1451,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     # maxBatchTimeMs: ""
     # queuedMaxMessagesKbytes: ""
@@ -1471,7 +1471,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1499,7 +1499,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1520,7 +1520,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1541,7 +1541,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1562,7 +1562,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1583,7 +1583,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1604,7 +1604,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     livenessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1625,7 +1625,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1653,7 +1653,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1681,7 +1681,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1709,7 +1709,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1740,7 +1740,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1763,7 +1763,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     volumes: []
     volumeMounts: []
     livenessProbe:
@@ -1785,7 +1785,7 @@ snuba:
     containerSecurityContext: {}
     # maxPollIntervalMs: 30000
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1818,7 +1818,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1851,7 +1851,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1885,7 +1885,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1918,7 +1918,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1951,7 +1951,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -1984,7 +1984,7 @@ snuba:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
@@ -2077,7 +2077,7 @@ snuba:
         - "group_attributes_raw_local"
         - "generic_metric_gauges_raw_local"
         - "profile_chunks_raw_local"
-    # podLabels: {}
+    podLabels: {}
     # affinity: {}
     # nodeSelector: {}
     tolerations: []
@@ -2103,7 +2103,7 @@ hooks:
       # pullPolicy: IfNotPresent
       imagePullSecrets: []
     env: []
-    # podLabels: {}
+    podLabels: {}
     podAnnotations: {}
     resources:
       limits:
@@ -2121,7 +2121,7 @@ hooks:
   dbInit:
     enabled: true
     env: []
-    # podLabels: {}
+    podLabels: {}
     podAnnotations: {}
     resources:
       limits:
@@ -2142,7 +2142,7 @@ hooks:
     # Note that when you set `kafka.enabled` to `false`, snuba component might fail to start if newly added topics are not created by `kafka.provisioning`.
     kafka:
       enabled: true
-    # podLabels: {}
+    podLabels: {}
     podAnnotations: {}
     resources:
       limits:
@@ -2158,7 +2158,7 @@ hooks:
     volumeMounts: []
   snubaMigrate:
     enabled: true
-    # podLabels: {}
+    podLabels: {}
     volumes: []
     volumeMounts: []
 
@@ -2234,7 +2234,7 @@ symbolicator:
     topologySpreadConstraints: []
     containerSecurityContext: {}
     tolerations: []
-    # podLabels: {}
+    podLabels: {}
     # priorityClassName: "xxx"
     config: |-
       # See: https://getsentry.github.io/symbolicator/#configuration
@@ -2744,7 +2744,7 @@ cleanerfs:
 # securityContext: {}
 # containerSecurityContext: {}
   annotations: {}
-# podLabels: {}
+podLabels: {}
 # affinity: {}
 # nodeSelector: {}
 tolerations: []
@@ -3283,7 +3283,7 @@ metrics:
 
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
-  # podLabels: {}
+  podLabels: {}
   service:
     type: ClusterIP
     labels: {}


### PR DESCRIPTION
Uncomment `podLabels: {}` across all components in `values.yaml` to enable automated validation and make the field consistently available for configuration.

#### Components affected

- `vroom`
- `uptimeChecker`
- `relay`
- `sentry` (web, worker, cron, ingestConsumer, ingestConsumerV2, ingestConsumerV3, postProcessForwarder, postProcessForwarderV2, subscriptionConsumer, subscriptionConsumerV2, subscriptionConsumerTransactions, subscriptionConsumerTransactionsV2, subscriptionConsumerMetrics, subscriptionConsumerMetricsV2, subscriptionConsumerGenericMetrics, subscriptionConsumerGenericMetricsV2, subscriptionConsumerOccurrences, subscriptionConsumerOccurrencesV2, subscriptionConsumerReplayRecordings, subscriptionConsumerMonitors, symbols, cleanup, cleanup-batch, snubaCleanup, snubaCleanupMonitor, metrics)
- `snuba` (api, consumer, consumerV2, replacer, replacerV2, transactionsConsumer, outcomesConsumer, outcomesConsumerV2, sessionsConsumer, metricsConsumer, metricsCountersConsumer, metricsSetsConsumer, metricsDistributionsConsumer, metricsGaugesConsumer, genericMetricsCountersConsumer, genericMetricsSetsConsumer, genericMetricsDistributionsConsumer, genericMetricsGaugesConsumer, profilesConsumer, profileChunksConsumer, genericMetricsSummaryConsumer, groupAttributesConsumer, searchIssuesConsumer, eapSpansConsumer, eapSpansCommitLogConsumer, spansConsumer, attributesConsumer)
- `hooks` (clickhouseInit, dbInit, kafkaInit, snubaMigrate)
- `symbolicator`
- `cleanerfs`
- `metrics`


Check
```
diff template_default.txt template_podLabels.txt | cut -d ":" -f 1
134c134
<   kraft-cluster-id
---
>   kraft-cluster-id
150c150
<   postgres-password
---
>   postgres-password
3954c3954
<   key
---
>   key
```