### PR TITLE
feat!: replace deprecated distutils.strtobool and enable rustConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog below refers to the main `sentry` chart only.
 
+## Upgrading to Chart 32.0.0
+
+- **Rust Snuba consumer** is now enabled by default. Set `snuba.rustConsumer: false` to revert.
+- Removed deprecated `distutils.strtobool` from `sentry.conf.py` template — mail TLS/SSL now uses `.lower() in ("true", "1", "yes")`.
+
 ## Upgrading to Chart 31.7.0
 
 Chart `31.7.0` adds configuration for [Sentry 26.5.0](https://github.com/getsentry/self-hosted/releases/tag/26.5.0) that was not included when `appVersion` was bumped in `31.4.0`:

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -86,7 +86,6 @@ config.yml: |-
   {{- end }}
 sentry.conf.py: |-
   from sentry.conf.server import *  # NOQA
-  from distutils.util import strtobool
 
   BYTE_MULTIPLIER = 1024
   UNITS = ("K", "M", "G")
@@ -496,8 +495,8 @@ sentry.conf.py: |-
   # Email Configuration #
   #######################
   SENTRY_OPTIONS['mail.backend'] = os.getenv("SENTRY_EMAIL_BACKEND", {{ .Values.mail.backend | quote }})
-  SENTRY_OPTIONS['mail.use-tls'] = bool(strtobool(os.getenv("SENTRY_EMAIL_USE_TLS", {{ .Values.mail.useTls | quote }})))
-  SENTRY_OPTIONS['mail.use-ssl'] = bool(strtobool(os.getenv("SENTRY_EMAIL_USE_SSL", {{ .Values.mail.useSsl | quote }})))
+  SENTRY_OPTIONS['mail.use-tls'] = os.getenv("SENTRY_EMAIL_USE_TLS", {{ .Values.mail.useTls | quote }}).lower() in ("true", "1", "yes")
+  SENTRY_OPTIONS['mail.use-ssl'] = os.getenv("SENTRY_EMAIL_USE_SSL", {{ .Values.mail.useSsl | quote }}).lower() in ("true", "1", "yes")
   SENTRY_OPTIONS['mail.username'] = os.getenv("SENTRY_EMAIL_USERNAME", {{ .Values.mail.username | quote }})
   SENTRY_OPTIONS['mail.password'] = os.getenv("SENTRY_EMAIL_PASSWORD", "")
   SENTRY_OPTIONS['mail.port'] = int(os.getenv("SENTRY_EMAIL_PORT", {{ .Values.mail.port | quote }}))

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2179,7 +2179,7 @@ snuba:
   clickhouse:
     maxConnections: 100
 
-  rustConsumer: false
+  rustConsumer: true
 
   # ClickHouse database cleanup configuration
   # WARNING: NOT READY FOR PRODUCTION USE


### PR DESCRIPTION
## Changes

- Remove deprecated `from distutils.util import strtobool` import (deprecated since Python 3.10, removed in 3.12)
- Replace `strtobool()` calls with `.lower() in ("true", "1", "yes")` for mail TLS/SSL configuration options
- Enable `rustConsumer` by default

## Motivation

`distutils` module is deprecated since Python 3.10 and removed in Python 3.12. Using it causes an `ImportError` on newer Python versions. This change replaces the `strtobool` usage with an equivalent inline check that works across all Python versions.