### PR TITLE
fix: charts/sentry: render volumeMounts key for global.volumeMounts

### DIFF
--- a/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
@@ -101,12 +101,14 @@ spec:
         securityContext:
 {{ toYaml .Values.launchpadTaskWorker.containerSecurityContext | indent 10 }}
 {{- end }}
-{{- if .Values.launchpadTaskWorker.volumeMounts }}
+{{- if or .Values.launchpadTaskWorker.volumeMounts .Values.global.volumeMounts }}
         volumeMounts:
+{{- if .Values.launchpadTaskWorker.volumeMounts }}
 {{ toYaml .Values.launchpadTaskWorker.volumeMounts | indent 8 }}
 {{- end }}
 {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
 {{- end }}
         livenessProbe:
           exec:

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -83,12 +83,14 @@ spec:
           containerPort: 9125
         - name: metrics
           containerPort: 9102
-{{- if .Values.metrics.volumeMounts }}
+{{- if or .Values.metrics.volumeMounts .Values.global.volumeMounts }}
         volumeMounts:
+{{- if .Values.metrics.volumeMounts }}
 {{ toYaml .Values.metrics.volumeMounts | indent 8 }}
 {{- end }}
 {{- if .Values.global.volumeMounts }}
 {{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
 {{- end }}
 {{- if .Values.metrics.livenessProbe.enabled }}
         livenessProbe:


### PR DESCRIPTION
## Summary
- Fixes YAML parse failure in `deployment-launchpad-taskworker.yaml` when `global.volumeMounts` is set without component-level mounts ([#2251](https://github.com/sentry-kubernetes/charts/issues/2251)).
- Applies the same guard to `deployment-metrics.yaml`, which had the identical pattern.
- Matches the established `uptime-checker` `or` + nested `if` pattern so the `volumeMounts:` key is always emitted when either source is present.

## Test plan
- [x] `helm template` with only `global.volumeMounts` / `global.volumes` reproduces the reported error before the fix
- [x] After fix, `helm template --show-only templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml` succeeds and renders `volumeMounts:` + mounts
- [x] Same check for `templates/sentry/metrics/deployment-metrics.yaml` with `metrics.enabled=true`
- [x] Component + global mounts both render under a single `volumeMounts:` key
- [x] `helm lint` and full `helm template` succeed with the repro values

Fixes #2251