### PR TITLE
fix(cleanerfs): fix indentation in cleanerfs configuration

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2801,13 +2801,13 @@ cleanerfs:
   concurrencyPolicy: Allow
   schedule: "0 1 * * *"
   days: 90
-# securityContext: {}
-# containerSecurityContext: {}
+  # securityContext: {}
+  # containerSecurityContext: {}
   annotations: {}
-podLabels: {}
-# affinity: {}
-# nodeSelector: {}
-tolerations: []
+  podLabels: {}
+  # affinity: {}
+  # nodeSelector: {}
+  tolerations: []
 
 config:
   # No YAML Extension Config Given


### PR DESCRIPTION
Fixed indentation for fields in the `cleanerfs` section of `values.yaml`:
- `securityContext`
- `containerSecurityContext`
- `annotations`
- `podLabels`
- `affinity`
- `nodeSelector`
- `tolerations`

### Problem

These fields were at the wrong nesting level, which could lead to incorrect parsing of the YAML configuration.

### Solution

All listed fields have been adjusted to the correct indentation level matching the cleanerfs configuration structure.
