### PR TITLE
docs: fix replicasUseFQDN value in README clickhouse-operator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ spec:
             requests:
               storage: 20Gi
   defaults:
-    replicasUseFQDN: "true"
+    replicasUseFQDN: "yes"
     templates:
       podTemplate: clickhouse
       dataVolumeClaimTemplate: data-volume


### PR DESCRIPTION
## Summary

Fixes #2248

The root `README.md` documented `replicasUseFQDN: "true"` in the `ClickHouseInstallation` manifest example (Step 3: Install ClickHouse). The Altinity clickhouse-operator expects `"yes"`/`"no"` string values for this field, as shown in the [upstream documentation](https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md) and the [full CRD example](https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/99-clickhouseinstallation-max.yaml).

## Change

Single-line documentation fix in `README.md` line 146:

```diff
   defaults:
-    replicasUseFQDN: "true"
+    replicasUseFQDN: "yes"
     templates:
       podTemplate: clickhouse
       dataVolumeClaimTemplate: data-volume
```

## Verification

- Validated the `ClickHouseInstallation` YAML manifest parses correctly (PyYAML, Ruby YAML, yq)
- Confirmed `replicasUseFQDN: "yes"` is correctly placed under `.spec.defaults`, matching the upstream CRD structure
- Confirmed this is the only occurrence of `replicasUseFQDN` in the repo
- `helm lint` passes on all charts (sentry, clickhouse, sentry-kubernetes)
- Commit message follows Conventional Commits spec (`docs:` type)
- Root `README.md` change is outside chart directories, so `ct list-changed` will correctly skip chart lint/install steps