### PR TITLE
chore: uncomment securityContext, affinity and nodeSelector defaults

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1268,8 +1268,8 @@ sentry:
     days: 90
     # logLevel: INFO
     logLevel: ''
-    # securityContext: {}
-    # containerSecurityContext: {}
+    securityContext: {}
+    containerSecurityContext: {}
     sidecars: []
     volumes: []
     volumeMounts: []
@@ -1277,8 +1277,8 @@ sentry:
     # priorityClassName: ""
     annotations: {}
     podLabels: {}
-    # affinity: {}
-    # nodeSelector: {}
+    affinity: {}
+    nodeSelector: {}
     tolerations: []
 
   # Sentry settings of connections to Kafka
@@ -2136,14 +2136,14 @@ snuba:
         - "generic_metric_gauges_raw_local"
         - "profile_chunks_raw_local"
     podLabels: {}
-    # affinity: {}
-    # nodeSelector: {}
+    affinity: {}
+    nodeSelector: {}
     tolerations: []
     env: []
     volumes: []
     sidecars: []
-    # containerSecurityContext: {}
-    # securityContext: {}
+    containerSecurityContext: {}
+    securityContext: {}
     annotations: {}
     volumeMounts: []
 
@@ -2799,12 +2799,12 @@ cleanerfs:
   concurrencyPolicy: Allow
   schedule: "0 1 * * *"
   days: 90
-  # securityContext: {}
-  # containerSecurityContext: {}
+  securityContext: {}
+  containerSecurityContext: {}
   annotations: {}
   podLabels: {}
-  # affinity: {}
-  # nodeSelector: {}
+  affinity: {}
+  nodeSelector: {}
   tolerations: []
 
 config:


### PR DESCRIPTION
Uncomment default empty object values for `securityContext`, `containerSecurityContext`, `affinity`, and `nodeSelector` fields in `values.yaml` across multiple chart components.

## Changes

- **sentry**: Uncomment `securityContext`, `containerSecurityContext`, `affinity`, `nodeSelector`
- **snuba**: Uncomment `securityContext`, `containerSecurityContext`, `affinity`, `nodeSelector`
- **cleanerfs**: Uncomment `securityContext`, `containerSecurityContext`, `affinity`, `nodeSelector`


```
diff template_default.txt template_securityContext.txt | cut -d ":" -f 1
134c134
<   kraft-cluster-id
---
>   kraft-cluster-id
150c150
<   postgres-password
---
>   postgres-password
3980c3980
<   key
---
>   key
```