### PR TITLE
fix: make kafkaTopicOverrides.prefix work again on Sentry 26.7.x

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -235,6 +235,19 @@ sentry.conf.py: |-
   from sentry.conf.types.kafka_definition import Topic
   for topic in Topic:
     KAFKA_TOPIC_OVERRIDES[topic.value] = f"{SENTRY_CHARTS_KAFKA_TOPIC_PREFIX}{topic.value}"
+
+  # KAFKA_TOPIC_TO_CLUSTER is keyed by the DEFAULT topic names, but since Sentry 26.7.0
+  # sentry.utils.kafka_config.get_topic_definition() resolves real_topic_name through
+  # KAFKA_TOPIC_OVERRIDES and then looks THAT name up in KAFKA_TOPIC_TO_CLUSTER, with a
+  # strict [] for Topic enum members. Mirror every entry under its overridden name so
+  # those lookups keep resolving once a prefix is set.
+  KAFKA_TOPIC_TO_CLUSTER = {
+    **KAFKA_TOPIC_TO_CLUSTER,
+    **{
+      KAFKA_TOPIC_OVERRIDES.get(topic, topic): cluster
+      for topic, cluster in KAFKA_TOPIC_TO_CLUSTER.items()
+    },
+  }
   {{- end }}
 
   KAFKA_CLUSTERS["default"] = DEFAULT_KAFKA_OPTIONS

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-accepted-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-accepted-consumer.yaml
@@ -98,8 +98,11 @@ spec:
           - "--raw-topic"
           - "{{ .Values.snuba.outcomesAcceptedConsumer.rawTopic }}"
           {{- end }}
+          # Unlike --raw-events-topic elsewhere, this takes a LOGICAL topic name: snuba
+          # builds Topic(<value>) from it, so a prefixed name is not a valid enum member.
+          # Do not apply kafkaTopicOverrides.prefix here.
           - "--accepted-outcomes-topic"
-          - "{{ default "" ((.Values.kafkaTopicOverrides).prefix) }}{{ default "outcomes-billing" .Values.snuba.outcomesAcceptedConsumer.outcomesAcceptedTopic }}"
+          - "{{ default "outcomes-billing" .Values.snuba.outcomesAcceptedConsumer.outcomesAcceptedTopic }}"
           {{- if .Values.snuba.outcomesAcceptedConsumer.maxBatchSize }}
           - "--max-batch-size"
           - "{{ .Values.snuba.outcomesAcceptedConsumer.maxBatchSize }}"


### PR DESCRIPTION
## Summary

`kafkaTopicOverrides.prefix` is unusable on chart 33.x (Sentry 26.7.x): `sentry-web`,
`sentry-taskscheduler` and the ingest consumers crashloop at startup, and the new
`snuba-outcomes-accepted-consumer` crashloops too. Two independent causes, one commit each.

Both changes are no-ops when no prefix is set.

## 1. `KAFKA_TOPIC_TO_CLUSTER` lookups (`_helper-sentry.tpl`)

Since Sentry 26.7.0, `sentry/utils/kafka_config.py` resolves `real_topic_name` through
`KAFKA_TOPIC_OVERRIDES` and then indexes `KAFKA_TOPIC_TO_CLUSTER` with it — strictly, for
`Topic` enum members:

```python
real_topic_name = settings.KAFKA_TOPIC_OVERRIDES.get(topic_name, topic_name)

if isinstance(topic, str):
    cluster = settings.KAFKA_TOPIC_TO_CLUSTER.get(real_topic_name, "default")
else:
    cluster = settings.KAFKA_TOPIC_TO_CLUSTER[real_topic_name]   # KeyError
```

But `KAFKA_TOPIC_TO_CLUSTER` is keyed by the **default** topic names — `conf/server.py` states
it explicitly: *"This must be the default name that matches the topic in
sentry.conf.types.kafka_definition and sentry-kafka-schemas and not any environment-specific
override value"*.

