### PR TITLE
fix: remove invalid annotations from hook jobs

### DIFF
--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -27,18 +27,12 @@ spec:
     metadata:
       name: {{ template "sentry.fullname" . }}-db-check
       annotations:
-        {{- if .Values.sentry.web.annotations }}
-{{ toYaml .Values.sentry.web.annotations | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbCheck.podAnnotations }}
 {{ toYaml .Values.hooks.dbCheck.podAnnotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        {{- if .Values.sentry.web.podLabels }}
-{{ toYaml .Values.sentry.web.podLabels | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbCheck.podLabels }}
 {{ toYaml .Values.hooks.dbCheck.podLabels | indent 8 }}
         {{- end }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -23,18 +23,12 @@ spec:
       name: {{ template "sentry.fullname" . }}-db-init
       annotations:
         checksum/configmap.yaml: {{ include "sentry.config" . | sha256sum }}
-        {{- if .Values.sentry.web.annotations }}
-{{ toYaml .Values.sentry.web.annotations | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbInit.podAnnotations }}
 {{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        {{- if .Values.sentry.web.podLabels }}
-{{ toYaml .Values.sentry.web.podLabels | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbInit.podLabels }}
 {{ toYaml .Values.hooks.dbInit.podLabels | indent 8 }}
         {{- end }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -24,17 +24,14 @@ spec:
       name: {{ template "sentry.fullname" . }}-user-create
       annotations:
         checksum/configmap.yaml: {{ include "sentry.config" . | sha256sum }}
-        {{- if .Values.sentry.web.annotations }}
-{{ toYaml .Values.sentry.web.annotations | indent 8 }}
-        {{- end }}
         {{- if .Values.hooks.dbInit.podAnnotations }}
 {{ toYaml .Values.hooks.dbInit.podAnnotations | indent 8 }}
         {{- end }}
       labels:
         app: sentry
         release: "{{ .Release.Name }}"
-        {{- if .Values.sentry.web.podLabels }}
-{{ toYaml .Values.sentry.web.podLabels | indent 8 }}
+        {{- if .Values.hooks.dbInit.podLabels }}
+{{ toYaml .Values.hooks.dbInit.podLabels | indent 8 }}
         {{- end }}
     spec:
       {{- if .Values.hooks.dbInit.affinity }}


### PR DESCRIPTION
Remove `sentry.web.annotations` and `sentry.web.podLabels` from hook jobs that are not web-related.

These annotations were incorrectly copied from web templates and do not belong in database check, init, or user creation jobs.

## Changes

- Removed `sentry.web.annotations` from `sentry-db-check` pod template
- Removed `sentry.web.annotations` from `sentry-db-init` pod template
- Removed `sentry.web.annotations` and `sentry.web.podLabels` from `user-create` pod template

## Files Modified

- `charts/sentry/templates/hooks/sentry-db-check.job.yaml`
- `charts/sentry/templates/hooks/sentry-db-init.job.yaml`
- `charts/sentry/templates/hooks/user-create.yaml`

## Why

Hook jobs (db-check, db-init, user-create) should not inherit web server annotations.
