### PR TITLE
chore(kafka): remove unused Zookeeper support

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -305,7 +305,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | kafka.sasl.client.users | list | `[]` | List of usernames for client communications when SASL is enabled, first user will be used if enabled |
 | kafka.sasl.client.passwords | list | `[]` | List of passwords for client communications when SASL is enabled, must match the number of client.users, first password will be used if enabled |
 | kafka.sasl.enabledMechanisms | string | `"PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"` | Comma-separated list of allowed SASL mechanisms when SASL listeners are configured |
-| kafka.zookeeper.enabled | bool | `false` |  |
 | mail.backend | string | `"dummy"` |  |
 | mail.from | string | `""` |  |
 | mail.host | string | `""` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -174,19 +174,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "kafka" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "sentry.zookeeper.fullname" -}}
-{{- if .Values.kafka.zookeeper.fullnameOverride -}}
-{{- .Values.kafka.zookeeper.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.kafka.zookeeper.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name "zookeeper" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 Set postgres host
 */}}

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -105,27 +105,6 @@ spec:
               KAFKA_STATUS=1
               {{- if .Values.kafka.enabled }}
 
-              {{- if .Values.kafka.zookeeper.enabled }}
-              KAFKA_REPLICAS={{ .Values.kafka.broker.replicaCount | default 3 }}
-              echo "Kafka Zookeeper is enabled, checking if kafka brokers are up"
-              KZ_STATUS=0
-              while [ $KZ_STATUS -eq 0 ]; do
-                KZ_STATUS=1
-                i=0; while [ $i -lt $KAFKA_REPLICAS ]; do
-                  KZ_HOST={{ $kafkaHost }}-broker-$i.{{ $kafkaHost }}-broker-headless
-                  if ! nc -z "$KZ_HOST" {{ $kafkaPort }}; then
-                    KZ_STATUS=0
-                    echo "$KZ_HOST is not available yet"
-                  fi
-                  i=$((i+1))
-                done
-                if [ "$KZ_STATUS" -eq 0 ]; then
-                  echo "Kafka not ready. Sleeping for 10s before trying again"
-                  sleep 10;
-                fi
-              done
-              echo "Zookeeper is up"
-              {{- end }}
               {{- if .Values.kafka.kraft.enabled }}
               KAFKA_REPLICAS={{ .Values.kafka.controller.replicaCount | default 3 }}
               echo "Kafka Kraft is enabled, checking if Kraft controllers are up"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3068,8 +3068,6 @@ kafka:
       protocol: "PLAINTEXT"
     external:
       protocol: "PLAINTEXT"
-  zookeeper:
-    enabled: false
   kraft:
     enabled: true
   metrics:
@@ -3090,12 +3088,6 @@ kafka:
   # serviceAccount:
   #   create: false
   #   name: kafka
-
-  ## Use this to enable an extra service account
-  # zookeeper:
-  #   serviceAccount:
-  #     create: false
-  #     name: zookeeper
 
   # sasl:
   #  ## Credentials for client communications.


### PR DESCRIPTION
This PR removes all legacy Zookeeper-related configuration from the Sentry Helm chart. Kafka in this chart uses KRaft mode (`kraft.enabled: true`), making the Zookeeper configuration dead code.

## Changes

- **`values.yaml`**: Removed `kafka.zookeeper.enabled` and the commented-out `kafka.zookeeper.serviceAccount` block.
- **`templates/_helper.tpl`**: Removed the `sentry.zookeeper.fullname` template helper, which is no longer referenced.
- **`templates/hooks/sentry-db-check.job.yaml`**: Removed the Zookeeper-based broker readiness check from the `sentry-db-check` hook. The KRaft controller check remains intact.
- **`README.md`**: Removed the `kafka.zookeeper.enabled` parameter from the configuration table.