So once the chart sets `KAFKA_TOPIC_OVERRIDES`, every enum lookup raises. Because
`sentry/snuba/query_subscriptions/constants.py` performs one at **module level**, it surfaces as
an `ImportError` during `django.setup()` for every component importing `sentry.incidents`:

```
File "sentry/snuba/query_subscriptions/constants.py", line 14, in <module>
    get_topic_definition(Topic(logical_topic))["real_topic_name"]: dataset
File "sentry/utils/kafka_config.py", line 135, in get_topic_definition
    cluster = settings.KAFKA_TOPIC_TO_CLUSTER[real_topic_name]
KeyError: 'sentry-events-subscription-results'
```

The fix mirrors each entry under its overridden name. It derives the mapping from
`KAFKA_TOPIC_OVERRIDES` rather than the prefix string, so it stays correct for any override
scheme, and it lives inside the existing `if prefix` block.

This arguably wants fixing in Sentry too (the strict lookup contradicts the mapping's own
docstring), but the chart is what introduces the override, so it can fix itself today.

## 2. `--accepted-outcomes-topic` is a logical name (`deployment-snuba-outcomes-accepted-consumer.yaml`)

The template prepends the prefix, but snuba builds a `Topic` enum member out of this value:

```
File "snuba/consumers/consumer_config.py", line 238, in resolve_consumer_config
    KafkaTopicSpec(Topic(accepted_outcomes_topic)) if accepted_outcomes_topic else None
ValueError: 'sentry-outcomes-billing' is not a valid Topic
```

This differs from `--raw-events-topic` on the sibling outcomes consumers, which does take a
physical name and is correctly prefixed. snuba's own CLI default for this flag is the logical
`outcomes-billing`.

### ⚠️ Why this PR is a draft — this commit alone is not sufficient

`_resolve_topic_config()` uses the CLI value as the **physical** topic name whenever it is not
`None`, which short-circuits `KAFKA_TOPIC_MAP`. Measured on a live 26.7.1 deployment with
`prefix: "sentry-"`:

| `--accepted-outcomes-topic` | logical | physical |
|---|---|---|
| `sentry-outcomes-billing` (current chart) | — | `ValueError` |
| `outcomes-billing` (this PR) | `outcomes-billing` | `outcomes-billing` ❌ |
| flag omitted / `None` | — | topic disabled entirely |
| *expected* (`spec.get_physical_topic_name()`) | `outcomes-billing` | `sentry-outcomes-billing` ✅ |

So after this commit the consumer starts but subscribes to `outcomes-billing`, which does not
exist on a prefixed install — a silent failure replacing a loud one. There is **no chart-only
change that makes this consumer work under a topic prefix**; snuba must stop passing the logical
name as the physical override:

```diff
  resolved_accepted_outcomes_topic = _resolve_topic_config(
      "accepted outcomes topic",
      accepted_outcomes_topic_spec,
-     accepted_outcomes_topic,
+     None,
      slice_id,
  )
```

Happy to open that snuba PR and/or split this into two chart PRs — commit 1 is complete and
valuable on its own, and maintainers may prefer to hold commit 2 until snuba is fixed, or to
skip rendering this consumer entirely while a prefix is set. Guidance welcome.

## Testing

- `helm lint` passes.
- Rendered with and without `kafkaTopicOverrides.prefix`; **without** a prefix the output is
  byte-identical to `develop` apart from the randomly generated secrets.
- The rendered `sentry.conf.py` was executed inside `ghcr.io/getsentry/sentry:26.7.1`:
  `KAFKA_TOPIC_TO_CLUSTER` goes from 52 to 104 entries and all 52 `Topic` enum members resolve
  (52 unresolvable before the patch).
- Applied to a production cluster (chart 33.1.0, external Kafka/ClickHouse/Postgres,
  `prefix: "sentry-"`): `sentry-web` and the consumers start and stay healthy, ingestion works.

Related: #2041 (`sentry-taskbroker-*` does not respect `kafkaTopicOverrides.prefix`) — same
family of problem, still open in effect.
