### PR TITLE
feat: add startup probe for kafka consumer workloads; tighten liveness timing

### DIFF
--- a/charts/sentry/ci/kind-values.yaml
+++ b/charts/sentry/ci/kind-values.yaml
@@ -14,6 +14,15 @@ kafka:
     replicaCount: 1
   broker:
     replicaCount: 1
+  # The CI cluster runs only two Kafka nodes (1 controller + 1 broker), but the
+  # internal __consumer_offsets and transaction-state topics default to
+  # replication factor 3. With fewer than 3 brokers these topics cannot be
+  # created, and Arroyo never reaches Healthcheck.poll() to write
+  # /tmp/health.txt. That makes startup probe fail.
+  extraConfig: |
+    offsets.topic.replication.factor=1
+    transaction.state.log.replication.factor=1
+    transaction.state.log.min.isr=1
 
 redis:
   enabled: true

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -37,6 +37,34 @@ livenessProbe:
 {{- end -}}
 {{- end -}}
 
+{{/*
+  startupProbe block for kafka-consumer / worker deployments.
+  Absorbs cold-start latency so liveness can't fire during startup.
+
+  Arguments (dict):
+    startupProbe:    the workload's .Values.<x>.startupProbe value (may be unset)
+    healthcheckFile: file path (default: /tmp/health.txt)
+*/}}
+{{- define "sentry.startupProbe.execHealthcheckFile" -}}
+{{- $probe := .startupProbe | default (dict) -}}
+{{- $enabled := true -}}
+{{- if hasKey $probe "enabled" -}}{{- $enabled = $probe.enabled -}}{{- end -}}
+{{- if $enabled -}}
+{{- $defaults := dict "periodSeconds" 5 "failureThreshold" 60 -}}
+{{- $probeConfig := omit (merge (deepCopy $probe) $defaults) "enabled" -}}
+{{- $file := default "/tmp/health.txt" .healthcheckFile -}}
+startupProbe:
+  exec:
+    command:
+      - test
+      - -f
+      - {{ $file }}
+{{- with $probeConfig }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
 {{- define "relay.image" -}}
 {{- default "ghcr.io/getsentry/relay" .Values.images.relay.repository -}}
 :

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -102,10 +102,8 @@ spec:
           {{- if .Values.sentry.ingestConsumerAttachments.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerAttachments.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerAttachments.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerAttachments.logLevel }}"
@@ -129,6 +127,7 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestConsumerAttachments.maxBatchTimeMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestConsumerAttachments.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestConsumerAttachments.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -102,10 +102,8 @@ spec:
           {{- if .Values.sentry.ingestConsumerEvents.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerEvents.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerEvents.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerEvents.logLevel }}"
@@ -129,6 +127,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerEvents.concurrency }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestConsumerEvents.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestConsumerEvents.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -103,10 +103,9 @@ spec:
           {{- if .Values.sentry.ingestFeedback.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestFeedback.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestFeedback.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestFeedback.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -103,14 +103,13 @@ spec:
           {{- if .Values.sentry.ingestMonitors.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestMonitors.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.ingestMonitors.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.ingestMonitors.maxPollIntervalMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestMonitors.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestMonitors.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -102,10 +102,9 @@ spec:
           {{- if .Values.sentry.monitorsClockTasks.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.monitorsClockTasks.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.monitorsClockTasks.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.monitorsClockTasks.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -102,10 +102,9 @@ spec:
           {{- if .Values.sentry.monitorsClockTick.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.monitorsClockTick.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.monitorsClockTick.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.monitorsClockTick.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -103,10 +103,8 @@ spec:
           {{- if .Values.sentry.ingestOccurrences.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestOccurrences.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if or .Values.sentry.ingestOccurrences.concurrency .Values.sentry.ingestOccurrences.inputBlockSize .Values.sentry.ingestOccurrences.maxBatchSize .Values.sentry.ingestOccurrences.maxBatchTimeMs }}
           - "--"
           {{- end }}
@@ -126,6 +124,7 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.ingestOccurrences.maxBatchTimeMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestOccurrences.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestOccurrences.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
+++ b/charts/sentry/templates/sentry/ingest/profiles/deployment-sentry-ingest-profiles.yaml
@@ -103,10 +103,9 @@ spec:
           {{- if .Values.sentry.ingestProfiles.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestProfiles.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestProfiles.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestProfiles.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -103,14 +103,13 @@ spec:
           {{- if .Values.sentry.ingestReplayRecordings.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestReplayRecordings.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.ingestReplayRecordings.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.sentry.ingestReplayRecordings.maxPollIntervalMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestReplayRecordings.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestReplayRecordings.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -103,10 +103,8 @@ spec:
           {{- if .Values.sentry.ingestConsumerTransactions.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.ingestConsumerTransactions.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.ingestConsumerTransactions.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.ingestConsumerTransactions.logLevel }}"
@@ -130,6 +128,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.ingestConsumerTransactions.concurrency }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.ingestConsumerTransactions.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.ingestConsumerTransactions.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -103,10 +103,9 @@ spec:
           {{- if .Values.sentry.billingMetricsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.billingMetricsConsumer.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.billingMetricsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.billingMetricsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -101,10 +101,8 @@ spec:
           {{- if .Values.sentry.metricsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.metricsConsumer.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.metricsConsumer.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.metricsConsumer.logLevel }}"
@@ -118,6 +116,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.metricsConsumer.concurrency }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.metricsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.metricsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -101,10 +101,8 @@ spec:
           {{- end }}
           - "--consumer-group"
           - "generic-metrics-consumer"
-          {{- if .Values.sentry.genericMetricsConsumer.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.genericMetricsConsumer.logLevel }}
           - "--log-level"
           - "{{ .Values.sentry.genericMetricsConsumer.logLevel }}"
@@ -118,6 +116,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.genericMetricsConsumer.concurrency }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.genericMetricsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.genericMetricsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -102,10 +102,9 @@ spec:
           {{- if .Values.sentry.postProcessForwardErrors.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.postProcessForwardErrors.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.postProcessForwardErrors.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.postProcessForwardErrors.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -104,10 +104,9 @@ spec:
           {{- if .Values.sentry.postProcessForwardIssuePlatform.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.postProcessForwardIssuePlatform.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.postProcessForwardIssuePlatform.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.postProcessForwardIssuePlatform.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -104,10 +104,8 @@ spec:
           {{- if .Values.sentry.postProcessForwardTransactions.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.postProcessForwardTransactions.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.sentry.postProcessForwardTransactions.processes }}
           - "--"
           - "--mode"
@@ -115,6 +113,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.postProcessForwardTransactions.processes }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.postProcessForwardTransactions.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.postProcessForwardTransactions.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -101,10 +101,8 @@ spec:
           {{- if .Values.sentry.processSegments.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.processSegments.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if or .Values.sentry.processSegments.concurrency .Values.sentry.processSegments.maxBatchSize .Values.sentry.processSegments.maxBatchTimeMs }}
           - "--"
           {{- end }}
@@ -120,6 +118,7 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.processSegments.maxBatchTimeMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.processSegments.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.processSegments.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -101,10 +101,8 @@ spec:
           {{- if .Values.sentry.processSpans.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.processSpans.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if or .Values.sentry.processSpans.concurrency .Values.sentry.processSpans.maxBatchSize .Values.sentry.processSpans.maxBatchTimeMs }}
           - "--"
           {{- end }}
@@ -120,6 +118,7 @@ spec:
           - "--max-batch-time-ms"
           - "{{ .Values.sentry.processSpans.maxBatchTimeMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.processSpans.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.processSpans.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/events/deployment-sentry-subscription-consumer-events.yaml
@@ -93,10 +93,9 @@ spec:
           {{- end }}
           - "--consumer-group"
           - "query-subscription-consumer"
-          {{- if .Values.sentry.subscriptionConsumerEvents.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.subscriptionConsumerEvents.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.subscriptionConsumerEvents.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/generic-metrics/deployment-sentry-subscription-consumer-generic-metrics.yaml
@@ -101,10 +101,8 @@ spec:
           {{- if .Values.sentry.subscriptionConsumerGenericMetrics.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if or .Values.sentry.subscriptionConsumerGenericMetrics.maxBatchSize .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}
           - "--"
           {{- end }}
@@ -116,6 +114,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerGenericMetrics.concurrency }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.subscriptionConsumerGenericMetrics.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.subscriptionConsumerGenericMetrics.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/metrics/deployment-sentry-subscription-consumer-metrics.yaml
@@ -101,10 +101,8 @@ spec:
           {{- if .Values.sentry.subscriptionConsumerMetrics.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.subscriptionConsumerMetrics.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if or .Values.sentry.subscriptionConsumerMetrics.maxBatchSize .Values.sentry.subscriptionConsumerMetrics.concurrency }}
           - "--"
           {{- end }}
@@ -116,6 +114,7 @@ spec:
           - "--processes"
           - "{{ .Values.sentry.subscriptionConsumerMetrics.concurrency }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.subscriptionConsumerMetrics.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.subscriptionConsumerMetrics.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
         - name: C_FORCE_ROOT

--- a/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/results-eap/deployment-sentry-subscription-results-eap-items.yaml
@@ -93,10 +93,9 @@ spec:
           {{- end }}
           - "--consumer-group"
           - "subscription-results-eap-items"
-          {{- if .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.subscriptionConsumerResultsEapItems.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.subscriptionConsumerResultsEapItems.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/subscription-consumer/transactions/deployment-sentry-subscription-consumer-transactions.yaml
@@ -94,10 +94,9 @@ spec:
           {{- if .Values.sentry.subscriptionConsumerTransactions.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.subscriptionConsumerTransactions.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.subscriptionConsumerTransactions.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.subscriptionConsumerTransactions.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -101,10 +101,9 @@ spec:
           {{- if .Values.sentry.uptimeResults.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.sentry.uptimeResults.livenessProbe.enabled }}
           - "--healthcheck-file-path"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.sentry.uptimeResults.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.sentry.uptimeResults.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         env:
 {{ include "sentry.env" . | indent 8 }}

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -125,10 +125,9 @@ spec:
           {{- if .Values.snuba.consumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.consumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.consumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.consumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.eapItemsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.eapItemsConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.eapItemsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.eapItemsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.genericMetricsCountersConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.genericMetricsCountersConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.genericMetricsCountersConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.genericMetricsCountersConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.genericMetricsDistributionConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.genericMetricsDistributionConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.genericMetricsDistributionConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.genericMetricsDistributionConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.genericMetricsGaugesConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.genericMetricsGaugesConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.genericMetricsGaugesConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.genericMetricsGaugesConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.genericMetricsSetsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.genericMetricsSetsConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.genericMetricsSetsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.genericMetricsSetsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -125,10 +125,9 @@ spec:
           {{- if .Values.snuba.groupAttributesConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.groupAttributesConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.groupAttributesConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.groupAttributesConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.issueOccurrenceConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.issueOccurrenceConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.issueOccurrenceConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.issueOccurrenceConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.metricsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.metricsConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.metricsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.metricsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -126,14 +126,13 @@ spec:
           {{- if .Values.snuba.outcomesBillingConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.outcomesBillingConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.snuba.outcomesBillingConsumer.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.snuba.outcomesBillingConsumer.maxPollIntervalMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.outcomesBillingConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.outcomesBillingConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -123,10 +123,9 @@ spec:
           {{- if .Values.snuba.outcomesConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.outcomesConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.outcomesConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.outcomesConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.profilingChunksConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.profilingChunksConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.profilingChunksConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.profilingChunksConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.profilingFunctionsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.profilingFunctionsConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.profilingFunctionsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.profilingFunctionsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.profilingProfilesConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.profilingProfilesConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.profilingProfilesConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.profilingProfilesConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -126,14 +126,13 @@ spec:
           {{- if .Values.snuba.replaysConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.replaysConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
           {{- if .Values.snuba.replaysConsumer.maxPollIntervalMs }}
           - "--max-poll-interval-ms"
           - "{{ .Values.snuba.replaysConsumer.maxPollIntervalMs }}"
           {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.replaysConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.replaysConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -99,10 +99,9 @@ spec:
           - "--followed-consumer-group=eap_items_group"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerEapItems.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerEapItems.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerEapItems.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -99,10 +99,9 @@ spec:
           - "--followed-consumer-group=snuba-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerEvents.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerEvents.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerEvents.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -100,10 +100,9 @@ spec:
           - "--followed-consumer-group=snuba-gen-metrics-counters-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerGenericMetricsCounters.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerGenericMetricsCounters.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -100,10 +100,9 @@ spec:
           - "--followed-consumer-group=snuba-gen-metrics-distributions-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerGenericMetricsDistributions.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerGenericMetricsDistributions.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -100,10 +100,9 @@ spec:
           - "--followed-consumer-group=snuba-gen-metrics-gauges-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerGenericMetricsGauges.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerGenericMetricsGauges.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -100,10 +100,9 @@ spec:
           - "--followed-consumer-group=snuba-gen-metrics-sets-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerGenericMetricsSets.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerGenericMetricsSets.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -101,10 +101,9 @@ spec:
           - "--followed-consumer-group=snuba-metrics-consumers"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerMetrics.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerMetrics.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerMetrics.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -100,10 +100,9 @@ spec:
           - "--followed-consumer-group=transactions_group"
           - "--schedule-ttl=60"
           - "--stale-threshold-seconds=900"
-          {{- if .Values.snuba.subscriptionConsumerTransactions.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.subscriptionConsumerTransactions.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.subscriptionConsumerTransactions.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -126,10 +126,9 @@ spec:
           {{- if .Values.snuba.transactionsConsumer.noStrictOffsetReset }}
           - "--no-strict-offset-reset"
           {{- end }}
-          {{- if .Values.snuba.transactionsConsumer.livenessProbe.enabled }}
           - "--health-check-file"
           - "/tmp/health.txt"
-          {{- end }}
+        {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.transactionsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.transactionsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:
         - containerPort: {{ template "snuba.port" }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -549,9 +549,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -594,9 +594,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -639,9 +639,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -676,9 +676,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -708,9 +708,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -745,9 +745,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -784,9 +784,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -821,9 +821,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -854,9 +854,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -887,9 +887,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -923,9 +923,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -962,9 +962,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -1001,9 +1001,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # volumeMounts:
     #   - mountPath: /dev/shm
     #     name: dshm
@@ -1025,9 +1025,9 @@ sentry:
     podLabels: {}
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     sidecars: []
     volumes: []
     volumeMounts: []
@@ -1054,9 +1054,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     volumeMounts: []
@@ -1081,9 +1081,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     volumeMounts: []
@@ -1108,9 +1108,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     volumeMounts: []
@@ -1136,9 +1136,9 @@ sentry:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1163,9 +1163,9 @@ sentry:
     volumes: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumeMounts: []
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
@@ -1191,9 +1191,9 @@ sentry:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1219,9 +1219,9 @@ sentry:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # maxBatchSize: "500"
@@ -1249,9 +1249,9 @@ sentry:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
     # maxBatchSize: "500"
@@ -1280,9 +1280,9 @@ sentry:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1309,9 +1309,9 @@ sentry:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1418,9 +1418,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # noStrictOffsetReset: false
     # maxBatchSize: ""
     # processes: ""
@@ -1454,9 +1454,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1492,9 +1492,9 @@ snuba:
     maxBatchSize: "3"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -1529,9 +1529,9 @@ snuba:
     maxBatchSize: "3"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # processes: ""
     # inputBlockSize: ""
     # outputBlockSize: ""
@@ -1585,9 +1585,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1615,9 +1615,9 @@ snuba:
     sidecars: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1639,9 +1639,9 @@ snuba:
     sidecars: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1663,9 +1663,9 @@ snuba:
     sidecars: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1687,9 +1687,9 @@ snuba:
     sidecars: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1711,9 +1711,9 @@ snuba:
     sidecars: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1735,9 +1735,9 @@ snuba:
     sidecars: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # autoOffsetReset: "earliest"
@@ -1760,9 +1760,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1791,9 +1791,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1822,9 +1822,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1853,9 +1853,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
     # maxBatchSize: ""
@@ -1887,9 +1887,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     volumes: []
     volumeMounts: []
 
@@ -1914,9 +1914,9 @@ snuba:
     volumeMounts: []
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # autoOffsetReset: "earliest"
     # noStrictOffsetReset: false
 
@@ -1938,9 +1938,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -1974,9 +1974,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2009,9 +2009,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2045,9 +2045,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2080,9 +2080,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2116,9 +2116,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""
@@ -2152,9 +2152,9 @@ snuba:
     # autoOffsetReset: "earliest"
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 5
-      periodSeconds: 320
-      timeoutSeconds: 3
+      periodSeconds: 30
+      failureThreshold: 5
+      timeoutSeconds: 5
     # maxBatchSize: ""
     # processes: ""
     # inputBlockSize: ""


### PR DESCRIPTION
Followup to #2230. Add startup probe. Tighten liveness defaults now that startup owns cold-start.

Resolves the long-standing request in #1874 and makes the `initialDelaySeconds: 30` workaround from #2131 unnecessary.

### Startup probe

`test -f /tmp/health.txt`. Passes once arroyo has produced the file at least once. While it's running, kubelet disables liveness, so cold-start latency can't trip a restart. Defaults give ~5min cold-start window.

### Liveness timing

- `initialDelaySeconds` removed since startup probe owns cold-start; kubelet ignores liveness until startup passes
- `periodSeconds` changed from `320` to `30` for faster detection
- `failureThreshold` set to `5` - with new `periodSeconds` gives 150s slow-batch tolerance
- `timeoutSeconds` changed from `3` to `5` - headroom in case `sh + date + stat` invocation exceeds 3s under CPU throttling

Net kill latency for a deadlocked consumer should drop from ~960s to ~210s.

### --healthcheck-file flag

Previously gated on `livenessProbe.enabled`. Now always enabled. Avoids situation where disabling liveness would silently break the new startup probe.