### PR TITLE
- Fix Snuba CrashLoop on Sentry 26.5.2

### DIFF
--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -65,6 +65,7 @@ settings.py: |
           "generic_metrics_counters",
           "spans",
           "events_analytics_platform",
+          "events_analytics_platform_ro",
           "group_attributes",
           "generic_metrics_gauges",
           "metrics_summaries",


### PR DESCRIPTION
Without this config, Snuba crashes on Snuba and Sentry Version 26.5.2, with the error:
StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO is not defined in the CLUSTERS setting for this environment