### PR TITLE
feat: add concurrency, inputBlockSize, maxBatchSize, maxBatchTimeMs support for ingest-occurences consumer

### DIFF
--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -107,6 +107,25 @@ spec:
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
           {{- end }}
+          {{- if or .Values.sentry.ingestOccurrences.concurrency .Values.sentry.ingestOccurrences.inputBlockSize .Values.sentry.ingestOccurrences.maxBatchSize .Values.sentry.ingestOccurrences.maxBatchTimeMs }}
+          - "--"
+          {{- end }}
+          {{- if .Values.sentry.ingestOccurrences.concurrency }}
+          - "--processes"
+          - "{{ .Values.sentry.ingestOccurrences.concurrency }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestOccurrences.inputBlockSize }}
+          - "--input-block-size"
+          - "{{ .Values.sentry.ingestOccurrences.inputBlockSize }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestOccurrences.maxBatchSize }}
+          - "--max-batch-size"
+          - "{{ .Values.sentry.ingestOccurrences.maxBatchSize }}"
+          {{- end }}
+          {{- if .Values.sentry.ingestOccurrences.maxBatchTimeMs }}
+          - "--max-batch-time-ms"
+          - "{{ .Values.sentry.ingestOccurrences.maxBatchTimeMs }}"
+          {{- end }}
         {{- if .Values.sentry.ingestOccurrences.livenessProbe.enabled }}
         livenessProbe:
           exec:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -679,6 +679,7 @@ sentry:
   ingestOccurrences:
     enabled: true
     replicas: 1
+    # concurrency: 4
     env: []
     resources: {}
     #  requests:
@@ -709,6 +710,9 @@ sentry:
     #     name: dshm
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
+    # inputBlockSize: "1"
+    # maxBatchSize: "500"
+    # maxBatchTimeMs: "1000"
 
   ingestFeedback:
     enabled: true


### PR DESCRIPTION
## Problem

`sentry-ingest-occurences` consumer was added to the chart without support for configuring consumer-specific CLI flags.


## Solution

Adds `concurrency`, `inputBlockSize`, `maxBatchSize`, and `maxBatchTimeMs` values for the consumer, passed as consumer-specific arguments after the `--` separator.

Flags were verified against the running binary:
```
$ sentry run consumer ingest-occurrences --consumer-group ingest-occurrences -- --help
Usage: ingest-occurrences [OPTIONS]

Options:
  --processes INTEGER
  --input-block-size INTEGER
  --output-block-size INTEGER
  --max-batch-size INTEGER        Maximum number of messages to batch before
                                  flushing.
  --max-batch-time-ms INTEGER     Maximum time (in milliseconds) to wait
                                  before flushing a batch.
  --mode [batched-parallel|parallel]
                                  The mode to process occurrences in. Batched-
                                  parallel uses batched in parallel to
                                  guarantee messages are processed in order
                                  per group, parallel uses multi-processing.
  --help                          Show this message and exit.
```

## Changes

- `templates/deployment-sentry-ingest-occurences.yaml` — emit `--` separator and conditionally pass `--processes`, `--input-block-size`, `--max-batch-size`, `--max-batch-time-ms`
- `values.yaml` — add commented-out `concurrency`, `inputBlockSize`, `maxBatchSize`, `maxBatchTimeMs` keys to the consumer section, matching the style of sibling consumers