### PR TITLE
feat: make setup-hook Job restartPolicy configurable

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -170,6 +170,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | hooks.enabled | bool | `true` |  |
 | hooks.preUpgrade | bool | `false` |  |
 | hooks.removeOnSuccess | bool | `true` |  |
+| hooks.restartPolicy | string | `"Never"` |  |
 | hooks.shareProcessNamespace | bool | `false` |  |
 | hooks.snubaInit.affinity | object | `{}` |  |
 | hooks.snubaInit.enabled | bool | `true` |  |

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -55,7 +55,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
       {{- if .Values.hooks.dbCheck.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.hooks.dbCheck.image.imagePullSecrets | indent 8 }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
       {{- if .Values.images.sentry.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -59,7 +59,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
       {{- if .Values.images.snuba.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -59,7 +59,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
       {{- if .Values.images.snuba.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -45,7 +45,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.global.nodeSelector | indent 8 }}
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
       {{- if .Values.hooks.dbInit.tolerations }}
       tolerations:
 {{ toYaml .Values.hooks.dbInit.tolerations | indent 8 }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2259,6 +2259,7 @@ hooks:
   preUpgrade: false
   removeOnSuccess: true
   activeDeadlineSeconds: 1200
+  restartPolicy: Never
   shareProcessNamespace: false
   dbCheck:
     enabled: true


### PR DESCRIPTION
## What

Adds a `hooks.restartPolicy` value (default `Never`) applied to all setup hook Jobs: `db-check`, `db-init`, `snuba-db-init`, `snuba-migrate`, and `user-create`.

## Why

These post-install/post-upgrade hook Jobs hardcode `restartPolicy: Never`. Combined with the Job's default `backoffLimit` of 6, a transient database/Kafka connection blip during install or upgrade fails the pod and the Job controller spawns a **new pod per attempt** — commonly 5–6 short-lived failed pods before one finally succeeds.

Setting `restartPolicy: OnFailure` lets the kubelet restart the container **in place within the same pod**, so a transient blip becomes a single pod with an incrementing restart count instead of a pile of failed pods. The hook commands (`sentry upgrade`, `sentry createuser`, `snuba ... --force`) are idempotent, so re-running on restart is safe.

## Behaviour

- Default is `Never` — **no change** for existing users.
- Operators opt in with `hooks.restartPolicy: OnFailure`.

Verified with `helm lint` and `helm template` (renders `Never` by default, `OnFailure` when set).