### PR TITLE
fix: use reconnecting memcache backend

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -98,12 +98,12 @@ sentry.conf.py: |-
   {{- if or .Values.cache.enabled .Values.sourcemaps.enabled }}
   CACHES = {
       "default": {
-          "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+          "BACKEND": "sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache",
           "LOCATION": [
               "{{ template "sentry.fullname" . }}-memcached:11211"
           ],
           "TIMEOUT": 3600,
-          "OPTIONS": {"ignore_exc": True}
+          "OPTIONS": {"ignore_exc": True, "reconnect_age": 300}
       }
   }
   {{- end }}


### PR DESCRIPTION
## Summary
- replace the generated Sentry Django cache backend with `sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache`
- set `reconnect_age: 300` to match the self-hosted configuration from getsentry/self-hosted#4338

Fixes #2188

## Testing
- `helm dependency build charts/sentry`
- `helm lint charts/sentry`
- `helm template sentry charts/sentry --set cache.enabled=true --set user.password=ci-test-password`
- `helm template sentry charts/sentry -f charts/sentry/ci/kind-values.yaml --set cache.enabled=true`

