### PR TITLE
fix: use hooks.snubaMigrate instead of hooks.snubaInit in snuba-migrate job

### DIFF
--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -28,8 +28,8 @@ spec:
         {{- if .Values.snuba.annotations }}
 {{ toYaml .Values.snuba.annotations | indent 8 }}
         {{- end }}
-        {{- if .Values.hooks.snubaInit.podAnnotations }}
-{{ toYaml .Values.hooks.snubaInit.podAnnotations | indent 8 }}
+        {{- if .Values.hooks.snubaMigrate.podAnnotations }}
+{{ toYaml .Values.hooks.snubaMigrate.podAnnotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry
@@ -41,20 +41,20 @@ spec:
 {{ toYaml .Values.hooks.snubaMigrate.podLabels | indent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.hooks.snubaInit.affinity }}
+      {{- if .Values.hooks.snubaMigrate.affinity }}
       affinity:
-{{ toYaml .Values.hooks.snubaInit.affinity | indent 8 }}
+{{ toYaml .Values.hooks.snubaMigrate.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.hooks.snubaInit.nodeSelector }}
+      {{- if .Values.hooks.snubaMigrate.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.hooks.snubaInit.nodeSelector | indent 8 }}
+{{ toYaml .Values.hooks.snubaMigrate.nodeSelector | indent 8 }}
       {{- else if .Values.global.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.hooks.snubaInit.tolerations }}
+      {{- if .Values.hooks.snubaMigrate.tolerations }}
       tolerations:
-{{ toYaml .Values.hooks.snubaInit.tolerations | indent 8 }}
+{{ toYaml .Values.hooks.snubaMigrate.tolerations | indent 8 }}
       {{- else if .Values.global.tolerations }}
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
@@ -98,14 +98,14 @@ spec:
         - mountPath: /etc/snuba
           name: config
           readOnly: true
-{{- if .Values.hooks.snubaInit.volumeMounts }}
-{{ toYaml .Values.hooks.snubaInit.volumeMounts | indent 8 }}
+{{- if .Values.hooks.snubaMigrate.volumeMounts }}
+{{ toYaml .Values.hooks.snubaMigrate.volumeMounts | indent 8 }}
 {{- end }}
 {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 8 }}
 {{- end }}
         resources:
-{{ toYaml .Values.hooks.snubaInit.resources | indent 10 }}
+{{ toYaml .Values.hooks.snubaMigrate.resources | indent 10 }}
 {{- if .Values.hooks.snubaMigrate.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.hooks.snubaMigrate.containerSecurityContext | indent 10 }}
@@ -120,8 +120,8 @@ spec:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}-snuba
-{{- if .Values.hooks.snubaInit.volumes }}
-{{ toYaml .Values.hooks.snubaInit.volumes | indent 6 }}
+{{- if .Values.hooks.snubaMigrate.volumes }}
+{{ toYaml .Values.hooks.snubaMigrate.volumes | indent 6 }}
 {{- end }}
 {{- if .Values.global.volumes }}
 {{ toYaml .Values.global.volumes | indent 6 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2242,6 +2242,19 @@ hooks:
   snubaMigrate:
     enabled: true
     podLabels: {}
+    podAnnotations: {}
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 1Gi
+      requests:
+        cpu: 700m
+        memory: 1Gi
+    affinity: {}
+    nodeSelector: {}
+    tolerations: []
+    securityContext: {}
+    containerSecurityContext: {}
     sidecars: []
     volumes: []
     volumeMounts: []


### PR DESCRIPTION
### Problem

The `snuba-migrate.job.yaml` template incorrectly referenced `.Values.hooks.snubaInit` for the following fields: `podAnnotations`, `affinity`, `nodeSelector`, `tolerations`, `volumeMounts`, `resources`, and `volumes`. This meant that configuring `hooks.snubaMigrate` in `values.yaml` had no effect for those fields, and users had to modify `hooks.snubaInit` to customize the migration job — which is confusing and undocumented.

### Changes

**`charts/sentry/templates/hooks/snuba-migrate.job.yaml`**
- Replaced 7 references from `.Values.hooks.snubaInit` to `.Values.hooks.snubaMigrate` for: `podAnnotations`, `affinity`, `nodeSelector`, `tolerations`, `volumeMounts`, `resources`, `volumes`

**`charts/sentry/values.yaml`**
- Added missing fields to `hooks.snubaMigrate`: `podAnnotations`, `resources`, `affinity`, `nodeSelector`, `tolerations`, `securityContext`, `containerSecurityContext`
- Default values match those previously used via `hooks.snubaInit`, so this is a non-breaking change