### PR TITLE
feat: configuration changes for sentry v26.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 The changelog below refers to the main `sentry` chart only.
 
+## Upgrading to Chart 31.7.0
+
+Chart `31.7.0` adds configuration for [Sentry 26.5.0](https://github.com/getsentry/self-hosted/releases/tag/26.5.0) that was not included when `appVersion` was bumped in `31.4.0`:
+
+- **Launchpad taskworker** (default `feature-complete` profile): new `launchpad-taskworker` Deployment and `LAUNCHPAD_RPC_SHARED_SECRET` on Sentry pods.
+- **Trace Metrics**: related `organizations:tracemetrics-*` feature flags are enabled in generated `sentry.conf.py`.
+
+### Launchpad RPC shared secret
+
+When Launchpad is enabled (`launchpadTaskWorker.enabled=true`, the default with `feature-complete`), the chart needs a shared RPC secret. Choose **one** of:
+
+| Situation                                              | Action                                                                                                                                                                      |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fresh install**, no preference                       | Do nothing — the chart creates `<release-fullname>-launchpad-secret` via a `pre-install` hook.                                                                              |
+| **Production**                                         | Set `launchpadTaskWorker.existingSecret` to a Secret you manage (recommended).                                                                                              |
+| **Upgrade** from a chart version **without** Launchpad | Create the secret (or set `existingSecret` / `rpcSharedSecret`) **before** `helm upgrade`. The hook does not run on upgrade; `helm upgrade` fails if the secret is missing. |
+| **Upgrade** from `31.7.0+` on the same release         | Reuses the hook-created secret from the first install.                                                                                                                      |
+| **Do not need Launchpad**                              | Set `launchpadTaskWorker.enabled=false`, or use the `errors-only` profile.                                                                                                  |
+
+Example — create a secret before upgrading an existing release:
+
+```
+# Replace RELEASE-FULLNAME with your release fullname (e.g. sentry or my-release-sentry).
+# Secret name must be RELEASE-FULLNAME-launchpad-secret unless you set launchpadTaskWorker.existingSecret.
+kubectl create secret generic RELEASE-FULLNAME-launchpad-secret \
+  --from-literal=rpc-shared-secret='CHANGE_ME'
+
+helm upgrade RELEASE sentry/sentry -f values.yaml
+```
+
+Example — use your own Secret name:
+
+```
+kubectl create secret generic sentry-launchpad-rpc-secret \
+  --from-literal=rpc-shared-secret='CHANGE_ME'
+
+helm upgrade sentry sentry/sentry -f values.yaml \
+  --set launchpadTaskWorker.existingSecret=sentry-launchpad-rpc-secret
+```
+
+See `charts/sentry/README.md` (Configuration) and `values.yaml` under `launchpadTaskWorker:` for all options.
+
 ## Upgrading to Chart 31.x.x
 
 > [!CAUTION]
@@ -30,6 +72,7 @@ helm upgrade sentry sentry/sentry \
 The `externalKafka.provisioning.image` block has been removed and replaced with `externalKafka.provisioning.topicctl`. Users who were using external Kafka provisioning must update their `values.yaml`:
 
 **Before:**
+
 ```yaml
 externalKafka:
   provisioning:
@@ -39,6 +82,7 @@ externalKafka:
 ```
 
 **After:**
+
 ```yaml
 externalKafka:
   provisioning:

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -186,6 +186,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | images.snuba.imagePullSecrets | list | `[]` |  |
 | images.symbolicator.imagePullSecrets | list | `[]` |  |
 | images.vroom.imagePullSecrets | list | `[]` |  |
+| images.launchpad.imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{"nginx.ingress.kubernetes.io/use-regex":"true","nginx.ingress.kubernetes.io/proxy-buffers-number":"4","nginx.ingress.kubernetes.io/proxy-buffer-size":"128k","nginx.ingress.kubernetes.io/proxy-busy-buffers-size":"256k"}` | Default ingress annotations (override per controller) |
 | ingress.enabled | bool | `false` |  |
 | ingress.ingressClassName | string | `"nginx"` |  |
@@ -816,6 +817,23 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskWorker.volumeMounts | list | `[]` | |
 | sentry.taskWorker.volumes | list | `[]` | |
 | sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`). |
+| launchpadTaskWorker.enabled | bool | `true` | Deploy Launchpad taskworker (mobile build processing). Requires `feature-complete` profile and `sentry.taskBroker.enabled`. |
+| launchpadTaskWorker.replicas | int | `1` |  |
+| launchpadTaskWorker.concurrency | int | `4` | Parallel Launchpad worker processes (`LAUNCHPAD_WORKER_CONCURRENCY`). |
+| launchpadTaskWorker.rpcSharedSecret | string | `""` | Plaintext Launchpad RPC shared secret. If unset, the chart uses `launchpadTaskWorker.existingSecret` or auto-creates `<release>-launchpad-secret` on install. Not recommended for production. |
+| launchpadTaskWorker.existingSecret | string | `""` | Existing Secret name containing the Launchpad RPC shared secret (recommended for production). |
+| launchpadTaskWorker.existingSecretKey | string | `"rpc-shared-secret"` | Key in `launchpadTaskWorker.existingSecret` for the RPC shared secret. |
+| launchpadTaskWorker.env | list | `[]` | Extra environment variables for the Launchpad taskworker container. |
+| launchpadTaskWorker.resources | object | `{}` |  |
+| launchpadTaskWorker.affinity | object | `{}` |  |
+| launchpadTaskWorker.nodeSelector | object | `{}` |  |
+| launchpadTaskWorker.securityContext | object | `{}` |  |
+| launchpadTaskWorker.containerSecurityContext | object | `{}` |  |
+| launchpadTaskWorker.tolerations | list | `[]` |  |
+| launchpadTaskWorker.podLabels | object | `{}` |  |
+| launchpadTaskWorker.livenessProbe.initialDelaySeconds | int | `30` |  |
+| launchpadTaskWorker.livenessProbe.periodSeconds | int | `10` |  |
+| launchpadTaskWorker.livenessProbe.timeoutSeconds | int | `5` |  |
 | sentry.web.affinity | object | `{}` |  |
 | sentry.web.autoscaling.enabled | bool | `false` |  |
 | sentry.web.autoscaling.maxReplicas | int | `5` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -56,6 +56,24 @@
 {{- default .Chart.AppVersion .Values.images.taskbroker.tag -}}
 {{- end -}}
 
+{{- define "launchpad.image" -}}
+{{- default "ghcr.io/getsentry/launchpad" .Values.images.launchpad.repository -}}
+:
+{{- default .Chart.AppVersion .Values.images.launchpad.tag -}}
+{{- end -}}
+
+{{- define "launchpad.secretName" -}}
+{{- if .Values.launchpadTaskWorker.existingSecret -}}
+{{- .Values.launchpadTaskWorker.existingSecret -}}
+{{- else -}}
+{{- printf "%s-launchpad-secret" (include "sentry.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "launchpad.enabled" -}}
+{{- if and (has "feature-complete" .Values.profiles) .Values.launchpadTaskWorker.enabled .Values.sentry.taskBroker.enabled -}}true{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -673,6 +691,31 @@ See: https://github.com/sentry-kubernetes/charts/issues/2088
 {{- end }}
 {{- end -}}
 
+{{- define "launchpadTaskWorker.env" -}}
+- name: LAUNCHPAD_WORKER_RPC_HOST
+  value: {{ printf "%s-taskbroker-default:50051" (include "sentry.fullname" .) | quote }}
+- name: LAUNCHPAD_WORKER_CONCURRENCY
+  value: {{ .Values.launchpadTaskWorker.concurrency | quote }}
+- name: LAUNCHPAD_WORKER_HEALTH_CHECK_FILE_PATH
+  value: "/tmp/health.txt"
+- name: KAFKA_BOOTSTRAP_SERVERS
+  value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
+- name: SENTRY_BASE_URL
+  value: {{ printf "http://%s-web:%s" (include "sentry.fullname" .) (include "sentry.port" .) | quote }}
+- name: LAUNCHPAD_ENV
+  value: "self-hosted"
+{{- if .Values.launchpadTaskWorker.rpcSharedSecret }}
+- name: LAUNCHPAD_RPC_SHARED_SECRET
+  value: {{ .Values.launchpadTaskWorker.rpcSharedSecret | quote }}
+{{- else }}
+- name: LAUNCHPAD_RPC_SHARED_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "launchpad.secretName" . }}
+      key: {{ default "rpc-shared-secret" .Values.launchpadTaskWorker.existingSecretKey }}
+{{- end }}
+{{- end -}}
+
 {{- define "uptimeChecker.env" -}}
 - name: UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
@@ -1075,6 +1118,22 @@ Set JS SDK Loader assets setup
 {{- if .Values.sentry.jsSdk.setupAssets }}
 - name: SETUP_JS_SDK_ASSETS
   value: "1"
+{{- end }}
+
+{{/*
+Launchpad RPC shared secret (required by Sentry web and launchpad-taskworker)
+*/}}
+{{- if eq (include "launchpad.enabled" .) "true" }}
+{{- if .Values.launchpadTaskWorker.rpcSharedSecret }}
+- name: LAUNCHPAD_RPC_SHARED_SECRET
+  value: {{ .Values.launchpadTaskWorker.rpcSharedSecret | quote }}
+{{- else }}
+- name: LAUNCHPAD_RPC_SHARED_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "launchpad.secretName" . }}
+      key: {{ default "rpc-shared-secret" .Values.launchpadTaskWorker.existingSecretKey }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/sentry/templates/hooks/launchpad-secret-create.yaml
+++ b/charts/sentry/templates/hooks/launchpad-secret-create.yaml
@@ -1,0 +1,22 @@
+{{- if and (eq (include "launchpad.enabled" .) "true") (not .Values.launchpadTaskWorker.rpcSharedSecret) (not .Values.launchpadTaskWorker.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "launchpad.secretName" . }}
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- if .Values.useArgoCdCompatibleAnnotations }}
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/sync-wave": "-1"
+    {{- else }}
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "3"
+    {{- end }}
+type: Opaque
+data:
+  rpc-shared-secret: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}

--- a/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
@@ -1,0 +1,132 @@
+{{- if eq (include "launchpad.enabled" .) "true" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-launchpad-taskworker
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "sentry.component.labels" (dict "component" "launchpad-taskworker" "ctx" .) | nindent 4 }}
+  {{- if .Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "25"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  replicas: {{ .Values.launchpadTaskWorker.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "sentry.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: launchpad-taskworker
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.launchpadTaskWorker.annotations }}
+{{ toYaml .Values.launchpadTaskWorker.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: launchpad-taskworker
+        {{- include "sentry.component.labels" (dict "component" "launchpad-taskworker" "ctx" .) | nindent 8 }}
+        {{- if .Values.launchpadTaskWorker.podLabels }}
+{{ toYaml .Values.launchpadTaskWorker.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.images.launchpad.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.launchpad.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.launchpadTaskWorker.affinity }}
+      affinity:
+{{ toYaml .Values.launchpadTaskWorker.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.launchpadTaskWorker.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.launchpadTaskWorker.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.launchpadTaskWorker.tolerations }}
+      tolerations:
+{{ toYaml .Values.launchpadTaskWorker.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.launchpadTaskWorker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.launchpadTaskWorker.topologySpreadConstraints | indent 8 }}
+      {{- end }}
+      {{- if .Values.launchpadTaskWorker.securityContext }}
+      securityContext:
+{{ toYaml .Values.launchpadTaskWorker.securityContext | indent 8 }}
+      {{- end }}
+      {{- if .Values.launchpadTaskWorker.priorityClassName }}
+      priorityClassName: "{{ .Values.launchpadTaskWorker.priorityClassName }}"
+      {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-launchpad-taskworker
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      containers:
+      - name: launchpad-taskworker
+        image: "{{ template "launchpad.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.launchpad.pullPolicy }}
+        command: ["worker"]
+        args: ["--verbose"]
+        env:
+{{- include "launchpadTaskWorker.env" . | nindent 8 }}
+{{- if .Values.launchpadTaskWorker.env }}
+{{ toYaml .Values.launchpadTaskWorker.env | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.launchpadTaskWorker.resources | indent 10 }}
+{{- if .Values.launchpadTaskWorker.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.launchpadTaskWorker.containerSecurityContext | indent 10 }}
+{{- end }}
+{{- if .Values.launchpadTaskWorker.volumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.launchpadTaskWorker.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - rm
+            - /tmp/health.txt
+          initialDelaySeconds: {{ default 30 .Values.launchpadTaskWorker.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.launchpadTaskWorker.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ default 5 .Values.launchpadTaskWorker.livenessProbe.timeoutSeconds }}
+{{- if .Values.launchpadTaskWorker.sidecars }}
+{{ toYaml .Values.launchpadTaskWorker.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
+{{- if or .Values.launchpadTaskWorker.volumes .Values.global.volumes }}
+      volumes:
+{{- if .Values.launchpadTaskWorker.volumes }}
+{{ toYaml .Values.launchpadTaskWorker.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
@@ -86,8 +86,10 @@ spec:
       - name: launchpad-taskworker
         image: "{{ template "launchpad.image" . }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.launchpad.pullPolicy }}
-        command: ["worker"]
-        args: ["--verbose"]
+        command: ["launchpad"]
+        args: 
+        - worker
+        - --verbose
         env:
 {{- include "launchpadTaskWorker.env" . | nindent 8 }}
 {{- if .Values.launchpadTaskWorker.env }}

--- a/charts/sentry/templates/launchpad-taskworker/serviceaccount-launchpad-taskworker.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/serviceaccount-launchpad-taskworker.yaml
@@ -1,0 +1,8 @@
+{{- if and (eq (include "launchpad.enabled" .) "true") .Values.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-launchpad-taskworker
+  labels:
+    {{- include "sentry.component.labels" (dict "component" "launchpad-taskworker" "ctx" .) | nindent 4 }}
+{{- end }}

--- a/charts/sentry/templates/launchpad-taskworker/validate-launchpad.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/validate-launchpad.yaml
@@ -1,0 +1,13 @@
+{{- if eq (include "launchpad.enabled" .) "true" }}
+{{- if .Values.launchpadTaskWorker.rpcSharedSecret }}
+{{- else if .Values.launchpadTaskWorker.existingSecret }}
+{{- else }}
+{{- $secretName := include "launchpad.secretName" . }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- if not $secret }}
+{{- if not .Release.IsInstall }}
+{{- fail (printf "\n\nERROR: Launchpad RPC shared secret %q was not found in namespace %q.\nWhen upgrading to a release with Launchpad enabled, create the secret or set ONE of:\n  - launchpadTaskWorker.existingSecret (recommended)\n  - launchpadTaskWorker.rpcSharedSecret (NOT recommended for production)\nOn fresh installs the chart creates %q automatically via a pre-install hook.\nSee values.yaml under launchpadTaskWorker: and README.md.\n" $secretName .Release.Namespace $secretName) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -464,6 +464,17 @@ sentry.conf.py: |-
               "organizations:ourlogs-stats",
               "organizations:ourlogs-replay-ui",
 
+              # Metrics (Trace Metrics)
+              "organizations:tracemetrics-enabled",
+              "organizations:tracemetrics-alerts",
+              "organizations:tracemetrics-ingestion",
+              "organizations:tracemetrics-equations-in-alerts",
+              "organizations:tracemetrics-equations-in-explore",
+              "organizations:tracemetrics-multi-metric-selection-in-dashboards",
+              "organizations:tracemetrics-units-ui",
+              "organizations:tracemetrics-stats-bytes-ui",
+              "organizations:tracemetrics-pii-scrubbing-ui",
+
               # Chart-only / misc
               "organizations:related-events",
               "organizations:reprocessing-v2",

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -77,6 +77,11 @@ images:
     # tag: Chart.AppVersion
     # pullPolicy: IfNotPresent
     imagePullSecrets: []
+  launchpad:
+    # repository: getsentry/launchpad
+    # tag: Chart.AppVersion
+    # pullPolicy: IfNotPresent
+    imagePullSecrets: []
 
 serviceAccount:
   # serviceAccount.annotations -- Additional Service Account annotations.
@@ -153,6 +158,35 @@ vroom:
   sidecars: []
   volumes: []
   volumeMounts: []
+
+launchpadTaskWorker:
+  enabled: true
+  annotations: {}
+  replicas: 1
+  concurrency: 4
+  ## Optional: set `rpcSharedSecret` or `existingSecret` to supply the RPC shared secret yourself.
+  ## If neither is set, the chart creates `<release>-launchpad-secret` on first install (pre-install hook).
+  ## Upgrades require that secret to already exist, or you must set one of the options below.
+  ## `existingSecret` is strongly recommended for production.
+  rpcSharedSecret: ""
+  # existingSecret: sentry-launchpad-rpc-secret
+  # existingSecretKey: rpc-shared-secret
+  env: []
+  resources: {}
+  affinity: {}
+  nodeSelector: {}
+  securityContext: {}
+  containerSecurityContext: {}
+  tolerations: []
+  podLabels: {}
+  sidecars: []
+  topologySpreadConstraints: []
+  volumes: []
+  volumeMounts: []
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
 
 uptimeChecker:
   annotations: {}


### PR DESCRIPTION
https://github.com/sentry-kubernetes/charts/pull/2179 upgraded to 26.5.0 but lacked the necessary config changes. This PR adds the missing configuration that is required for v26.5.0 of Sentry, based on https://github.com/getsentry/self-hosted/compare/26.4.2...26.5.0