### PR TITLE
fix: set default Kafka message size limits to prevent MSG_SIZE_TOO_LARGE

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2833,9 +2833,9 @@ kafka:
   ## These values are passed directly to the bitnami/kafka chart as `config`.
   ## Ref: https://github.com/bitnami/charts/tree/main/bitnami/kafka#kafka-broker-configuration
   ## replica.fetch.max.bytes should always be >= message.max.bytes.
-  config:
-    message.max.bytes: "50000000"
-    replica.fetch.max.bytes: "50000000"
+  config: |
+    message.max.bytes=50000000
+    replica.fetch.max.bytes=50000000
   provisioning:
     ## Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers.
     # Note that existing topics will remain with replicationFactor: 1 when updated.

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2832,14 +2832,10 @@ kafka:
   ## Kafka broker configuration.
   ## These values are passed directly to the bitnami/kafka chart as `config`.
   ## Ref: https://github.com/bitnami/charts/tree/main/bitnami/kafka#kafka-broker-configuration
-  ##
-  ## Increase message.max.bytes and replica.fetch.max.bytes if you see
-  ## "Broker: Message size too large" errors.
   ## replica.fetch.max.bytes should always be >= message.max.bytes.
-  ##
-  # config:
-  #   message.max.bytes: "50000000"
-  #   replica.fetch.max.bytes: "50000000"
+  config:
+    message.max.bytes: "50000000"
+    replica.fetch.max.bytes: "50000000"
   provisioning:
     ## Increasing the replicationFactor enhances data reliability during Kafka pod failures by replicating data across multiple brokers.
     # Note that existing topics will remain with replicationFactor: 1 when updated.


### PR DESCRIPTION
The internal Kafka broker uses Apache Kafka defaults for message size limits
(`message.max.bytes` and `replica.fetch.max.bytes` = 1 MiB). However, Sentry
clients (relay, sentry, process-spans) are already configured to send messages
up to 50 MB. This mismatch causes `process-spans` to crash with:

```
arroyo.errors.TransportError: KafkaError{code=MSG_SIZE_TOO_LARGE,val=10,str="Broker: Message size too large"}
```

See #2108.

## Fix

Set `message.max.bytes` and `replica.fetch.max.bytes` to `50000000` (≈50 MB)
by default in the internal Kafka broker configuration. This aligns broker limits
with the client-side configuration already present in `sentry.kafka.message.max.bytes`
and `externalKafka.message.max.bytes` (both default to 50000000 in `_helper.tpl`).

## Impact

- **No additional memory/resources required.** Kafka uses OS page cache and
  zero-copy (`sendfile()`) for message handling — these parameters are only
  limits, not memory reservations.
- **Disk usage** (`persistence.size`) should be monitored if span traffic grows,
  but the current default is sufficient for normal operation.
- These values were already documented and commented in `values.yaml` since PR #2181.
  This change simply enables them by default.

Fixes #2108