### PR TITLE
feat: add existingSecret support for launchpad RPC shared secret

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -819,6 +819,8 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | sentry.taskWorker.volumes | list | `[]` | |
 | sentry.taskWorker.workers | list | (see `values.yaml`) | One task worker Deployment per item (`name`, `brokerName`, `brokerReplicas`, `replicas`, `concurrency`, optional `resources` merged with `sentry.taskWorker.resources`, optional `autoscaling` overriding `sentry.taskWorker.autoscaling`, optional `topologySpreadConstraints` overriding `sentry.taskWorker.topologySpreadConstraints`). |
 | launchpadTaskWorker.enabled | bool | `true` | Deploy Launchpad taskworker (mobile build processing). Requires `feature-complete` profile and `sentry.taskBroker.enabled`. |
+| launchpadTaskWorker.existingSecret | string | `""` | Name of an externally-managed Secret holding the launchpad RPC shared secret. If unset, the chart generates and manages this Secret itself. |
+| launchpadTaskWorker.existingSecretKey | string | `"rpc-shared-secret"` | Key within `existingSecret` (or the chart-managed Secret) holding the RPC shared secret value. |
 | launchpadTaskWorker.replicas | int | `1` |  |
 | launchpadTaskWorker.concurrency | int | `4` | Parallel Launchpad worker processes (`LAUNCHPAD_WORKER_CONCURRENCY`). |
 | launchpadTaskWorker.env | list | `[]` | Extra environment variables for the Launchpad taskworker container. |
@@ -1313,6 +1315,13 @@ Notes:
 If no `sentry.existingSecret` value is specified, for your security, the [`system.secret-key`](https://develop.sentry.dev/config/#general) is generated for you on the first installation and stored in a kubernetes secret.
 
 If `sentry.existingSecret` / `sentry.existingSecretKey` values are provided, those secrets will be used.
+
+
+## Launchpad RPC shared secret
+
+If no `launchpadTaskWorker.existingSecret` value is specified, the RPC shared secret used between `sentry-web` and the Launchpad taskworker is generated for you on the first installation and stored in a kubernetes secret.
+
+If `launchpadTaskWorker.existingSecret` / `launchpadTaskWorker.existingSecretKey` values are provided, that externally-managed secret will be used instead.
 
 
 ## Symbolicator and or JavaScript source maps

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -118,7 +118,11 @@ startupProbe:
 {{- end -}}
 
 {{- define "launchpad.secretName" -}}
-{{- printf "%s-launchpad-secret" (include "sentry.fullname" .) -}}
+{{- default (printf "%s-launchpad-secret" (include "sentry.fullname" .)) .Values.launchpadTaskWorker.existingSecret -}}
+{{- end -}}
+
+{{- define "launchpad.secretKey" -}}
+{{- default "rpc-shared-secret" .Values.launchpadTaskWorker.existingSecretKey -}}
 {{- end -}}
 
 {{- define "launchpad.enabled" -}}
@@ -759,7 +763,7 @@ See: https://github.com/sentry-kubernetes/charts/issues/2088
   valueFrom:
     secretKeyRef:
       name: {{ include "launchpad.secretName" . }}
-      key: rpc-shared-secret
+      key: {{ include "launchpad.secretKey" . }}
 {{- end -}}
 
 {{- define "uptimeChecker.env" -}}
@@ -1174,7 +1178,7 @@ Launchpad RPC shared secret (required by Sentry web and launchpad-taskworker)
   valueFrom:
     secretKeyRef:
       name: {{ include "launchpad.secretName" . }}
-      key: rpc-shared-secret
+      key: {{ include "launchpad.secretKey" . }}
 {{- end }}
 {{- end -}}
 

--- a/charts/sentry/templates/launchpad-secret.yaml
+++ b/charts/sentry/templates/launchpad-secret.yaml
@@ -1,10 +1,9 @@
 {{- if eq (include "launchpad.enabled" .) "true" }}
-{{- $secretName := include "launchpad.secretName" . }}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- if not .Values.launchpadTaskWorker.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ include "launchpad.secretName" . }}
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -12,9 +11,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  {{- if and $existing (index $existing.data "rpc-shared-secret") }}
-  rpc-shared-secret: {{ index $existing.data "rpc-shared-secret" }}
-  {{- else }}
-  rpc-shared-secret: {{ randAlphaNum 32 | b64enc | quote }}
-  {{- end }}
+  {{ include "launchpad.secretKey" . }}: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -162,6 +162,11 @@ vroom:
 launchpadTaskWorker:
   enabled: true
   annotations: {}
+  # existingSecret - Name of an externally-managed Secret holding the launchpad RPC shared secret.
+  # If unset, the chart generates and manages this Secret itself.
+  existingSecret: ""
+  # existingSecretKey - Key within existingSecret (or the chart-managed Secret) holding the RPC shared secret value.
+  existingSecretKey: "rpc-shared-secret"
   replicas: 1
   concurrency: 4
   env: []

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -162,10 +162,9 @@ vroom:
 launchpadTaskWorker:
   enabled: true
   annotations: {}
-  # existingSecret - Name of an externally-managed Secret holding the launchpad RPC shared secret.
-  # If unset, the chart generates and manages this Secret itself.
+  # existingSecret -- Name of an externally-managed Secret holding the launchpad RPC shared secret. If unset, the chart generates and manages this Secret itself.
   existingSecret: ""
-  # existingSecretKey - Key within existingSecret (or the chart-managed Secret) holding the RPC shared secret value.
+  # existingSecretKey -- Key within `existingSecret` (or the chart-managed Secret) holding the RPC shared secret value.
   existingSecretKey: "rpc-shared-secret"
   replicas: 1
   concurrency: 4


### PR DESCRIPTION
Adds launchpadTaskWorker.existingSecret/existingSecretKey, mirroring the existing sentry.existingSecret pattern, so the launchpad RPC shared secret can be sourced from an externally-managed Secret instead of the chart generating/looking it up itself.