### PR TITLE
fix: remove dead code prefix and fix incorrect comments in externalClickhouse

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -400,7 +400,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | postgresql.replication.numSynchronousReplicas | int | `1` |  |
 | postgresql.replication.readReplicas | int | `2` |  |
 | postgresql.replication.synchronousCommit | string | `"on"` |  |
-| prefix | string | `nil` |  |
 | redis.auth.enabled | bool | `false` |  |
 | redis.auth.sentinel | bool | `false` |  |
 | redis.enabled | bool | `true` |  |

--- a/charts/sentry/docs/usage-aws-terraform.md
+++ b/charts/sentry/docs/usage-aws-terraform.md
@@ -3,8 +3,6 @@
 `./templates/sentry_values.yaml` file
 
 ```yaml
-prefix: ${module_prefix}
-
 user:
   create: true
   email: ${sentry_email}
@@ -68,7 +66,6 @@ resource "helm_release" "sentry" {
     templatefile(
       "${path.module}/templates/sentry_values.yaml",
       {
-        module_prefix   = "${var.module_prefix}",
         sentry_email    = "${var.sentry_email}",
         sentry_password = "${var.sentry_password}",
 

--- a/charts/sentry/docs/usage-digitalocean.md
+++ b/charts/sentry/docs/usage-digitalocean.md
@@ -45,8 +45,6 @@ doctl compute certificate list
 
 `values.yaml`
 ```yaml
-prefix:
-
 # Required only when installing
 user:
   create: true

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1,12 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
 
-{{- define "sentry.prefix" -}}
-    {{- if .Values.prefix -}}
-        {{.Values.prefix}}-
-    {{- else -}}
-    {{- end -}}
-{{- end -}}
-
 {{- define "relay.port" -}}{{ default 3000 .Values.relay.service.port }}{{- end -}}
 {{- define "relay.healthCheck.readinessRequestPath" -}}/api/relay/healthcheck/ready/{{- end -}}
 {{- define "relay.healthCheck.livenessRequestPath" -}}/api/relay/healthcheck/live/{{- end -}}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1,5 +1,3 @@
-prefix:
-
 # Set this to true to support IPV6 networks
 ipv6: false
 
@@ -2863,10 +2861,10 @@ externalClickhouse:
   database: default
   singleNode: true
   # existingSecret: secret-name
-  ## set existingSecretKey if key name inside existingSecret is different from 'postgres-password'
+  ## set existingSecretKey if key name inside existingSecret is different from 'clickhouse-password'
   # existingSecretKey: secret-key-name
   ## Cluster name, can be found in config
-  ## (https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-remote-servers)
+  ## (https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings/#server-settings-remote-servers)
   ## or by executing `select * from system.clusters`
   ##
   # clusterName: test_shard_localhost


### PR DESCRIPTION
### Changes

#### 1. Remove unused `sentry.prefix` helper and `prefix` parameter (dead code)

The `sentry.prefix` helper in `_helper.tpl` and the corresponding `prefix:` parameter in `values.yaml` were never referenced by any template. Removed:
- Helper definition `sentry.prefix` from `templates/_helper.tpl`
- Parameter `prefix:` from `values.yaml` (line 1)
- Table row from `README.md`
- Usage examples from `docs/usage-aws-terraform.md` and `docs/usage-digitalocean.md`

#### 2. Fix incorrect comment in `externalClickhouse` section

The comment in `values.yaml:2866` incorrectly referenced `'postgres-password'` as the default secret key, but the actual default used in `templates/_helper.tpl:654` is `'clickhouse-password'`. Users following the old comment would create a secret with the wrong key name, causing silent authentication failures against ClickHouse.

#### 3. Fix outdated URL (`clickhouse.tech` → `clickhouse.com`)

The `clickhouse.tech` domain was retired and redirects to `clickhouse.com`. Updated the documentation link in the `externalClickhouse` section of `values.yaml`.