### PR TITLE
feat: per taskbroker & taskworker topologySpreadConstraints

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -776,7 +776,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.subscriptionConsumerTransactions.topologySpreadConstraints | list | `[]` |  |
 | sentry.subscriptionConsumerTransactions.volumes | list | `[]` |  |
 | sentry.taskBroker.affinity | object | `{}` | |
-| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` merged with `sentry.taskBroker.topologySpreadConstraints`). |
+| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` supersedes `sentry.taskBroker.topologySpreadConstraints`). |
 | sentry.taskBroker.containerSecurityContext | object | `{}` | |
 | sentry.taskBroker.enabled | bool | `true` | |
 | sentry.taskBroker.env | list | `[]` | |
@@ -791,7 +791,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskBroker.securityContext | object | `{}` | |
 | sentry.taskBroker.sidecars | list | `[]` | |
 | sentry.taskBroker.tolerations | list | `[]` | |
-| sentry.taskBroker.topologySpreadConstraints | list | `[]` | Default container topologySpreadConstraints for task broker pods; merged with each broker’s `topologySpreadConstraints` in `sentry.taskBroker.brokers`. |
+| sentry.taskBroker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task broker pods; superseded by each broker’s `topologySpreadConstraints` in `sentry.taskBroker.brokers`. |
 | sentry.taskBroker.volumeMounts | list | `[]` | |
 | sentry.taskBroker.volumes | list | `[]` | |
 | sentry.taskWorker.affinity | object | `{}` | |
@@ -813,10 +813,10 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskWorker.securityContext | object | `{}` | |
 | sentry.taskWorker.sidecars | list | `[]` | |
 | sentry.taskWorker.tolerations | list | `[]` | |
-| sentry.taskWorker.topologySpreadConstraints | list | `[]` | Default container topologySpreadConstraints for task worker pods; merged with each worker’s `topologySpreadConstraints` in `sentry.taskWorker.workers`. |
+| sentry.taskWorker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task worker pods; superseded by each worker’s `topologySpreadConstraints` in `sentry.taskWorker.workers`. |
 | sentry.taskWorker.volumeMounts | list | `[]` | |
 | sentry.taskWorker.volumes | list | `[]` | |
-| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` merged with `sentry.taskWorker.topologySpreadConstraints`). |
+| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` supersedes `sentry.taskWorker.topologySpreadConstraints`). |
 | launchpadTaskWorker.enabled | bool | `true` | Deploy Launchpad taskworker (mobile build processing). Requires `feature-complete` profile and `sentry.taskBroker.enabled`. |
 | launchpadTaskWorker.replicas | int | `1` |  |
 | launchpadTaskWorker.concurrency | int | `4` | Parallel Launchpad worker processes (`LAUNCHPAD_WORKER_CONCURRENCY`). |

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -776,7 +776,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.subscriptionConsumerTransactions.topologySpreadConstraints | list | `[]` |  |
 | sentry.subscriptionConsumerTransactions.volumes | list | `[]` |  |
 | sentry.taskBroker.affinity | object | `{}` | |
-| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`). |
+| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` merged with `sentry.taskBroker.topologySpreadConstraints`). |
 | sentry.taskBroker.containerSecurityContext | object | `{}` | |
 | sentry.taskBroker.enabled | bool | `true` | |
 | sentry.taskBroker.env | list | `[]` | |
@@ -791,7 +791,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskBroker.securityContext | object | `{}` | |
 | sentry.taskBroker.sidecars | list | `[]` | |
 | sentry.taskBroker.tolerations | list | `[]` | |
-| sentry.taskBroker.topologySpreadConstraints | list | `[]` | |
+| sentry.taskBroker.topologySpreadConstraints | list | `[]` | Default container topologySpreadConstraints for task broker pods; merged with each broker’s `topologySpreadConstraints` in `sentry.taskBroker.brokers`. |
 | sentry.taskBroker.volumeMounts | list | `[]` | |
 | sentry.taskBroker.volumes | list | `[]` | |
 | sentry.taskWorker.affinity | object | `{}` | |
@@ -813,10 +813,10 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskWorker.securityContext | object | `{}` | |
 | sentry.taskWorker.sidecars | list | `[]` | |
 | sentry.taskWorker.tolerations | list | `[]` | |
