### PR TITLE
feat: add TLS settings support for Kafka provisioning topicctl

### DIFF
--- a/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
+++ b/charts/sentry/templates/kafka-provisioning/configmap-kafka-provisioning.yaml
@@ -71,6 +71,20 @@ data:
       {{- if or (eq $securityProtocol "SSL") (eq $securityProtocol "SASL_SSL") }}
       tls:
         enabled: true
+        {{- with $topicctl.tls }}
+        {{- if .caCertPath }}
+        caCertPath: {{ .caCertPath | quote }}
+        {{- end }}
+        {{- if .certPath }}
+        certPath: {{ .certPath | quote }}
+        {{- end }}
+        {{- if .keyPath }}
+        keyPath: {{ .keyPath | quote }}
+        {{- end }}
+        {{- if .skipVerify }}
+        skipVerify: true
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- if $saslEnabled }}
       sasl:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3284,6 +3284,22 @@ externalKafka:
       environment: "default"
       region: "default"
       placementStrategy: "any"
+      # TLS settings for topicctl cluster config (optional).
+      # Before using, create a ConfigMap with the CA bundle:
+      #   kubectl create configmap kafka-ca-bundle --from-file=ca-certificates.crt=./path/to/ca.crt
+      # tls:
+      #   caCertPath: /etc/ssl/custom-certs/ca-certificates.crt
+      #   # certPath: ""
+      #   # keyPath: ""
+      #   # skipVerify: false
+    # volumes:
+    #   - name: kafka-ca
+    #     configMap:
+    #       name: kafka-ca-bundle
+    # volumeMounts:
+    #   - name: kafka-ca
+    #     mountPath: /etc/ssl/custom-certs
+    #     readOnly: true
     # topics: []  # If empty, uses kafka.provisioning.topics
     # topicOverrides allows overriding partitions/config for specific topics without re-declaring all topics.
     # Keys must match topic names from kafka.provisioning.topics (or externalKafka.provisioning.topics if set).


### PR DESCRIPTION
## What this PR does

Adds TLS configuration support for Kafka provisioning topicctl. This allows users to specify custom CA certificate, client certificate, client key, and skip verify options for TLS connections when provisioning Kafka topics.



## Changes

- Added TLS settings (caCertPath, certPath, keyPath, skipVerify) to topicctl cluster configuration in configmap-kafka-provisioning.yaml
- Added commented TLS configuration examples with volume/volumeMount examples in values.yaml for reference

## Use case

This is needed when connecting to Kafka clusters that use custom CA certificates (e.g., self-signed or private CA). Users can now mount their CA bundle and configure topicctl to use it.

Fix: https://github.com/sentry-kubernetes/charts/issues/2213