### PR TITLE
feat!: remove deprecated externalPostgresql.existingSecretKey fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 The changelog below refers to the main `sentry` chart only.
 
+## Upgrading to Chart 32.2.0
+
+**Breaking change:** the deprecated singular `externalPostgresql.existingSecretKey` has been removed. Use `externalPostgresql.existingSecretKeys.password` instead.
+
+Before:
+
+```yaml
+externalPostgresql:
+  existingSecret: my-pg-secret
+  existingSecretKey: my-password-key
+```
+
+After:
+
+```yaml
+externalPostgresql:
+  existingSecret: my-pg-secret
+  existingSecretKeys:
+    password: my-password-key
+```
+
 ## Upgrading to Chart 32.0.0
 
 - **Rust Snuba consumer** is now enabled by default. Set `snuba.rustConsumer: false` to revert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The changelog below refers to the main `sentry` chart only.
 
-## Upgrading to Chart 32.2.0
+## Upgrading to Chart 33.0.0
 
 **Breaking change:** the deprecated singular `externalPostgresql.existingSecretKey` has been removed. Use `externalPostgresql.existingSecretKeys.password` instead.
 

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1652,8 +1652,6 @@ externalPostgresql:
   database: sentry
 ```
 
-> ⚠️ `.Values.externalPostgresql.existingSecretKey` is deprecated, `.Values.externalPostgresql.existingSecretKeys.password` should be used instead.
-
 # Usage
 
 - [AWS + Terraform](docs/usage-aws-terraform.md)

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -843,7 +843,7 @@ Set external Postgresql password from existingSecret
   valueFrom:
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
-      key: {{ or .Values.externalPostgresql.existingSecretKeys.password .Values.externalPostgresql.existingSecretKey "postgresql-password" }}
+      key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKeys.password }}
 {{- end }}
 
 {{/*
@@ -1235,7 +1235,7 @@ Pgbouncer environment variables
   valueFrom:
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
-      key: {{ or .Values.externalPostgresql.existingSecretKeys.password .Values.externalPostgresql.existingSecretKey "postgresql-password" }}
+      key: {{ default "postgresql-password" .Values.externalPostgresql.existingSecretKeys.password }}
 {{- end }}
 {{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.username }}
 - name: POSTGRESQL_USERNAME


### PR DESCRIPTION
### BREAKING CHANGE

The singular `externalPostgresql.existingSecretKey` is no longer supported. Use `externalPostgresql.existingSecretKeys.password` instead.

### Motivation

The singular `existingSecretKey` was deprecated in favor of the plural `existingSecretKeys` map, which supports specifying keys for `password`, `username`, `database`, `host`, and `port`. However, the old singular key was kept as a fallback in two places inside `_helper.tpl`, creating two code paths for the same functionality and potential silent misconfiguration.

### Changes

- **`templates/_helper.tpl`** — Replace `or .Values.externalPostgresql.existingSecretKeys.password .Values.externalPostgresql.existingSecretKey "postgresql-password"` with `default "postgresql-password" .Values.externalPostgresql.existingSecretKeys.password` in both `sentry.env` and `sentry.pgbouncer.env` definitions
- **`README.md`** — Remove deprecation warning

### Migration

If you are using:

```yaml
externalPostgresql:
  existingSecret: my-pg-secret
  existingSecretKey: my-password-key
```

Change to:

```yaml
externalPostgresql:
  existingSecret: my-pg-secret
  existingSecretKeys:
    password: my-password-key
```
