### PR TITLE
chore: inline apiVersion helpers for ingress and cronjob templates

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -97,13 +97,6 @@ Get KubeVersion removing pre-release information.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "sentry.ingress.apiVersion" -}}
-  {{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-
-{{/*
 Resolve ingress controller style for path rules.
 */}}
 {{- define "sentry.ingress.controller" -}}
@@ -130,14 +123,6 @@ Resolve ingress controller style for path rules.
   {{- else -}}
     {{- print "nginx" -}}
   {{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate batch apiVersion for cronjobs.
-batch/v1 is available since Kubernetes 1.21, batch/v1beta1 was removed in 1.25.
-*/}}
-{{- define "sentry.batch.apiVersion" -}}
-  {{- print "batch/v1" -}}
 {{- end -}}
 
 {{/*

--- a/charts/sentry/templates/cleanerfs/cronjob-cleanerfs.yaml
+++ b/charts/sentry/templates/cleanerfs/cronjob-cleanerfs.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cleanerfs.enabled }}
-apiVersion: {{ include "sentry.batch.apiVersion" . }}
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry-cleanerfs

--- a/charts/sentry/templates/routing/ingress.yaml
+++ b/charts/sentry/templates/routing/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $pathRulesByStyle := .Values.ingress.pathRules | default dict -}}
 {{- $ingressController := include "sentry.ingress.controller" . -}}
 {{- $pathRules := get $pathRulesByStyle $ingressController | default (get $pathRulesByStyle "nginx") | default list -}}
-apiVersion: {{ include "sentry.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sentry.cleanup.enabled }}
-apiVersion: {{ include "sentry.batch.apiVersion" . }}
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-sentry-cleanup

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.snuba.cleanup.enabled }}
-apiVersion: {{ include "sentry.batch.apiVersion" . }}
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "sentry.fullname" . }}-clickhouse-cleanup


### PR DESCRIPTION
## Description

Inline hardcoded `apiVersion` helpers for Ingress and CronJob templates.

## Changes

- Remove `sentry.ingress.apiVersion` helper (always returned `networking.k8s.io/v1`)
- Remove `sentry.batch.apiVersion` helper (always returned `batch/v1`)
- Replace helper calls with direct `apiVersion` values in templates:
  - `routing/ingress.yaml`
  - `cleanerfs/cronjob-cleanerfs.yaml`
  - `sentry/cleanup/cronjob-sentry-cleanup.yaml`
  - `snuba/cleanup/cronjob-clickhouse-cleanup.yaml`

## Motivation

Both helpers returned static strings with no conditional logic. Since Kubernetes 1.19+ supports `networking.k8s.io/v1` Ingress and 1.21+ supports `batch/v1` CronJob (with `batch/v1beta1` removed in 1.25), these helpers add unnecessary indirection. Inlining improves readability and maintainability.
