### PR TITLE
fix(charts/sentry): drop ArgoCD Sync hook annotation from sentry-secret

### DIFF
--- a/charts/sentry/templates/hooks/sentry-secret-create.yaml
+++ b/charts/sentry/templates/hooks/sentry-secret-create.yaml
@@ -1,4 +1,7 @@
 {{- if not .Values.sentry.existingSecret -}}
+{{- if .Values.useArgoCdCompatibleAnnotations -}}
+{{- fail "sentry.existingSecret must be set when useArgoCdCompatibleAnnotations is true: ArgoCD re-renders this chart on every sync, so the auto-generated SECRET_KEY would rotate on every sync and invalidate all sessions/CSRF tokens/signed links. Create a stable Secret yourself (e.g. `kubectl create secret generic sentry-secret-key --from-literal=key=$(openssl rand -base64 38)`) and set sentry.existingSecret to its name." -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sentry/templates/hooks/sentry-secret-create.yaml
+++ b/charts/sentry/templates/hooks/sentry-secret-create.yaml
@@ -10,7 +10,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
   annotations:
     {{- if .Values.useArgoCdCompatibleAnnotations }}
-    "argocd.argoproj.io/hook": "Sync"
     "argocd.argoproj.io/sync-wave": "-1"
     {{- else }}
     "helm.sh/hook": "pre-install"


### PR DESCRIPTION
The Secret holding SENTRY_SECRET_KEY is a long-lived value, not an ephemeral Job-like step, so it doesn't need ArgoCD hook semantics. sync-wave alone already guarantees it's applied before the pods that mount it.

Note: this does not stop SECRET_KEY from being regenerated on every sync — randAlphaNum is re-evaluated on every `helm template` render regardless of hook annotations, so ArgoCD still patches in a new value each sync. existingSecret is still required to keep sessions/CSRF/signed links stable across syncs.