### PR TITLE
feat: charts/sentry: add maxPollIntervalMs for snuba eapItemsConsumer

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -128,6 +128,10 @@ spec:
           {{- end }}
           - "--health-check-file"
           - "/tmp/health.txt"
+          {{- if .Values.snuba.eapItemsConsumer.maxPollIntervalMs }}
+          - "--max-poll-interval-ms"
+          - "{{ .Values.snuba.eapItemsConsumer.maxPollIntervalMs }}"
+          {{- end }}
         {{- include "sentry.startupProbe.execHealthcheckFile" (dict "startupProbe" .Values.snuba.eapItemsConsumer.startupProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         {{- include "sentry.livenessProbe.execHealthcheckFile" (dict "livenessProbe" .Values.snuba.eapItemsConsumer.livenessProbe "healthcheckFile" "/tmp/health.txt") | nindent 8 }}
         ports:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1454,6 +1454,7 @@ snuba:
     securityContext: {}
     topologySpreadConstraints: []
     containerSecurityContext: {}
+    # maxPollIntervalMs: 30000
     tolerations: []
     podLabels: {}
     sidecars: []


### PR DESCRIPTION
The eap-items consumer runs `snuba rust-consumer`, whose `--max-poll-interval-ms` defaults to `30000`. When a single poll cycle exceeds that, librdkafka evicts the consumer from the group and arroyo escalates the revocation into a `StrategyPanic`, so the container exits and Kubernetes restarts it.

Observed in production on `sentry-31.6.0` / snuba `26.5.0`, roughly once every ~1.7h:

```
librdkafka: MAXPOLL [thrd:main]: Application maximum poll interval (30000ms)
exceeded by 138ms (adjust max.poll.interval.ms for long-running message processing)
librdkafka: SESSTMOUT [thrd:main]: Consumer group session timed out (in join-state steady)
after 30029 ms without a successful response from the group coordinator
Partitions to revoke: [Partition { topic: Topic("snuba-items"), index: 0 }]
StrategyPanic
```

The consumer overshoots the 30s ceiling by a small margin, so a modest bump is enough to absorb it. `snuba rust-consumer` accepts `--max-poll-interval-ms`, but `eapItemsConsumer` has no chart value to set it, leaving users to either accept the restart loop or fork the template.

## Change

Expose `maxPollIntervalMs` for `snuba.eapItemsConsumer`, following the pattern already used by `replaysConsumer` and `outcomesBillingConsumer` (added in #1805).

- `charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml` — render the flag when set
- `charts/sentry/values.yaml` — document it as a commented default, matching `replaysConsumer`

## Backwards compatibility

The flag is only rendered when the value is set, so default output is byte-for-byte unchanged.

Verified with `helm template`:

```
# unset (default) -> flag absent
- "--health-check-file"
- "/tmp/health.txt"

# --set snuba.eapItemsConsumer.maxPollIntervalMs=60000 -> flag present
- "--health-check-file"
- "/tmp/health.txt"
- "--max-poll-interval-ms"
- "60000"
```

No `Chart.yaml` bump included, since release-please manages versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)