### PR TITLE
chore(sentry): remove commented-out memcached cache config

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -185,21 +185,6 @@ sentry.conf.py: |-
     }
   }
 
-  #########
-  # Cache #
-  #########
-
-  # Sentry currently utilizes two separate mechanisms. While CACHES is not a
-  # requirement, it will optimize several high throughput patterns.
-
-  # CACHES = {
-  #     "default": {
-  #         "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
-  #         "LOCATION": ["memcached:11211"],
-  #         "TIMEOUT": 3600,
-  #     }
-  # }
-
   # A primary cache is required for things such as processing events
   SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 


### PR DESCRIPTION
Delete unused CACHES block with memcached backend settings from
sentry.conf.py in _helper-sentry.tpl.