-| sentry.taskWorker.topologySpreadConstraints | list | `[]` | |
+| sentry.taskWorker.topologySpreadConstraints | list | `[]` | Default container topologySpreadConstraints for task worker pods; merged with each worker’s `topologySpreadConstraints` in `sentry.taskWorker.workers`. |
 | sentry.taskWorker.volumeMounts | list | `[]` | |
 | sentry.taskWorker.volumes | list | `[]` | |
-| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`). |
+| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` merged with `sentry.taskWorker.topologySpreadConstraints`). |
 | launchpadTaskWorker.enabled | bool | `true` | Deploy Launchpad taskworker (mobile build processing). Requires `feature-complete` profile and `sentry.taskBroker.enabled`. |
 | launchpadTaskWorker.replicas | int | `1` |  |
 | launchpadTaskWorker.concurrency | int | `4` | Parallel Launchpad worker processes (`LAUNCHPAD_WORKER_CONCURRENCY`). |

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -776,7 +776,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.subscriptionConsumerTransactions.topologySpreadConstraints | list | `[]` |  |
 | sentry.subscriptionConsumerTransactions.volumes | list | `[]` |  |
 | sentry.taskBroker.affinity | object | `{}` | |
-| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` supersedes `sentry.taskBroker.topologySpreadConstraints`). |
+| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` overridden by `sentry.taskBroker.topologySpreadConstraints`). |
 | sentry.taskBroker.containerSecurityContext | object | `{}` | |
 | sentry.taskBroker.enabled | bool | `true` | |
 | sentry.taskBroker.env | list | `[]` | |
@@ -791,7 +791,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskBroker.securityContext | object | `{}` | |
 | sentry.taskBroker.sidecars | list | `[]` | |
 | sentry.taskBroker.tolerations | list | `[]` | |
-| sentry.taskBroker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task broker pods; superseded by each broker’s `topologySpreadConstraints` in `sentry.taskBroker.brokers`. |
+| sentry.taskBroker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task broker pods; overridden by each broker’s `topologySpreadConstraints` in `sentry.taskBroker.brokers`. |
 | sentry.taskBroker.volumeMounts | list | `[]` | |
 | sentry.taskBroker.volumes | list | `[]` | |
 | sentry.taskWorker.affinity | object | `{}` | |
@@ -813,10 +813,10 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskWorker.securityContext | object | `{}` | |
 | sentry.taskWorker.sidecars | list | `[]` | |
 | sentry.taskWorker.tolerations | list | `[]` | |
-| sentry.taskWorker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task worker pods; superseded by each worker’s `topologySpreadConstraints` in `sentry.taskWorker.workers`. |
+| sentry.taskWorker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task worker pods; overriden by each worker’s `topologySpreadConstraints` in `sentry.taskWorker.workers`. |
 | sentry.taskWorker.volumeMounts | list | `[]` | |
 | sentry.taskWorker.volumes | list | `[]` | |
-| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` supersedes `sentry.taskWorker.topologySpreadConstraints`). |
+| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` overriden by `sentry.taskWorker.topologySpreadConstraints`). |
 | launchpadTaskWorker.enabled | bool | `true` | Deploy Launchpad taskworker (mobile build processing). Requires `feature-complete` profile and `sentry.taskBroker.enabled`. |
 | launchpadTaskWorker.replicas | int | `1` |  |
 | launchpadTaskWorker.concurrency | int | `4` | Parallel Launchpad worker processes (`LAUNCHPAD_WORKER_CONCURRENCY`). |

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -776,7 +776,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.subscriptionConsumerTransactions.topologySpreadConstraints | list | `[]` |  |
 | sentry.subscriptionConsumerTransactions.volumes | list | `[]` |  |
 | sentry.taskBroker.affinity | object | `{}` | |
-| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` overridden by `sentry.taskBroker.topologySpreadConstraints`). |
+| sentry.taskBroker.brokers | list | (see `values.yaml`) | One broker StatefulSet per item (`name`, `topic`, `consumerGroup`, `replicas`, optional `resources` merged with `sentry.taskBroker.resources`, optional `topologySpreadConstraints` overridding `sentry.taskBroker.topologySpreadConstraints`). |
 | sentry.taskBroker.containerSecurityContext | object | `{}` | |
 | sentry.taskBroker.enabled | bool | `true` | |
 | sentry.taskBroker.env | list | `[]` | |
@@ -816,7 +816,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskWorker.topologySpreadConstraints | list | `[]` | Default pod topologySpreadConstraints for task worker pods; overriden by each worker’s `topologySpreadConstraints` in `sentry.taskWorker.workers`. |
 | sentry.taskWorker.volumeMounts | list | `[]` | |
 | sentry.taskWorker.volumes | list | `[]` | |
-| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` overriden by `sentry.taskWorker.topologySpreadConstraints`). |
+| sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` overriding `sentry.taskWorker.topologySpreadConstraints`). |
 | launchpadTaskWorker.enabled | bool | `true` | Deploy Launchpad taskworker (mobile build processing). Requires `feature-complete` profile and `sentry.taskBroker.enabled`. |
 | launchpadTaskWorker.replicas | int | `1` |  |
 | launchpadTaskWorker.concurrency | int | `4` | Parallel Launchpad worker processes (`LAUNCHPAD_WORKER_CONCURRENCY`). |

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -75,7 +75,7 @@ spec:
       tolerations:
 {{ toYaml $root.Values.global.tolerations | indent 8 }}
       {{- end }}
-{{- $taskBrokerTopologySpreadConstraints := default $root.Values.sentry.taskBroker.topologySpreadConstraints $broker.topologySpreadConstraints }}
+{{- $taskBrokerTopologySpreadConstraints := ternary $broker.topologySpreadConstraints $root.Values.sentry.taskBroker.topologySpreadConstraints (hasKey $broker "topologySpreadConstraints") }}
       topologySpreadConstraints:
 {{ toYaml $taskBrokerTopologySpreadConstraints | indent 8 }}
       {{- if $root.Values.sentry.taskBroker.securityContext }}

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -75,10 +75,9 @@ spec:
       tolerations:
 {{ toYaml $root.Values.global.tolerations | indent 8 }}
       {{- end }}
-      {{- if $root.Values.sentry.taskBroker.topologySpreadConstraints }}
+{{- $taskBrokerTopologySpreadConstraints := default $root.Values.sentry.taskBroker.topologySpreadConstraints $broker.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml $root.Values.sentry.taskBroker.topologySpreadConstraints | indent 8 }}
-      {{- end }}
+{{ toYaml $taskBrokerTopologySpreadConstraints | indent 8 }}
       {{- if $root.Values.sentry.taskBroker.securityContext }}
       securityContext:
 {{ toYaml $root.Values.sentry.taskBroker.securityContext | indent 8 }}

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -74,7 +74,7 @@ spec:
       tolerations:
 {{ toYaml $root.Values.global.tolerations | indent 8 }}
       {{- end }}
-{{- $taskWorkerTopologySpreadConstraints := default $root.Values.sentry.taskWorker.topologySpreadConstraints $worker.topologySpreadConstraints }}
+{{- $taskWorkerTopologySpreadConstraints := ternary $worker.topologySpreadConstraints $root.Values.sentry.taskWorker.topologySpreadConstraints (hasKey $worker "topologySpreadConstraints") }}
       topologySpreadConstraints:
 {{ toYaml $taskWorkerTopologySpreadConstraints | indent 8 }}
       {{- if $root.Values.sentry.taskWorker.securityContext }}

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -45,7 +45,7 @@ spec:
         checksum/config.yaml: {{ include "sentry.config" $root | sha256sum }}
       {{- if $root.Values.sentry.taskWorker.annotations }}
 {{ toYaml $root.Values.sentry.taskWorker.annotations | indent 8 }}
-      {{- end }}          
+      {{- end }}
       labels:
         app: {{ template "sentry.fullname" $root }}
         release: "{{ $root.Release.Name }}"
@@ -74,10 +74,9 @@ spec:
       tolerations:
 {{ toYaml $root.Values.global.tolerations | indent 8 }}
       {{- end }}
-      {{- if $root.Values.sentry.taskWorker.topologySpreadConstraints }}
+{{- $taskWorkerTopologySpreadConstraints := default $root.Values.sentry.taskWorker.topologySpreadConstraints $worker.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml $root.Values.sentry.taskWorker.topologySpreadConstraints | indent 8 }}
-      {{- end }}
+{{ toYaml $taskWorkerTopologySpreadConstraints | indent 8 }}
       {{- if $root.Values.sentry.taskWorker.securityContext }}
       securityContext:
 {{ toYaml $root.Values.sentry.taskWorker.securityContext | indent 8 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -422,6 +422,7 @@ sentry:
       #   whenDeleted: Retain  # or Delete
       #   whenScaled: Retain   # or Delete
     # brokers[].resources -- Optional per-broker container resources; merged over taskBroker.resources (broker keys win).
+    # brokers[].topologySpreadConstraints -- Optional per-broker container topologySpreadConstraints; merged over taskBroker.topologySpreadConstraints (broker keys win).
     brokers:
       - name: default
         topic: taskworker
@@ -490,6 +491,7 @@ sentry:
       periodSeconds: 10
       timeoutSeconds: 5
     # workers[].resources -- Optional per-worker container resources; merged over taskWorker.resources (worker keys win).
+    # workers[].topologySpreadConstraints -- Optional per-worker container topologySpreadConstraints; merged over taskWorker.topologySpreadConstraints (worker keys win).
     workers:
       - name: default
         brokerName: default

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -422,7 +422,7 @@ sentry:
       #   whenDeleted: Retain  # or Delete
       #   whenScaled: Retain   # or Delete
     # brokers[].resources -- Optional per-broker container resources; merged over taskBroker.resources (broker keys win).
-    # brokers[].topologySpreadConstraints -- Optional per-broker container topologySpreadConstraints; merged over taskBroker.topologySpreadConstraints (broker keys win).
+    # brokers[].topologySpreadConstraints -- Optional per-broker pod topologySpreadConstraints; merged over taskBroker.topologySpreadConstraints (broker keys win).
     brokers:
       - name: default
         topic: taskworker
@@ -491,7 +491,7 @@ sentry:
       periodSeconds: 10
       timeoutSeconds: 5
     # workers[].resources -- Optional per-worker container resources; merged over taskWorker.resources (worker keys win).
-    # workers[].topologySpreadConstraints -- Optional per-worker container topologySpreadConstraints; merged over taskWorker.topologySpreadConstraints (worker keys win).
+    # workers[].topologySpreadConstraints -- Optional per-worker pod topologySpreadConstraints; merged over taskWorker.topologySpreadConstraints (worker keys win).
     workers:
       - name: default
         brokerName: default

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -422,7 +422,7 @@ sentry:
       #   whenDeleted: Retain  # or Delete
       #   whenScaled: Retain   # or Delete
     # brokers[].resources -- Optional per-broker container resources; merged over taskBroker.resources (broker keys win).
-    # brokers[].topologySpreadConstraints -- Optional per-broker pod topologySpreadConstraints; merged over taskBroker.topologySpreadConstraints (broker keys win).
+    # brokers[].topologySpreadConstraints -- Optional per-broker pod topologySpreadConstraints; overriding taskBroker.topologySpreadConstraints (broker list win).
     brokers:
       - name: default
         topic: taskworker
@@ -491,7 +491,7 @@ sentry:
       periodSeconds: 10
       timeoutSeconds: 5
     # workers[].resources -- Optional per-worker container resources; merged over taskWorker.resources (worker keys win).
-    # workers[].topologySpreadConstraints -- Optional per-worker pod topologySpreadConstraints; merged over taskWorker.topologySpreadConstraints (worker keys win).
+    # workers[].topologySpreadConstraints -- Optional per-worker pod topologySpreadConstraints; overriding taskWorker.topologySpreadConstraints (worker list win).
     workers:
       - name: default
         brokerName: default


### PR DESCRIPTION
## Problem

Taskbroker and taskworker pods are using a common topologySpreadConstraints, therefore it is impossible to specify per broker or worker their own component name as a `topologySpreadConstraints.labelSelector.matchLabels`.

## Fix

Added an optional `(taskBroker|taskWorker).(brokers|workers).*.topologySpreadConstraints` to taskbroker and taskworker (guarded by check).

Based on the work made for resources in https://github.com/sentry-kubernetes/charts/pull/2103 .
