### PR TITLE
feat: charts/sentry: add configurable PagerDuty integration

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -366,6 +366,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | nginx.existingServerConfigConfigmap | string | `"{{ template \"sentry.fullname\" . }}"` |  |
 | nginx.extraLocationSnippet | bool | `false` |  |
 | openai | object | `{}` |  |
+| pagerduty | object | `{}` |  |
 | pgbouncer.affinity | object | `{}` |  |
 | pgbouncer.authType | string | `"md5"` |  |
 | pgbouncer.enabled | bool | `false` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1092,6 +1092,17 @@ Set discord
 {{- end }}
 
 {{/*
+Set pagerduty
+*/}}
+{{- if .Values.pagerduty.existingSecret }}
+- name: PAGERDUTY_APP_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.pagerduty.existingSecret }}
+      key: {{ default "app-id" .Values.pagerduty.existingSecretAppId }}
+{{- end }}
+
+{{/*
 Set github app
 */}}
 {{- if and .Values.github.existingSecret }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -72,6 +72,13 @@ config.yml: |-
   discord.bot-token: {{ .Values.discord.botToken | quote }}
   {{ end }}
 
+  #############
+  # PagerDuty #
+  #############
+  {{- if and (.Values.pagerduty.appId) (not .Values.pagerduty.existingSecret) }}
+  pagerduty.app-id: {{ .Values.pagerduty.appId | quote }}
+  {{- end }}
+
   #########
   # Redis #
   #########
@@ -773,6 +780,13 @@ sentry.conf.py: |-
   SENTRY_OPTIONS['discord.public-key'] = os.environ.get("DISCORD_PUBLIC_KEY")
   SENTRY_OPTIONS['discord.client-secret'] = os.environ.get("DISCORD_CLIENT_SECRET")
   SENTRY_OPTIONS['discord.bot-token'] = os.environ.get("DISCORD_BOT_TOKEN")
+{{- end }}
+
+{{- if .Values.pagerduty.existingSecret }}
+  #############
+  # PAGERDUTY #
+  #############
+  SENTRY_OPTIONS['pagerduty.app-id'] = os.environ.get("PAGERDUTY_APP_ID")
 {{- end }}
 
 {{- if .Values.google.existingSecret }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2526,6 +2526,13 @@ discord: {}
 #   existingSecretBotToken: ""          # by default "bot-token"
 #   Reference -> https://develop.sentry.dev/integrations/discord/
 
+pagerduty: {}
+# pagerduty:
+#   appId: ""                           # PagerDuty App ID (public identifier, e.g. "PV5SD0T"), not a secret
+#   existingSecret: "xxxxx"
+#   existingSecretAppId: ""             # by default "app-id"
+#   Reference -> https://develop.sentry.dev/integrations/pagerduty/
+
 openai: {}
 #   existingSecret: "xxxxx"
 #   existingSecretKey: ""               # by default "api-token"


### PR DESCRIPTION
## What this does

Adds first-class configuration for the Sentry **PagerDuty** integration through `values.yaml`, following the same pattern already used for Slack and Discord. Previously, enabling PagerDuty on a self-hosted Sentry required manually editing Sentry's `config.yml` / `sentry.conf.py`; this exposes it as a simple, documented Helm interface.

Sentry uses a single instance-level option for PagerDuty — [`pagerduty.app-id`](https://develop.sentry.dev/integrations/pagerduty/) — which is the PagerDuty App Registry "App ID" used to build the app-install redirect URL. It is a **public identifier, not a credential** (per-service Events API v2 integration keys are still entered per-project in the Sentry UI and are out of scope here).

## How to use

Inline value:

```yaml
pagerduty:
  appId: "PV5SD0T"
```

Or from an existing Kubernetes Secret:

```yaml
pagerduty:
  existingSecret: "my-pagerduty-secret"
  existingSecretAppId: "app-id"   # optional, defaults to "app-id"
```

## Changes

- `values.yaml` — new documented `pagerduty` block (mirrors the `slack`/`discord` blocks).
- `templates/sentry/_helper-sentry.tpl` — renders `pagerduty.app-id` into `config.yml` for the inline case, and sets `SENTRY_OPTIONS['pagerduty.app-id']` in `sentry.conf.py` when `existingSecret` is used.
- `templates/_helper.tpl` — injects the `PAGERDUTY_APP_ID` env var from the referenced Secret when `existingSecret` is set.
- `README.md` — values table entry.

## Testing

- `helm lint` passes.
- `helm template` verified for three cases:
  - unset → no `pagerduty.app-id` emitted (only the section banner, consistent with Slack/Discord);
  - inline `appId` → `pagerduty.app-id: "…"` in `config.yml`, no env injection;
  - `existingSecret` → `SENTRY_OPTIONS['pagerduty.app-id']` in `sentry.conf.py` and a `PAGERDUTY_APP_ID` `secretKeyRef` env var (custom key override respected).
- Rendered ConfigMap parses as valid YAML.

## Reference

- Sentry self-hosted PagerDuty setup: https://develop.sentry.dev/integrations/pagerduty/
- Sentry option registration: `pagerduty.app-id` in `getsentry/sentry` `src/sentry/options/defaults.py`
