### PR TITLE
refactor: remove RabbitMQ references from docs, CI, and values comments

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -401,27 +401,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | postgresql.replication.readReplicas | int | `2` |  |
 | postgresql.replication.synchronousCommit | string | `"on"` |  |
 | prefix | string | `nil` |  |
-| rabbitmq.auth.erlangCookie | string | `"pHgpy3Q6adTskzAT6bLHCFqFTF7lMxhA"` |  |
-| rabbitmq.auth.password | string | `"guest"` |  |
-| rabbitmq.auth.username | string | `"guest"` |  |
-| rabbitmq.clustering.forceBoot | bool | `true` |  |
-| rabbitmq.clustering.rebalance | bool | `true` |  |
-| rabbitmq.enabled | bool | `true` |  |
-| rabbitmq.extraConfiguration | string | `"load_definitions = /app/load_definition.json\n"` |  |
-| rabbitmq.extraSecrets.load-definition."load_definition.json" | string | `"{\n  \"users\": [\n    {\n      \"name\": \"{{ .Values.auth.username }}\",\n      \"password\": \"{{ .Values.auth.password }}\",\n      \"tags\": \"administrator\"\n    }\n  ],\n  \"permissions\": [{\n    \"user\": \"{{ .Values.auth.username }}\",\n    \"vhost\": \"/\",\n    \"configure\": \".*\",\n    \"write\": \".*\",\n    \"read\": \".*\"\n  }],\n  \"policies\": [\n    {\n      \"name\": \"ha-all\",\n      \"pattern\": \".*\",\n      \"vhost\": \"/\",\n      \"definition\": {\n        \"ha-mode\": \"all\",\n        \"ha-sync-mode\": \"automatic\",\n        \"ha-sync-batch-size\": 1\n      }\n    }\n  ],\n  \"vhosts\": [\n    {\n      \"name\": \"/\"\n    }\n  ]\n}\n"` |  |
-| rabbitmq.loadDefinition.enabled | bool | `true` |  |
-| rabbitmq.loadDefinition.existingSecret | string | `"load-definition"` |  |
-| rabbitmq.memoryHighWatermark | object | `{}` |  |
-| rabbitmq.metrics.enabled | bool | `false` |  |
-| rabbitmq.metrics.serviceMonitor.enabled | bool | `false` |  |
-| rabbitmq.metrics.serviceMonitor.labels.release | string | `"prometheus-operator"` |  |
-| rabbitmq.metrics.serviceMonitor.path | string | `"/metrics/per-object"` |  |
-| rabbitmq.nameOverride | string | `""` |  |
-| rabbitmq.pdb.create | bool | `true` |  |
-| rabbitmq.persistence.enabled | bool | `true` |  |
-| rabbitmq.replicaCount | int | `1` |  |
-| rabbitmq.resources | object | `{}` |  |
-| rabbitmq.vhost | string | `"/"` |  |
 | redis.auth.enabled | bool | `false` |  |
 | redis.auth.sentinel | bool | `false` |  |
 | redis.enabled | bool | `true` |  |

--- a/charts/sentry/ci/kind-values.yaml
+++ b/charts/sentry/ci/kind-values.yaml
@@ -20,9 +20,6 @@ redis:
   master.persistence.enabled: false
   replica.replicaCount: 0
 
-rabbitmq:
-  enabled: false
-
 externalClickhouse:
   host: "clickhouse-clickhouse-external.default.svc"
   tcpPort: 9000

--- a/charts/sentry/docs/usage-aws-terraform.md
+++ b/charts/sentry/docs/usage-aws-terraform.md
@@ -13,9 +13,6 @@ user:
 nginx:
   enabled: false
 
-rabbitmq:
-  enabled: false
-
 sentry:
   web:
     service:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -502,8 +502,8 @@ sentry:
     podLabels: {}
     # maxBatchSize: "3"
     # logLevel: info
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -545,8 +545,8 @@ sentry:
     # inputBlockSize: "1"
     # maxBatchTimeMs: "750"
 
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -588,8 +588,8 @@ sentry:
     # inputBlockSize: "1"
     # maxBatchTimeMs: "750"
 
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -626,8 +626,8 @@ sentry:
     # maxPollIntervalMs: 30000
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -656,8 +656,8 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -690,8 +690,8 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -724,8 +724,8 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -759,8 +759,8 @@ sentry:
     # maxPollIntervalMs: 30000
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -793,8 +793,8 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
     sidecars: []
@@ -824,8 +824,8 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
     sidecars: []
@@ -855,8 +855,8 @@ sentry:
     containerSecurityContext: {}
     tolerations: []
     podLabels: {}
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -892,8 +892,8 @@ sentry:
     podLabels: {}
     # maxPollIntervalMs: "30000"
     # logLevel: "info"
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1
@@ -929,8 +929,8 @@ sentry:
     podLabels: {}
     # logLevel: "info"
     # maxPollIntervalMs: "30000"
-    # it's better to use prometheus adapter and scale based on
-    # the size of the rabbitmq queue
+    # it's better to use prometheus adapter or keda and scale based on
+    # the size of the queue
     autoscaling:
       enabled: false
       minReplicas: 1


### PR DESCRIPTION
Remove residual RabbitMQ references across the chart after the RabbitMQ dependency was removed:

- **README.md**: Drop 21 lines of `rabbitmq.*` parameters from the values table
- **ci/kind-values.yaml**: Remove `rabbitmq.enabled: false` (no longer needed)
- **docs/usage-aws-terraform.md**: Remove `rabbitmq.enabled: false` example
- **values.yaml**: Update 14 autoscaling comments from "rabbitmq queue" → "queue" and add "or keda" as an alternative scaling option alongside prometheus adapter

## Why

Sentry no longer uses RabbitMQ as its queue backend. These leftover references are misleading for chart users and should be cleaned up.

## Testing

- `helm lint charts/sentry` passes
- CI values no longer reference rabbitmq, so no breakage expected
