### PR TITLE
fix: crash on sentry 26.5.2 due to snuba 26.5.2

### DIFF
--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -65,6 +65,7 @@ settings.py: |
           "generic_metrics_counters",
           "spans",
           "events_analytics_platform",
+          "events_analytics_platform_ro",
           "group_attributes",
           "generic_metrics_gauges",
           "metrics_summaries",


### PR DESCRIPTION
## Problem

Snuba 26.5.2 requires a new configuration to be set in the `settings.py` for snuba.
When not setting it, Snuba crashes on startup causing the Snuba Pods to remain within a CrashLoop.

## Fix

Add the configuration `events_analytics_platform_ro` to `settings.py` for snuba.

