### PR TITLE
feat: upgrade sentry to v26.7.1

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 33.0.0
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 26.7.0
+appVersion: 26.7.1
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates


### PR DESCRIPTION
Fixes a critical SAML SSO vulnerability according to https://github.com/getsentry/self-hosted/releases/tag/26.7.1