### PR TITLE
fix: add hook-weight 3 to taskbroker and taskworker to prevent CrashLoopBackOff

### DIFF
--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -12,6 +12,13 @@ metadata:
     heritage: "{{ $root.Release.Service }}"
     role: taskbroker-{{ $broker.name }}
     {{- include "sentry.component.labels" (dict "component" (printf "taskbroker-%s" $broker.name) "ctx" $root) | nindent 4 }}
+  {{- if $root.Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ $root.Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ $root.Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "3"
+  {{- end }}
 spec:
   serviceName: {{ template "sentry.fullname" $root }}-taskbroker-{{ $broker.name }}
   replicas: {{ default $root.Values.sentry.taskBroker.replicas $broker.replicas }}
@@ -168,6 +175,13 @@ metadata:
     app: {{ template "sentry.fullname" $root }}
     release: "{{ $root.Release.Name }}"
     role: taskbroker-{{ $broker.name }}
+  {{- if $root.Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ $root.Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ $root.Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "3"
+  {{- end }}
 spec:
   ports:
   - port: 50051

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -12,6 +12,13 @@ metadata:
     heritage: "{{ $root.Release.Service }}"
     role: taskworker-{{ $worker.name }}
     {{- include "sentry.component.labels" (dict "component" (printf "taskworker-%s" $worker.name) "ctx" $root) | nindent 4 }}
+  {{- if $root.Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ $root.Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ $root.Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "3"
+  {{- end }}
 spec:
   revisionHistoryLimit: {{ $root.Values.revisionHistoryLimit }}
 {{- $workerAutoscaling := default dict $worker.autoscaling }}

--- a/charts/sentry/templates/sentry/taskworker/hpa-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/hpa-taskworker.yaml
@@ -21,6 +21,13 @@ apiVersion: {{ template "sentry.autoscaling.apiVersion" $root }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sentry.fullname" $root }}-taskworker-{{ $worker.name }}
+  {{- if $root.Values.asHook }}
+  annotations:
+    meta.helm.sh/release-name: "{{ $root.Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ $root.Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "3"
+  {{- end }}
   labels:
     {{- include "sentry.component.labels" (dict "component" (printf "taskworker-%s" $worker.name) "ctx" $root) | nindent 4 }}
 spec:


### PR DESCRIPTION
## Problem

Taskbroker and taskworker pods experience  during Helm install/upgrade because they start in parallel with the  job (all at default weight 0).

**Root cause:** taskbroker subscribes to Kafka topics (e.g., , ) that don't exist yet — the provisioning job hasn't created them. This causes:



## Fix

Added  to taskbroker and taskworker resources (guarded by  check):

-  — StatefulSet + Service
-  — Deployment
-  — HPA

## Deploy order after fix

| Weight | Component |
|--------|-----------|
| -5 | kafka-provisioning/configmap |
| -1 | sentry-db-check (job) |
| 0 | kafka-provisioning/job, subcharts, services |
| **3** | **taskbroker, taskworker** |
| 3+ | hooks (snuba-db-init, sentry-db-init, etc.) |
| 10+ | sentry-web, snuba, relay, etc. |

This ensures Kafka topics are created before taskbroker/taskworker attempt to subscribe to them.