### PR TITLE
fix: symbolicator cleaner sidecar ignores resource definitions

### DIFF
--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -155,6 +155,8 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+        resources:
+{{ toYaml .Values.symbolicator.api.cleaner.resources | indent 12 }}
 {{- if .Values.symbolicator.api.cleaner.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.symbolicator.api.cleaner.containerSecurityContext | indent 12 }}

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -155,6 +155,8 @@ spec:
         - name: sentry-google-cloud-key
           mountPath: /var/run/secrets/google
         {{ end }}
+        resources:
+{{ toYaml .Values.symbolicator.api.cleaner.resources | indent 12 }}
       {{- end }}
 {{- if .Values.symbolicator.api.sidecars }}
 {{ toYaml .Values.symbolicator.api.sidecars | indent 6 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2378,6 +2378,7 @@ symbolicator:
     cleaner:
       enabled: true
       repeat: "1h"
+      resources: {}
     usedeployment: true  # Set true to use Deployment, false for StatefulSet
     persistence:
       enabled: true  # Set true for using PersistentVolumeClaim, false for emptyDir


### PR DESCRIPTION
## Description

Fixes #2214

The symbolicator cleaner sidecar container was ignoring resource definitions set for the symbolicator. When users set `symbolicator.api.resources` in their values.yaml, the main symbolicator container respected those settings, but the cleaner sidecar had no resource requests or limits at all.

This change adds a dedicated `resources` field for the cleaner container under `symbolicator.api.cleaner.resources`, allowing users to set CPU and memory requests/limits independently for the sidecar.

## Changes

- Added `resources: {}` to `symbolicator.api.cleaner` in `values.yaml`
- Added `resources` section to cleaner container in `deployment-symbolicator.yaml`
- Added `resources` section to cleaner container in `statefulset-symbolicator.yaml`

## Usage

Users can now define resources for the cleaner sidecar:

```yaml
symbolicator:
  enabled: true
  api:
    cleaner:
      enabled: true
      repeat: "1h"
      resources:
        requests:
          cpu: "100m"
          memory: "128Mi"
        limits:
          memory: "128Mi"
```

## Testing

Verified with `helm template` that:
1. Empty resources `{}` renders correctly when no resources are specified
2. Custom resources render correctly when specified in values.yaml