### PR TITLE
fix(sentry): stop launchpad secret regenerating on every Argo CD sync

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -118,7 +118,11 @@ startupProbe:
 {{- end -}}
 
 {{- define "launchpad.secretName" -}}
+{{- if .Values.launchpadTaskWorker.existingSecret -}}
+{{- .Values.launchpadTaskWorker.existingSecret -}}
+{{- else -}}
 {{- printf "%s-launchpad-secret" (include "sentry.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "launchpad.enabled" -}}

--- a/charts/sentry/templates/launchpad-secret.yaml
+++ b/charts/sentry/templates/launchpad-secret.yaml
@@ -1,20 +1,24 @@
 {{- if eq (include "launchpad.enabled" .) "true" }}
-{{- $secretName := include "launchpad.secretName" . }}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- if not .Values.launchpadTaskWorker.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ include "launchpad.secretName" . }}
   labels:
     app: sentry
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- if .Values.useArgoCdCompatibleAnnotations }}
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/sync-wave": "-1"
+    {{- else }}
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "3"
+    {{- end }}
 type: Opaque
 data:
-  {{- if and $existing (index $existing.data "rpc-shared-secret") }}
-  rpc-shared-secret: {{ index $existing.data "rpc-shared-secret" }}
-  {{- else }}
   rpc-shared-secret: {{ randAlphaNum 32 | b64enc | quote }}
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -161,6 +161,7 @@ vroom:
 
 launchpadTaskWorker:
   enabled: true
+  existingSecret: ""
   annotations: {}
   replicas: 1
   concurrency: 4


### PR DESCRIPTION
  The launchpad rpc-shared-secret Secret is rendered as a normal,
  Argo CD-tracked manifest whose value is produced by `randAlphaNum 32`,
  guarded by a `lookup` meant to reuse the existing value. `lookup` only
  returns data during a live `helm install/upgrade`; under `helm template`
  (used by Argo CD and `helm diff`) it returns an empty result, so the
  template always falls through to `randAlphaNum` and mints a new secret on
  every render. This produces a permanent OutOfSync diff and rotates
  rpc-shared-secret on every sync, which can break launchpad RPC until the
  pods restart.

  Align launchpad-secret.yaml with the existing sentry-secret-create.yaml
  pattern instead:

  - gate generation behind `launchpadTaskWorker.existingSecret` so the
    secret can be supplied externally (e.g. via a secret manager), and the
    chart generates nothing in that case
  - add the standard hook annotations (`argocd.argoproj.io/hook: Sync` when
    `useArgoCdCompatibleAnnotations`, else `helm.sh/hook: pre-install`) so
    the generated Secret is treated as a hook and excluded from the Argo CD
    diff, matching how the core sentry secret already behaves
  - drop the non-functional `lookup`

  `launchpad.secretName` now resolves to `existingSecret` when set, so the
  launchpad-taskworker secretKeyRef points at the user-provided Secret.

  Backwards compatible: `existingSecret` defaults to "" and the generated
  secret keeps the same name and `rpc-shared-secret` key.

  PR description

  ### Summary

  Fixes a permanent Argo CD `OutOfSync` diff on the launchpad
  `rpc-shared-secret` Secret, and the secret rotation that comes with it.

  ### Problem

  `templates/launchpad-secret.yaml` renders the Secret as a normal
  (Argo CD-tracked) manifest and generates its value with `randAlphaNum 32`,
  guarded by a `lookup` that is intended to reuse the previously generated
  value:

  ```yaml
  {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
  ...
    {{- if and $existing (index $existing.data "rpc-shared-secret") }}
    rpc-shared-secret: {{ index $existing.data "rpc-shared-secret" }}
    {{- else }}
    rpc-shared-secret: {{ randAlphaNum 32 | b64enc | quote }}
    {{- end }}

  lookup only returns data during a live helm install/helm upgrade.
  Under helm template — which is what Argo CD (and helm diff) use — it
  returns an empty map, so the else branch runs and a new random value
  is produced on every render. Result:

  - the rendered manifest never matches the live Secret → permanent
  OutOfSync;
  - every sync rewrites rpc-shared-secret, which can break launchpad RPC
  until the launchpad-taskworker / taskbroker pods restart.

  The core Sentry secret (templates/hooks/sentry-secret-create.yaml) does
  not have this problem because it is a hook (excluded from the Argo CD diff)
  and supports existingSecret. This PR brings launchpad-secret in line with
  that pattern.

  Changes

  - templates/launchpad-secret.yaml
    - gate generation behind launchpadTaskWorker.existingSecret (no Secret
  is rendered when it is set);
    - add hook annotations — argocd.argoproj.io/hook: Sync /
  sync-wave: -1 when useArgoCdCompatibleAnnotations, otherwise
  helm.sh/hook: pre-install / hook-weight: 3 — matching
  sentry-secret-create.yaml, so the generated Secret is a hook and not
  diffed by Argo CD;
    - remove the non-functional lookup.
  - templates/_helper.tpl: launchpad.secretName resolves to
  launchpadTaskWorker.existingSecret when set, so the taskworker
  secretKeyRef points at the user-supplied Secret.
  - values.yaml: add launchpadTaskWorker.existingSecret (default "")
  with documentation.

  Behaviour

  ┌────────────────────┬────────────────────────────────────────────────────┬───────────────────────────────────────────────────┐
  │       Config       │                       Before                       │                       After                       │
  ├────────────────────┼────────────────────────────────────────────────────┼───────────────────────────────────────────────────┤
  │ Default (generate) │ new value every render → permanent diff + rotation │ generated once as a hook; not diffed by Argo CD   │
  ├────────────────────┼────────────────────────────────────────────────────┼───────────────────────────────────────────────────┤
  │ existingSecret set │ n/a (unsupported)                                  │ chart generates nothing; uses the provided Secret │
  └────────────────────┴────────────────────────────────────────────────────┴───────────────────────────────────────────────────┘

  Backwards compatibility

  Fully backwards compatible. existingSecret defaults to ""; the
  generated Secret keeps the same name (<fullname>-launchpad-secret) and
  the same rpc-shared-secret data key. Existing installs keep working; on
  the next sync the secret is created as a hook instead of a tracked
  resource.

  How to reproduce / verify

  # Before: two renders produce different values
  helm template charts/sentry --set profiles='{feature-complete}' \
    --show-only templates/launchpad-secret.yaml | grep rpc-shared-secret
  helm template charts/sentry --set profiles='{feature-complete}' \
    --show-only templates/launchpad-secret.yaml | grep rpc-shared-secret

  # After: the Secret carries hook annotations and is excluded from Argo CD diffs;
  # with launchpadTaskWorker.existingSecret set, no Secret is rendered:
  helm template charts/sentry --set profiles='{feature-complete}' \
    --set launchpadTaskWorker.existingSecret=my-launchpad-secret \
    --show-only templates/launchpad-secret.yaml   # -> empty
