### PR TITLE
fix: use Recreate strategy for single-partition Kafka consumers

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1056,7 +1056,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.subscriptionConsumerEvents.replicas | int | `1` |  |
 | snuba.subscriptionConsumerEvents.resources | object | `{}` |  |
 | snuba.subscriptionConsumerEvents.securityContext | object | `{}` |  |
-| snuba.subscriptionConsumerEvents.strategyType | string | `"Recreate"` | single-partition consumer: RollingUpdate surge pods deadlock the rollout |
+| snuba.subscriptionConsumerEvents.strategyType | string | `nil` | Recreate if replicas=1, else RollingUpdate |
 | snuba.subscriptionConsumerEvents.topologySpreadConstraints | list | `[]` |  |
 | snuba.subscriptionConsumerMetrics.affinity | object | `{}` |  |
 | snuba.subscriptionConsumerMetrics.containerSecurityContext | object | `{}` |  |
@@ -1069,7 +1069,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.subscriptionConsumerMetrics.replicas | int | `1` |  |
 | snuba.subscriptionConsumerMetrics.resources | object | `{}` |  |
 | snuba.subscriptionConsumerMetrics.securityContext | object | `{}` |  |
-| snuba.subscriptionConsumerMetrics.strategyType | string | `"Recreate"` | single-partition consumer: RollingUpdate surge pods deadlock the rollout |
+| snuba.subscriptionConsumerMetrics.strategyType | string | `nil` | Recreate if replicas=1, else RollingUpdate |
 | snuba.subscriptionConsumerMetrics.topologySpreadConstraints | list | `[]` |  |
 | snuba.subscriptionConsumerTransactions.affinity | object | `{}` |  |
 | snuba.subscriptionConsumerTransactions.containerSecurityContext | object | `{}` |  |
@@ -1082,7 +1082,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.subscriptionConsumerTransactions.replicas | int | `1` |  |
 | snuba.subscriptionConsumerTransactions.resources | object | `{}` |  |
 | snuba.subscriptionConsumerTransactions.securityContext | object | `{}` |  |
-| snuba.subscriptionConsumerTransactions.strategyType | string | `"Recreate"` | single-partition consumer: RollingUpdate surge pods deadlock the rollout |
+| snuba.subscriptionConsumerTransactions.strategyType | string | `nil` | Recreate if replicas=1, else RollingUpdate |
 | snuba.subscriptionConsumerTransactions.topologySpreadConstraints | list | `[]` |  |
 | snuba.transactionsConsumer.affinity | object | `{}` |  |
 | snuba.transactionsConsumer.containerSecurityContext | object | `{}` |  |

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1056,6 +1056,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.subscriptionConsumerEvents.replicas | int | `1` |  |
 | snuba.subscriptionConsumerEvents.resources | object | `{}` |  |
 | snuba.subscriptionConsumerEvents.securityContext | object | `{}` |  |
+| snuba.subscriptionConsumerEvents.strategyType | string | `"Recreate"` | single-partition consumer: RollingUpdate surge pods deadlock the rollout |
 | snuba.subscriptionConsumerEvents.topologySpreadConstraints | list | `[]` |  |
 | snuba.subscriptionConsumerMetrics.affinity | object | `{}` |  |
 | snuba.subscriptionConsumerMetrics.containerSecurityContext | object | `{}` |  |
@@ -1068,6 +1069,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.subscriptionConsumerMetrics.replicas | int | `1` |  |
 | snuba.subscriptionConsumerMetrics.resources | object | `{}` |  |
 | snuba.subscriptionConsumerMetrics.securityContext | object | `{}` |  |
+| snuba.subscriptionConsumerMetrics.strategyType | string | `"Recreate"` | single-partition consumer: RollingUpdate surge pods deadlock the rollout |
 | snuba.subscriptionConsumerMetrics.topologySpreadConstraints | list | `[]` |  |
 | snuba.subscriptionConsumerTransactions.affinity | object | `{}` |  |
 | snuba.subscriptionConsumerTransactions.containerSecurityContext | object | `{}` |  |
@@ -1080,6 +1082,7 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | snuba.subscriptionConsumerTransactions.replicas | int | `1` |  |
 | snuba.subscriptionConsumerTransactions.resources | object | `{}` |  |
 | snuba.subscriptionConsumerTransactions.securityContext | object | `{}` |  |
