### PR TITLE
feat: support local JS SDK Loader asset hosting

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1158,6 +1158,14 @@ Set openai api
       name: {{ .Values.openai.existingSecret }}
       key: {{ default "api-token" .Values.openai.existingSecretKey }}
 {{- end }}
+
+{{/*
+Set JS SDK Loader assets setup
+*/}}
+{{- if .Values.sentry.jsSdk.setupAssets }}
+- name: SETUP_JS_SDK_ASSETS
+  value: "1"
+{{- end }}
 {{- end -}}
 
 {{- define "sentry.autoscaling.apiVersion" -}}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -732,6 +732,13 @@ sentry.conf.py: |-
   if OPENAI_API_KEY:
     SENTRY_FEATURES["organizations:open-ai-suggestion"] = True
 
+  ########################
+  # JS SDK Loader Script #
+  ########################
+  {{- if .Values.sentry.jsSdk.setupAssets }}
+  JS_SDK_LOADER_DEFAULT_SDK_URL = {{ .Values.sentry.jsSdk.defaultSdkUrl | quote }}
+  {{- end }}
+
 {{- if .Values.metrics.enabled }}
   SENTRY_METRICS_BACKEND = 'sentry.metrics.statsd.StatsdMetricsBackend'
   SENTRY_METRICS_OPTIONS = {

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -361,6 +361,14 @@ sentry:
   # - organizations:derive-code-mappings
   # other feature here https://github.com/getsentry/sentry/blob/24.11.2/src/sentry/features/temporary.py
 
+  jsSdk:
+    # Enable local hosting of JS SDK bundles instead of loading from browser.sentry-cdn.com
+    # When enabled, Sentry will download and serve JS SDK bundles locally
+    setupAssets: false
+    # URL template for JS SDK bundles (used when setupAssets is true)
+    # %s will be replaced with SDK version and bundle variant
+    defaultSdkUrl: "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+
   taskBroker:
     enabled: true
     replicas: 1


### PR DESCRIPTION
Add support for local hosting of JavaScript SDK Loader bundles in the
Sentry Helm Chart. By default, Sentry loads JS SDK from
`browser.sentry-cdn.com`, but in some environments (air-gapped,
private networks, security policies) it is necessary to host the SDK
locally or use a custom CDN.

## What changed

- `values.yaml` — new configuration parameters:
  - `sentry.jsSdk.setupAssets` (bool, default: `false`) — enables local
    JS SDK asset hosting
  - `sentry.jsSdk.defaultSdkUrl` (string) — URL template for SDK bundles
    (defaults to Sentry CDN)

- `templates/_helper.tpl` — adds `SETUP_JS_SDK_ASSETS=1` environment
  variable when `setupAssets` is enabled

- `templates/sentry/_helper-sentry.tpl` — adds
  `JS_SDK_LOADER_DEFAULT_SDK_URL` setting to `sentry.conf.py`

## Upstream reference

This feature maps to the upstream Sentry setting
`JS_SDK_LOADER_DEFAULT_SDK_URL` defined in
[src/sentry/conf/server.py](https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L2612).

## Usage

```yaml
sentry:
  jsSdk:
    setupAssets: true
    defaultSdkUrl: "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
```

## Verification

After deploying with `setupAssets: true`, verify that the ConfigMap
contains the expected setting:

```bash
kubectl get configmap -n sentry sentry-sentry -o jsonpath='{.data.sentry\.conf\.py}' | grep JS_SDK_LOADER_DEFAULT_SDK_URL
```

Expected output:

```
JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
```

## Use cases

- Air-gapped installations without access to external CDNs
- SDK version control and caching
- Compliance with organizational security policies