### PR TITLE
fix: add timeoutSeconds to exec livenessProbe in consumer deployments

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -137,6 +137,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestConsumerAttachments.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestConsumerAttachments.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestConsumerAttachments.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -137,6 +137,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestConsumerEvents.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestConsumerEvents.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestConsumerEvents.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -115,6 +115,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestFeedback.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestFeedback.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestFeedback.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -119,6 +119,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestMonitors.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -114,6 +114,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.monitorsClockTasks.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -114,6 +114,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.monitorsClockTick.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -115,6 +115,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestOccurrences.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -115,6 +115,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestProfiles.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -119,6 +119,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestReplayRecordings.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.ingestConsumerTransactions.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.ingestConsumerTransactions.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.ingestConsumerTransactions.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -115,6 +115,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.billingMetricsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -126,6 +126,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.metricsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -126,6 +126,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.genericMetricsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -114,6 +114,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.postProcessForwardErrors.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -116,6 +116,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -123,6 +123,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.postProcessForwardTransactions.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -128,6 +128,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.processSegments.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.processSegments.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.processSegments.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -128,6 +128,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.processSpans.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.processSpans.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.processSpans.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -105,6 +105,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.subscriptionConsumerEvents.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -124,6 +124,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -124,6 +124,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.subscriptionConsumerMetrics.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -105,6 +105,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -106,6 +106,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.subscriptionConsumerTransactions.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -113,6 +113,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.sentry.uptimeResults.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.sentry.uptimeResults.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentry.uptimeResults.livenessProbe.timeoutSeconds }}
         {{- end }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -137,6 +137,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.consumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.consumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.consumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.eapItemsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.eapItemsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.eapItemsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.genericMetricsCountersConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.genericMetricsSetsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -137,6 +137,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.groupAttributesConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.groupAttributesConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.groupAttributesConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.issueOccurrenceConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.metricsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -142,6 +142,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.outcomesBillingConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.outcomesBillingConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.outcomesBillingConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -135,6 +135,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.outcomesConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.profilingChunksConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.profilingChunksConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.profilingChunksConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.profilingFunctionsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.profilingProfilesConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -142,6 +142,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.replaysConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -111,6 +111,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerEapItems.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerEapItems.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerEapItems.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -111,6 +111,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerEvents.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -112,6 +112,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -112,6 +112,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -112,6 +112,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -112,6 +112,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -113,6 +113,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerMetrics.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -112,6 +112,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.subscriptionConsumerTransactions.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -138,6 +138,7 @@ spec:
               - /tmp/health.txt
           initialDelaySeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.snuba.transactionsConsumer.livenessProbe.timeoutSeconds }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -519,6 +519,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -562,6 +563,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -605,6 +607,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -640,6 +643,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -670,6 +674,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -704,6 +709,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -738,6 +744,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -773,6 +780,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -804,6 +812,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -835,6 +844,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -869,6 +879,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -906,6 +917,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -943,6 +955,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -965,6 +978,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -991,6 +1005,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     volumeMounts: []
@@ -1016,6 +1031,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     volumeMounts: []
@@ -1041,6 +1057,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     volumeMounts: []
@@ -1067,6 +1084,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1092,6 +1110,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumeMounts: []
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
@@ -1118,6 +1137,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1144,6 +1164,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # maxBatchSize: "500"
@@ -1172,6 +1193,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # maxBatchSize: "500"
@@ -1201,6 +1223,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1228,6 +1251,7 @@ sentry:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1332,6 +1356,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -1365,6 +1390,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1400,6 +1426,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -1434,6 +1461,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -1485,6 +1513,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1512,6 +1541,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1533,6 +1563,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1554,6 +1585,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1575,6 +1607,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1596,6 +1629,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1617,6 +1651,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1639,6 +1674,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1667,6 +1703,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1695,6 +1732,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1723,6 +1761,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1754,6 +1793,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     volumes: []
     volumeMounts: []
 
@@ -1778,6 +1818,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1799,6 +1840,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1832,6 +1874,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1865,6 +1908,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1899,6 +1943,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1932,6 +1977,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1965,6 +2011,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1998,6 +2045,7 @@ snuba:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 320
+      timeoutSeconds: 3
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""


### PR DESCRIPTION
  **Problem**

  48 consumer/worker deployment templates render exec-based livenessProbe blocks without a timeoutSeconds field:

```
  livenessProbe:
    exec:
      command:
        - rm
        - /tmp/health.txt
    initialDelaySeconds: 5
    periodSeconds: 320
    # timeoutSeconds missing → defaults to 1s
```
  When timeoutSeconds is omitted, Kubernetes defaults to 1s. This was harmless until now because Kubernetes had a long-standing bug where timeoutSeconds on exec probes was silently ignored since 1.0.

  Kubernetes 1.35 ([#134635](https://github.com/kubernetes/kubernetes/pull/134635)) locked the gate to true — enforcement is now mandatory on all distributions (GKE, EKS, AKS, etc.).

  Result: any exec probe without an explicit timeoutSeconds now runs with a hard 1s deadline.