+| snuba.subscriptionConsumerTransactions.strategyType | string | `"Recreate"` | single-partition consumer: RollingUpdate surge pods deadlock the rollout |
 | snuba.subscriptionConsumerTransactions.topologySpreadConstraints | list | `[]` |  |
 | snuba.transactionsConsumer.affinity | object | `{}` |  |
 | snuba.transactionsConsumer.containerSecurityContext | object | `{}` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -38,6 +38,22 @@ livenessProbe:
 {{- end -}}
 
 {{/*
+  Recreate when replicas=1 (single-partition consumer, sentry-kubernetes/charts#2238),
+  else RollingUpdate. Explicit strategyType always wins.
+  Args: strategyType, replicas, autoscaling (all from .Values.<x>).
+*/}}
+{{- define "sentry.kafkaConsumer.strategyType" -}}
+{{- $autoscaling := .autoscaling | default dict -}}
+{{- if .strategyType -}}
+{{- .strategyType -}}
+{{- else if and (eq (.replicas | int) 1) (not $autoscaling.enabled) -}}
+Recreate
+{{- else -}}
+RollingUpdate
+{{- end -}}
+{{- end -}}
+
+{{/*
   startupProbe block for kafka-consumer / worker deployments.
   Absorbs cold-start latency so liveness can't fire during startup.
 

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -19,11 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.sentry.monitorsClockTasks.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.monitorsClockTasks.strategyType "replicas" .Values.sentry.monitorsClockTasks.replicas "autoscaling" .Values.sentry.monitorsClockTasks.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -19,6 +19,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.sentry.monitorsClockTasks.strategyType | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -19,6 +19,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.sentry.monitorsClockTick.strategyType | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -19,11 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.sentry.monitorsClockTick.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.monitorsClockTick.strategyType "replicas" .Values.sentry.monitorsClockTick.replicas "autoscaling" .Values.sentry.monitorsClockTick.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -19,6 +19,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerEapItems.strategyType | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -19,11 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerEapItems.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerEapItems.strategyType "replicas" .Values.snuba.subscriptionConsumerEapItems.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -19,6 +19,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerEvents.strategyType | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -19,11 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerEvents.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerEvents.strategyType "replicas" .Values.snuba.subscriptionConsumerEvents.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -20,11 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerGenericMetricsCounters.strategyType "replicas" .Values.snuba.subscriptionConsumerGenericMetricsCounters.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -20,6 +20,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsCounters.strategyType | default "Recreate" }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -20,11 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerGenericMetricsDistributions.strategyType "replicas" .Values.snuba.subscriptionConsumerGenericMetricsDistributions.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -20,6 +20,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsDistributions.strategyType | default "Recreate" }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -20,6 +20,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.strategyType | default "Recreate" }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -20,11 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsGauges.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerGenericMetricsGauges.strategyType "replicas" .Values.snuba.subscriptionConsumerGenericMetricsGauges.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -20,6 +20,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.strategyType | default "Recreate" }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -20,11 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerGenericMetricsSets.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerGenericMetricsSets.strategyType "replicas" .Values.snuba.subscriptionConsumerGenericMetricsSets.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -20,11 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerMetrics.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerMetrics.strategyType "replicas" .Values.snuba.subscriptionConsumerMetrics.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -20,6 +20,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerMetrics.strategyType | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -20,11 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
-  partition assignment, so it fails its healthcheck-file probes and the rollout
-  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
   strategy:
-    type: {{ .Values.snuba.subscriptionConsumerTransactions.strategyType | default "Recreate" }}
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.subscriptionConsumerTransactions.strategyType "replicas" .Values.snuba.subscriptionConsumerTransactions.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -20,6 +20,11 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- /* Single-partition consumer: a RollingUpdate surge pod can never get a
+  partition assignment, so it fails its healthcheck-file probes and the rollout
+  deadlocks. Recreate stops the old consumer first so the new one can take over. */}}
+  strategy:
+    type: {{ .Values.snuba.subscriptionConsumerTransactions.strategyType | default "Recreate" }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -899,6 +899,10 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -934,6 +938,10 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1595,6 +1603,10 @@ snuba:
 
   subscriptionConsumerEapItems:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1619,6 +1631,10 @@ snuba:
 
   subscriptionConsumerEvents:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1643,6 +1659,10 @@ snuba:
 
   subscriptionConsumerGenericMetricsDistributions:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1667,6 +1687,10 @@ snuba:
 
   subscriptionConsumerGenericMetricsSets:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1691,6 +1715,10 @@ snuba:
 
   subscriptionConsumerGenericMetricsCounters:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1715,6 +1743,10 @@ snuba:
 
   subscriptionConsumerGenericMetricsGauges:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1871,6 +1903,10 @@ snuba:
 
   subscriptionConsumerMetrics:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []
@@ -1897,6 +1933,10 @@ snuba:
 
   subscriptionConsumerTransactions:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
+    # Deployment strategy. Single-partition consumer: keep Recreate, a
+    # RollingUpdate surge pod can never get a partition assignment and the
+    # rollout deadlocks (see sentry-kubernetes/charts#2238).
+    strategyType: Recreate
     annotations: {}
     replicas: 1
     env: []

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -899,10 +899,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -938,10 +936,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1603,10 +1599,8 @@ snuba:
 
   subscriptionConsumerEapItems:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1631,10 +1625,8 @@ snuba:
 
   subscriptionConsumerEvents:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1659,10 +1651,8 @@ snuba:
 
   subscriptionConsumerGenericMetricsDistributions:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1687,10 +1677,8 @@ snuba:
 
   subscriptionConsumerGenericMetricsSets:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1715,10 +1703,8 @@ snuba:
 
   subscriptionConsumerGenericMetricsCounters:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1743,10 +1729,8 @@ snuba:
 
   subscriptionConsumerGenericMetricsGauges:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1903,10 +1887,8 @@ snuba:
 
   subscriptionConsumerMetrics:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1933,10 +1915,8 @@ snuba:
 
   subscriptionConsumerTransactions:  # should have 1 partition and only 1 consumer replica: https://github.com/getsentry/snuba/issues/5855
     enabled: true
-    # Deployment strategy. Single-partition consumer: keep Recreate, a
-    # RollingUpdate surge pod can never get a partition assignment and the
-    # rollout deadlocks (see sentry-kubernetes/charts#2238).
-    strategyType: Recreate
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []


### PR DESCRIPTION
## Problem

Since #2233 added healthcheck-file startup/liveness probes, any `RollingUpdate` permanently wedges the single-partition consumer deployments (monitors-clock-tick/tasks, snuba commit-log subscription consumers):

1. These topics have 1 partition consumed by 1 consumer group; the old pod holds the only assignment.
2. The surge pod gets no partition assignment, never touches `/tmp/health.txt`, fails its startup probe and is killed in a loop.
3. The Deployment never scales down the old ReplicaSet because the new pod never becomes Ready → permanent deadlock. Only manual `kubectl delete rs <old>` unblocks it.

These consumers are single-partition/single-consumer **by design** (getsentry/snuba#5855), so a surge pod can never succeed.

Fixes #2238

## Solution

Default the affected Deployments' `strategy.type` to `Recreate` **only when `replicas=1`** (where `RollingUpdate` deadlocks); otherwise default stays `RollingUpdate`. A new `sentry.kafkaConsumer.strategyType` helper in `_helper.tpl` encodes this, and an explicit `<component>.strategyType` (matching the existing `sentry.web.strategyType` idiom) always overrides either default — including for `monitorsClockTick`/`monitorsClockTasks`, which also factor in `autoscaling.enabled` since HPA can move them past 1 replica.

Implements the approach suggested by @fcuello-fudo in the #2238 discussion. Precedent: the same deadlock mechanism (surge pod unable to acquire an exclusive resource) was fixed the same way for sentry-web on ReadWriteOnce PVCs in #216 (#77, #214).

- 10 deployment templates: `monitors-clock-{tick,tasks}`; snuba `subscription-consumer-{events,transactions,metrics,generic-metrics-{counters,distributions,sets,gauges},eap-items}`
- `_helper.tpl`: added `sentry.kafkaConsumer.strategyType`
- `values.yaml`: `strategyType` now documented as `null` (dynamic default) for each block
- README: updated rows for keys already present in the parameter table

Note: this PR originally also touched 5 `sentry.subscriptionConsumer*`/`subscriptionConsumerResultsEapItems` deployments, which were removed in the meantime by the TaskBroker migration in #2257. Rebased onto `develop` and dropped those; the fix now only covers consumers that still exist.

## Scope

With `asHook: true` (default) these Deployments are recreated by the Helm hook lifecycle anyway (see #2256), so this change is a no-op there. The deadlock bites installs using `asHook: false` or GitOps tooling (e.g. Argo CD) where a real RollingUpdate happens — this fixes those.

## Verification

- `helm lint` passes
- `helm template` (default values): all 10 affected Deployments render `strategy.type: Recreate`
- Bumping a consumer's `replicas` above 1 renders `strategy.type: RollingUpdate` for that consumer, others unaffected
- `--set snuba.subscriptionConsumerEvents.strategyType=RollingUpdate` overrides back regardless of `replicas`
- `--set sentry.monitorsClockTasks.autoscaling.enabled=true` renders `RollingUpdate` despite the default `replicas: 1`
