### PR TITLE
chore: remove stale RabbitMQ references from docs, config, and comments

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -401,27 +401,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | postgresql.replication.readReplicas | int | `2` |  |
 | postgresql.replication.synchronousCommit | string | `"on"` |  |
 | prefix | string | `nil` |  |
-| rabbitmq.auth.erlangCookie | string | `"pHgpy3Q6adTskzAT6bLHCFqFTF7lMxhA"` |  |
-| rabbitmq.auth.password | string | `"guest"` |  |
-| rabbitmq.auth.username | string | `"guest"` |  |
-| rabbitmq.clustering.forceBoot | bool | `true` |  |
-| rabbitmq.clustering.rebalance | bool | `true` |  |
-| rabbitmq.enabled | bool | `true` |  |
-| rabbitmq.extraConfiguration | string | `"load_definitions = /app/load_definition.json\n"` |  |
-| rabbitmq.extraSecrets.load-definition."load_definition.json" | string | `"{\n  \"users\": [\n    {\n      \"name\": \"{{ .Values.auth.username }}\",\n      \"password\": \"{{ .Values.auth.password }}\",\n      \"tags\": \"administrator\"\n    }\n  ],\n  \"permissions\": [{\n    \"user\": \"{{ .Values.auth.username }}\",\n    \"vhost\": \"/\",\n    \"configure\": \".*\",\n    \"write\": \".*\",\n    \"read\": \".*\"\n  }],\n  \"policies\": [\n    {\n      \"name\": \"ha-all\",\n      \"pattern\": \".*\",\n      \"vhost\": \"/\",\n      \"definition\": {\n        \"ha-mode\": \"all\",\n        \"ha-sync-mode\": \"automatic\",\n        \"ha-sync-batch-size\": 1\n      }\n    }\n  ],\n  \"vhosts\": [\n    {\n      \"name\": \"/\"\n    }\n  ]\n}\n"` |  |
-| rabbitmq.loadDefinition.enabled | bool | `true` |  |
-| rabbitmq.loadDefinition.existingSecret | string | `"load-definition"` |  |
-| rabbitmq.memoryHighWatermark | object | `{}` |  |
-| rabbitmq.metrics.enabled | bool | `false` |  |
-| rabbitmq.metrics.serviceMonitor.enabled | bool | `false` |  |
-| rabbitmq.metrics.serviceMonitor.labels.release | string | `"prometheus-operator"` |  |
-| rabbitmq.metrics.serviceMonitor.path | string | `"/metrics/per-object"` |  |
-| rabbitmq.nameOverride | string | `""` |  |
-| rabbitmq.pdb.create | bool | `true` |  |
-| rabbitmq.persistence.enabled | bool | `true` |  |
-| rabbitmq.replicaCount | int | `1` |  |
-| rabbitmq.resources | object | `{}` |  |
-| rabbitmq.vhost | string | `"/"` |  |
+
 | redis.auth.enabled | bool | `false` |  |
 | redis.auth.sentinel | bool | `false` |  |
 | redis.enabled | bool | `true` |  |

--- a/charts/sentry/ci/kind-values.yaml
+++ b/charts/sentry/ci/kind-values.yaml
@@ -20,9 +20,6 @@ redis:
   master.persistence.enabled: false
   replica.replicaCount: 0
 
-rabbitmq:
-  enabled: false
-
 externalClickhouse:
   host: "clickhouse-clickhouse-external.default.svc"
   tcpPort: 9000

--- a/charts/sentry/docs/usage-aws-terraform.md
+++ b/charts/sentry/docs/usage-aws-terraform.md
@@ -13,9 +13,6 @@ user:
 nginx:
   enabled: false
 
-rabbitmq:
-  enabled: false
-
 sentry:
   web:
     service:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -494,8 +494,6 @@ sentry:
     # podLabels: {}
     # maxBatchSize: "3"
     # logLevel: info
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -537,8 +535,6 @@ sentry:
     # inputBlockSize: "1"
     # maxBatchTimeMs: "750"
 
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -580,8 +576,6 @@ sentry:
     # inputBlockSize: "1"
     # maxBatchTimeMs: "750"
 
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -618,8 +612,6 @@ sentry:
     # maxPollIntervalMs: 30000
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -648,8 +640,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -682,8 +672,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -716,8 +704,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -751,8 +737,6 @@ sentry:
     # maxPollIntervalMs: 30000
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -785,8 +769,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
     sidecars: []
@@ -816,8 +798,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
     sidecars: []
@@ -847,8 +827,6 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     # podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -884,8 +862,6 @@ sentry:
     # podLabels: {}
     # maxPollIntervalMs: "30000"
     # logLevel: "info"
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -921,8 +897,6 @@ sentry:
     # podLabels: {}
     # logLevel: "info"
     # maxPollIntervalMs: "30000"
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
     autoscaling:
       enabled: false
       minReplicas: 1


### PR DESCRIPTION
## Summary

Clean up leftover RabbitMQ references that remained after the RabbitMQ dependency was removed from the chart. These are dead comments, documentation entries, and example config snippets that no longer apply.

## Changes

### `charts/sentry/values.yaml`
- Removed 13 occurrences of the comment `# it's better to use prometheus adapter and scale based on / # the size of the rabbitmq queue` across all worker/consumer autoscaling sections.

### `charts/sentry/README.md`
- Removed 21 lines from the parameters table documenting `rabbitmq.*` parameters that no longer exist in the chart.

### `charts/sentry/ci/kind-values.yaml`
- Removed `rabbitmq: enabled: false` block (no longer a valid configuration key).

### `charts/sentry/docs/usage-aws-terraform.md`
- Removed `rabbitmq: enabled: false` from the example Terraform values file.

## Impact

**No breaking changes.** All removed items were:
- YAML comments (no effect on Helm rendering)
- Documentation for parameters that no longer exist
- Example config referencing a removed dependency

CHANGELOG files were intentionally left untouched.