### PR TITLE
feat: replace netcat image with busybox for dbCheck hooks

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -33,9 +33,9 @@
 {{- end -}}
 
 {{- define "dbCheck.image" -}}
-{{- default "subfuzion/netcat" .Values.hooks.dbCheck.image.repository -}}
+{{- default "busybox" .Values.hooks.dbCheck.image.repository -}}
 :
-{{- default "latest" .Values.hooks.dbCheck.image.tag -}}
+{{- default "1.38.0" .Values.hooks.dbCheck.image.tag -}}
 {{- end -}}
 
 {{- define "vroom.image" -}}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2179,8 +2179,8 @@ hooks:
   dbCheck:
     enabled: true
     image:
-      # repository: subfuzion/netcat
-      # tag: latest
+      # repository: busybox
+      # tag: 1.38.0
       # pullPolicy: IfNotPresent
       imagePullSecrets: []
     env: []


### PR DESCRIPTION
## Replace netcat image with busybox for dbCheck hooks

### Description
Changed the default image used by dbCheck hooks from `subfuzion/netcat` to `busybox` to improve reliability and reduce dependencies.

### Changes
- Updated default image repository from `subfuzion/netcat` to `busybox` in `_helper.tpl`
- Updated default image tag from `latest` to `1.38.0` for better version pinning
- Updated commented examples in `values.yaml` to reflect new defaults

### Motivation
The `subfuzion/netcat` image is less maintained and has known issues. Using `busybox` provides a more reliable and well-maintained alternative with similar functionality for simple connectivity checks.