### PR TITLE
chore: remove batch/v1beta1 fallback for CronJobs

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -141,22 +141,10 @@ Resolve ingress controller style for path rules.
 
 {{/*
 Return the appropriate batch apiVersion for cronjobs.
-batch/v1beta1 will no longer be served in v1.25
-See more at https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125
+batch/v1 is available since Kubernetes 1.21, batch/v1beta1 was removed in 1.25.
 */}}
 {{- define "sentry.batch.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "batch/v1") (semverCompare ">= 1.21.x" (include "sentry.kubeVersion" .)) -}}
-      {{- print "batch/v1" -}}
-  {{- else if .Capabilities.APIVersions.Has "batch/v1beta1" -}}
-    {{- print "batch/v1beta1" -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Return if batch is stable.
-*/}}
-{{- define "sentry.batch.isStable" -}}
-  {{- eq (include "sentry.batch.apiVersion" .) "batch/v1" -}}
+  {{- print "batch/v1" -}}
 {{- end -}}
 
 {{/*

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.sentry.cleanup.enabled }}
-{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
 apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: CronJob
 metadata:

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.snuba.cleanup.enabled }}
-{{- $batchApiIsStable := eq (include "sentry.batch.isStable" .) "true" -}}
 apiVersion: {{ include "sentry.batch.apiVersion" . }}
 kind: CronJob
 metadata:


### PR DESCRIPTION
Remove the `batch/v1beta1` fallback for CronJob — the `batch/v1beta1` API was removed from Kubernetes 1.25 (June 2023).

#### Changes

- **`templates/_helper.tpl`** — `sentry.batch.apiVersion` simplified to always return `batch/v1`. Removed the `sentry.batch.isStable` helper (unused anywhere).
- **`templates/sentry/cleanup/cronjob-sentry-cleanup.yaml`** — removed unused `$batchApiIsStable` variable.
- **`templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml`** — removed unused `$batchApiIsStable` variable.

#### Why

`batch/v1beta1` was removed from Kubernetes starting with version 1.25. Current Kubernetes versions (1.27+) do not support this API. The `sentry.batch.isStable` helper was defined but the `$batchApiIsStable` variable based on it was never read — dead code. The `batch/v1beta1` fallback itself would never trigger on supported clusters.

#### Breaking changes

None. `batch/v1` is available since Kubernetes 1.21+, and the minimum supported version for modern Sentry is higher.
