### PR TITLE
feat: enable cache (memcached) by default

### DIFF
--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.7.0
-digest: sha256:db3349bfd8df7edf86fd67be5b6a4b369b3dd76a1c5548c860e855c89bcd8e4f
-generated: "2026-05-05T17:50:54.803225971+06:00"
+digest: sha256:11613581288338b8b94759d4438866780bcd3adbcbb815d9dee7132753ffb2da
+generated: "2026-05-29T12:27:53.995591111+06:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -9,7 +9,6 @@ dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates
     version: 0.9.3
-    condition: cache.enabled,sourcemaps.enabled
   - name: redis
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 17.11.3

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1120,8 +1120,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.transactionsConsumer.resources | object | `{}` |  |
 | snuba.transactionsConsumer.securityContext | object | `{}` |  |
 | snuba.transactionsConsumer.topologySpreadConstraints | list | `[]` |  |
-| sourcemaps.enabled | bool | `false` | DEPRECATED: use cache.enabled instead |
-| cache.enabled | bool | `false` | Enable Django CACHES (memcached) |
 | symbolicator.api.affinity | object | `{}` |  |
 | symbolicator.api.autoscaling.enabled | bool | `false` |  |
 | symbolicator.api.autoscaling.maxReplicas | int | `5` |  |
@@ -1348,14 +1346,7 @@ Its also important having `connect_to_reserved_ips: true` in the symbolicator co
 
 #### Source Maps
 
-> **Deprecated:** `sourcemaps.enabled` is deprecated and will be removed in a future release. Use `cache.enabled` instead.
-
-To get javascript source map processing working, you need to enable the Django cache (memcached), which is also used by 60+ Sentry components for caching:
-
-```yaml
-cache:
-  enabled: true
-```
+To get javascript source map processing working, the Django cache (memcached) is enabled by default, which is also used by 60+ Sentry components for caching.
 
 For details on the background see this blog post: https://engblog.yext.com/post/sentry-js-source-maps
 

--- a/charts/sentry/templates/NOTES.txt
+++ b/charts/sentry/templates/NOTES.txt
@@ -3,8 +3,3 @@
 
 {{ template "sentry.kafka.bootstrap_servers_string" . }}
 {{ end -}}
-
-{{- if .Values.sourcemaps.enabled }}
-WARNING: sourcemaps.enabled is deprecated and will be removed in a future release.
-         Use cache.enabled instead.
-{{- end }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -95,7 +95,6 @@ sentry.conf.py: |-
       power = UNITS.index(unit) + 1
       return float(text[:-1])*(BYTE_MULTIPLIER**power)
 
-  {{- if or .Values.cache.enabled .Values.sourcemaps.enabled }}
   CACHES = {
       "default": {
           "BACKEND": "sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache",
@@ -106,7 +105,6 @@ sentry.conf.py: |-
           "OPTIONS": {"ignore_exc": True, "reconnect_age": 300}
       }
   }
-  {{- end }}
 
   DATABASES = {
       "default": {

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3309,14 +3309,6 @@ externalKafka:
     nodeSelector: {}
     tolerations: []
 
-# DEPRECATED: sourcemaps.enabled is deprecated and will be removed in a future release.
-# Use cache.enabled instead. See cache.enabled below.
-sourcemaps:
-  enabled: false
-
-cache:
-  enabled: false
-
 redis:
   enabled: true
   image:


### PR DESCRIPTION
## What this PR does

Enables Django cache (memcached) by default, removing the need for  and  toggles.

## Changes

- Remove  condition from 
- Remove  from memcached dependency in 
- Remove  and  sections from 
- Remove deprecated warning from 
- Update  to reflect that cache is now always enabled

## Motivation

Memcached is required by 60+ Sentry components for caching. Having it disabled by default causes issues for most deployments.