### PR TITLE
fix: correct ingestFeedback serviceAccount condition and remove duplicate snuba-replacer option

### DIFF
--- a/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestMonitors.enabled }}
+{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestFeedback.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -106,9 +106,6 @@ spec:
           {{- if .Values.snuba.replacer.queuedMinMessages }}
           - "--queued-min-messages"
           - "{{ .Values.snuba.replacer.queuedMinMessages }}"
-          {{- if .Values.snuba.replacer.noStrictOffsetReset }}
-          - "--no-strict-offset-reset"
-          {{- end }}
         {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}


### PR DESCRIPTION
### Changes

1. **Fix ingestFeedback ServiceAccount condition** (`serviceaccount-sentry-ingest-feedback.yaml`):
   - The ServiceAccount template was incorrectly gated by `sentry.ingestMonitors.enabled` instead of `sentry.ingestFeedback.enabled`, causing the feedback ingest ServiceAccount to be rendered based on the wrong feature flag.

2. **Remove `--no-strict-offset-reset` from snuba-replacer** (`deployment-snuba-replacer.yaml`):
   - The `--no-strict-offset-reset` flag is a duplicate of the default behavior and is no longer needed. Removing it simplifies the deployment configuration.
