### PR TITLE
fix: add relay.asHook for rolling updates

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -410,6 +410,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | redis.replica.nodeSelector | object | `{}` |  |
 | redis.replica.replicaCount | int | `1` |  |
 | relay.affinity | object | `{}` |  |
+| relay.asHook | bool | `true` | Deploy relay as a Helm hook. Set to false for rolling updates instead of delete-and-recreate on upgrades |
 | relay.autoscaling.enabled | bool | `false` |  |
 | relay.autoscaling.maxReplicas | int | `5` |  |
 | relay.autoscaling.minReplicas | int | `2` |  |

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -15,7 +15,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     {{- include "sentry.component.labels" (dict "component" "relay" "ctx" .) | nindent 4 }}
-  {{- if .Values.asHook }}
+  {{- if .Values.relay.asHook }}
   {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
   annotations:
     meta.helm.sh/release-name: "{{ .Release.Name }}"

--- a/charts/sentry/templates/relay/hpa-relay.yaml
+++ b/charts/sentry/templates/relay/hpa-relay.yaml
@@ -3,11 +3,13 @@ apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sentry.fullname" . }}-relay
+  {{- if .Values.relay.asHook }}
   annotations:
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "25"
+  {{- end }}
   labels:
     {{- include "sentry.component.labels" (dict "component" "relay" "ctx" .) | nindent 4 }}
 spec:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -207,6 +207,7 @@ uptimeChecker:
 
 relay:
   enabled: true
+  asHook: true
   annotations: {}
   strategyType: RollingUpdate
   replicas: 1


### PR DESCRIPTION
## Summary

When `asHook: true` (the default), Helm deletes and recreates the relay Deployment on every upgrade (hook lifecycle), bypassing `strategy: RollingUpdate` and causing downtime. The relay pod(s) are killed before new ones start, dropping all incoming traffic.

This adds `relay.asHook` (default `true`) so relay can opt out of hook behavior. When set to `false`, Helm patches the Deployment in-place, allowing Kubernetes to perform a rolling update.

```yaml
relay:
  asHook: false  # Helm patches in-place → rolling update
```

## Changes

- **`values.yaml`**: Added `relay.asHook: true` (default — backward compatible)
- **`deployment-relay.yaml`**: Changed condition from `.Values.asHook` to `.Values.relay.asHook`
- **`hpa-relay.yaml`**: Added `{{- if .Values.relay.asHook }}` guard around hook annotations (pre-existing bug — HPA had hook annotations unconditionally, unlike taskworker HPA which already has the guard)
- **`README.md`**: Documented the new parameter

## Backward compatibility

Default `relay.asHook: true` preserves existing behavior. Users who want rolling updates set `relay.asHook: false`.

Note: For zero-downtime rolling updates with `relay.asHook: false`, ensure `relay.replicas` is at least 2 (or enable `relay.autoscaling` with `minReplicas: 2`). With the default `replicas: 1`, Kubernetes will surge a new pod before killing the old one, but there may be a brief window with zero ready pods.

## Why not use the global `asHook: false`?

The global `asHook` affects all ~40 consumer deployments. `relay.asHook` allows targeting only relay — the user-facing ingress component where downtime is immediately visible — while keeping other components as hooks if desired.

## Verification

- `helm lint` passes
- Default rendering (`relay.asHook=true`): hook annotations present (backward compatible)
- Override rendering (`relay.asHook=false`): no hook annotations, `strategy: RollingUpdate` active
- HPA respects `relay.asHook` (previously always had hook annotations)
- Other components (snuba, sentry consumers) unaffected by `relay.asHook`
- Full chart render succeeds in both modes