### PR TITLE
feat(sentry): add KEDA autoscaling and ClickHouse preparation

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -33,6 +33,7 @@ jobs:
           helm repo add sentry-kubernetes https://sentry-kubernetes.github.io/charts
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add altinity https://helm.altinity.com
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo update
 
       - name: Run chart-testing (list-changed)

--- a/charts/sentry/Chart.lock
+++ b/charts/sentry/Chart.lock
@@ -1,4 +1,7 @@
 dependencies:
+- name: prometheus-kafka-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 3.1.0
 - name: memcached
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.9.3
@@ -14,5 +17,5 @@ dependencies:
 - name: nginx
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.7.0
-digest: sha256:11613581288338b8b94759d4438866780bcd3adbcbb815d9dee7132753ffb2da
-generated: "2026-05-29T12:27:53.995591111+06:00"
+digest: sha256:bc75c3813176d446ac8101610aa7710e16cdef4a14848361ddddb0e124a1a5de
+generated: "2026-07-27T10:06:43.041761+03:00"

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -6,6 +6,11 @@ version: 33.0.0
 # renovate image=ghcr.io/getsentry/sentry
 appVersion: 26.7.1
 dependencies:
+  - name: prometheus-kafka-exporter
+    alias: kafkaExporter
+    repository: https://prometheus-community.github.io/helm-charts
+    version: 3.1.0
+    condition: kafkaExporter.enabled
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates
     version: 0.9.3

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -1639,4 +1639,4 @@ externalPostgresql:
 - [AWS + Terraform](docs/usage-aws-terraform.md)
 - [DigitalOcean](docs/usage-digitalocean.md)
 - [External Services](docs/external-services.md)
-
+- [Workspace features: KEDA, Kafka lag scaling, and ClickHouse preparation](docs/keda-autoscaler.md)

--- a/charts/sentry/docs/clickhouse-prepare.md
+++ b/charts/sentry/docs/clickhouse-prepare.md
@@ -42,6 +42,27 @@ The Job does not have separate credentials. It uses
 `externalClickhouse.existingSecret/existingSecretKey`. Existing Secrets are
 recommended for production.
 
+The Job always uses its own `<release>-sentry-clickhouse-prepare`
+ServiceAccount. The ServiceAccount is installed as a hook with weight `-1`, so
+it exists before the weight `0` prepare Job during the first installation as
+well as upgrades. It is independent of the chart-wide dedicated/shared
+ServiceAccount mode. Add workload-identity annotations under the prepare
+configuration when required:
+
+```yaml
+externalClickhouse:
+  prepare:
+    serviceAccount:
+      automountServiceAccountToken: false
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/sentry-clickhouse-prepare
+```
+
+The ServiceAccount uses the `hook-succeeded` delete policy and is removed only
+after the complete pre-install/pre-upgrade hook sequence succeeds. It remains
+available when the prepare Job fails so the failed hook can be inspected and
+is replaced before the next hook run.
+
 The Job is a `pre-install,pre-upgrade` hook. A failed topology, settings or
 distributed INSERT check stops the Helm operation. Verify `clusterName`,
 `distributedClusterName`, shard and replica counts before enabling it.

--- a/charts/sentry/docs/clickhouse-prepare.md
+++ b/charts/sentry/docs/clickhouse-prepare.md
@@ -1,0 +1,52 @@
+# ClickHouse prepare hook
+
+The optional `clickhouse-prepare` Job runs before Helm install and upgrade. It
+validates the external ClickHouse cluster topology, creates the Snuba database,
+can provision the runtime user and grants, verifies required user settings, and
+runs a distributed INSERT smoke test.
+
+The hook is disabled by default. It requires `hooks.enabled: true`, a valid
+ClickHouse cluster name, and the account configured by `externalClickhouse`
+must be allowed to query `system.clusters` and perform the selected operations.
+
+```yaml
+hooks:
+  enabled: true
+
+externalClickhouse:
+  host: clickhouse.example.svc
+  tcpPort: 9000
+  database: sentry
+  username: sentry
+  existingSecret: clickhouse-runtime
+  existingSecretKey: password
+  clusterName: sentry_local
+  distributedClusterName: sentry_distributed
+
+  prepare:
+    enabled: true
+    expectedShards: 2
+    expectedReplicasPerShard: 3
+    runtimeUser:
+      enabled: true
+      grantAll: false
+    settings:
+      apply: true
+      verify: true
+    distributedInsertTest:
+      enabled: true
+```
+
+The Job does not have separate credentials. It uses
+`externalClickhouse.username` together with `externalClickhouse.password` or
+`externalClickhouse.existingSecret/existingSecretKey`. Existing Secrets are
+recommended for production.
+
+The Job is a `pre-install,pre-upgrade` hook. A failed topology, settings or
+distributed INSERT check stops the Helm operation. Verify `clusterName`,
+`distributedClusterName`, shard and replica counts before enabling it.
+
+When `settings.verify` is enabled without `settings.apply`, the runtime user
+must already have the configured settings. Disable the distributed INSERT test
+only when the configured ClickHouse account is intentionally not allowed to create and
+drop temporary test tables.

--- a/charts/sentry/docs/keda-autoscaler.md
+++ b/charts/sentry/docs/keda-autoscaler.md
@@ -16,12 +16,46 @@ troubleshooting for:
 - selectable HPA or KEDA autoscaling;
 - Kafka consumer lag scaling through Prometheus and Kafka Exporter;
 - the optional `prometheus-kafka-exporter` subchart;
-- the ClickHouse preparation hook.
+- the ClickHouse preparation hook;
+- dedicated or shared ServiceAccounts for chart components and hooks.
 
 These features are disabled or backward-compatible by default. Existing
 installations continue to use the chart-managed HorizontalPodAutoscaler unless
 a workload explicitly selects KEDA. Kafka Exporter and ClickHouse preparation
 also require explicit enablement.
+
+## ServiceAccount modes
+
+Custom ServiceAccounts remain disabled by default. With
+`serviceAccount.enabled: true` and `serviceAccount.shared: false`, the chart
+creates component-specific accounts such as `sentry-web`, `sentry-snuba`, and
+`sentry-hooks`. Regular database and migration hooks use the hook account.
+`clickhouse-prepare` is an exception: because it runs before normal release
+resources exist, it always receives a dedicated pre-install/pre-upgrade hook
+ServiceAccount named `<release>-sentry-clickhouse-prepare`.
+
+Set `shared: true` when the regular first-party chart workloads and hooks
+should use a single account. The ClickHouse prepare hook, Kafka Exporter and
+other dependency subcharts retain their own ServiceAccount settings and are
+not redirected to the shared Sentry account.
+
+```yaml
+serviceAccount:
+  enabled: true
+  name: sentry
+  shared: true
+  automountServiceAccountToken: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/sentry
+```
+
+In shared mode the chart renders one regular first-party ServiceAccount named
+`sentry` for this example. If ClickHouse prepare is enabled, its lifecycle-safe
+hook ServiceAccount is rendered in addition. In dedicated mode the chart
+renders only the accounts needed by enabled components, plus `sentry-hooks`
+while regular hooks are enabled.
+Switching modes changes `serviceAccountName` on workloads and can restart
+their Pods; review RBAC and cloud workload-identity bindings before rollout.
 
 ## Architecture overview
 
@@ -72,8 +106,45 @@ groups, replica limits, or activation thresholds remain workload-specific.
 | Occurrences consumer | `sentry.ingestOccurrences.autoscaling` | `<release>-sentry-ingest-occurrences` |
 | Taskworker | `sentry.taskWorker.autoscaling` and `workers[].autoscaling` | one Deployment per worker |
 
-Transactions, occurrences, and Vroom only render when the
-`feature-complete` profile is enabled.
+Transactions and occurrences only render when the `feature-complete` profile
+is enabled. Vroom additionally requires
+`sentry.features.enableProfiling: true`; its HPA or ScaledObject is suppressed
+whenever the Vroom Deployment is absent.
+
+### Adding or renaming consumer components
+
+The supported-workload table is an explicit registry, not automatic
+discovery. A new consumer Deployment must be registered in
+`templates/_helper-keda.tpl` with its values path, rendered Deployment name,
+Kafka topic and consumer group. Its template must omit static `spec.replicas`
+when autoscaling is enabled, and an HPA template must render only when
+`autoscaler: hpa` is selected.
+
+For example, when the uptime-results consumer proposed in PR #1830 is added to
+the current chart, its documented configuration should be:
+
+```yaml
+sentry:
+  uptimeResults:
+    enabled: true
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 1
+      maxReplicas: 10
+      triggers:
+        kafkaLag:
+          enabled: true
+          topic: uptime-results
+          consumerGroup: uptime-results
+```
+
+This configuration becomes valid only after the component is added to the
+KEDA registry; setting it against the current unregistered component does not
+create a ScaledObject. Apply the same procedure to the Snuba uptime consumer,
+using the topic and group actually passed to its consumer command. Confirm the
+corresponding `topic` and `consumergroup` labels in Kafka Exporter before
+enabling scaling.
 
 ## KEDA prerequisites
 
@@ -178,7 +249,28 @@ They can be overridden under the workload trigger.
 Optional Kafka metadata includes `allowIdleConsumers`,
 `scaleToZeroOnInvalidOffset`, `excludePersistentLag`,
 `limitToPartitionsWithLag`, `version`, `partitionLimitation`, `sasl`,
-`tls`, and `unsafeSsl`.
+`tls`, and `unsafeSsl`. Set `authenticationRef` to reference a KEDA
+`TriggerAuthentication` for native Kafka credentials.
+
+Helm rendering fails if KEDA is selected without any effective Kafka, Kafka
+lag, Prometheus, CPU or memory trigger. `minReplicas: 0` is preserved for
+scale-to-zero rather than being replaced by the default value.
+
+Helm also rejects unknown `autoscaler` values and invalid replica/timing
+bounds. Valid KEDA settings satisfy `minReplicas >= 0`, `maxReplicas >= 1`,
+`minReplicas <= maxReplicas`, `pollingInterval >= 1`, and
+`cooldownPeriod >= 0`.
+
+### Service-name length validation
+
+First-party and enabled Redis/PostgreSQL dependency Service names are checked
+against Kubernetes' 63-character DNS label limit. Helm rendering stops with
+the generated name and its length when a Service would exceed the limit or
+dependency truncation could cause a collision. Shorten the release name or set
+an appropriate `fullnameOverride`, `redis.fullnameOverride`, or
+`postgresql.fullnameOverride`. The chart does not silently truncate
+first-party component suffixes because that could make workload references
+ambiguous.
 
 ## Kafka Exporter subchart
 

--- a/charts/sentry/docs/keda-autoscaler.md
+++ b/charts/sentry/docs/keda-autoscaler.md
@@ -1,0 +1,620 @@
+# Workspace feature guide
+
+> **AI-assisted development notice**
+>
+> A substantial part of the functionality described in this document, as well
+> as the documentation itself, was created with the assistance of artificial
+> intelligence. The implementation has been statically validated with Helm
+> linting and template-rendering checks, but it should still receive human code
+> review and environment-specific testing before being used in production.
+
+This document describes the features added to the workspace version of the
+Sentry Helm chart on top of upstream chart 33.0.0. It covers the behavior,
+configuration model, operational dependencies, rollout procedures, and
+troubleshooting for:
+
+- selectable HPA or KEDA autoscaling;
+- Kafka consumer lag scaling through Prometheus and Kafka Exporter;
+- the optional `prometheus-kafka-exporter` subchart;
+- the ClickHouse preparation hook.
+
+These features are disabled or backward-compatible by default. Existing
+installations continue to use the chart-managed HorizontalPodAutoscaler unless
+a workload explicitly selects KEDA. Kafka Exporter and ClickHouse preparation
+also require explicit enablement.
+
+## Architecture overview
+
+### Autoscaling resource ownership
+
+Every supported workload has one `autoscaling` block. The `autoscaler`
+field selects which Kubernetes resource the chart renders:
+
+| Configuration | Result |
+| --- | --- |
+| `enabled: false` | No chart-managed HPA or KEDA ScaledObject |
+| `enabled: true, autoscaler: hpa` | One HorizontalPodAutoscaler |
+| `enabled: true, autoscaler: keda` | One KEDA ScaledObject |
+
+The default is `autoscaler: hpa`. HPA templates contain guards that prevent
+them from rendering when KEDA is selected. This is important because KEDA
+creates and manages an HPA internally; rendering the chart HPA at the same time
+would give two controllers ownership of the same Deployment scale target.
+
+KEDA resources are generated centrally by
+`templates/keda-scaledobjects.yaml` using helpers from
+`templates/_helper-keda.tpl`. The existing upstream Deployment templates are
+left intact.
+
+### Configuration precedence
+
+KEDA settings are resolved in this order:
+
+1. chart-wide defaults under `global.autoscaling`;
+2. workload settings under the workload's `autoscaling` block;
+3. per-worker settings for Sentry Taskworker.
+
+A more specific value overrides a global value. This allows the Prometheus
+address and standard thresholds to be defined once while topics, consumer
+groups, replica limits, or activation thresholds remain workload-specific.
+
+### Supported workloads
+
+| Workload | Value path | Default scale target |
+| --- | --- | --- |
+| Relay | `relay.autoscaling` | `<release>-sentry-relay` |
+| Sentry Web | `sentry.web.autoscaling` | `<release>-sentry-web` |
+| Vroom | `vroom.autoscaling` | `<release>-sentry-vroom` |
+| Snuba API | `snuba.api.autoscaling` | `<release>-sentry-snuba-api` |
+| Attachments consumer | `sentry.ingestConsumerAttachments.autoscaling` | `<release>-sentry-ingest-consumer-attachments` |
+| Events consumer | `sentry.ingestConsumerEvents.autoscaling` | `<release>-sentry-ingest-consumer-events` |
+| Transactions consumer | `sentry.ingestConsumerTransactions.autoscaling` | `<release>-sentry-ingest-consumer-transactions` |
+| Occurrences consumer | `sentry.ingestOccurrences.autoscaling` | `<release>-sentry-ingest-occurrences` |
+| Taskworker | `sentry.taskWorker.autoscaling` and `workers[].autoscaling` | one Deployment per worker |
+
+Transactions, occurrences, and Vroom only render when the
+`feature-complete` profile is enabled.
+
+## KEDA prerequisites
+
+The chart renders KEDA custom resources but does not install KEDA itself.
+Before enabling a KEDA workload, install a compatible KEDA operator and CRDs
+and confirm that the following resource is available:
+
+```console
+kubectl api-resources | grep scaledobjects
+```
+
+If `autoscaler: keda` is selected without the KEDA CRDs and operator, the
+Helm release cannot create the ScaledObject or the workload will not be
+autoscaled.
+
+## KEDA trigger types
+
+### CPU and memory
+
+CPU and memory triggers are suitable for HTTP/API workloads or consumers where
+resource usage correlates with load.
+
+```yaml
+sentry:
+  web:
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 2
+      maxReplicas: 10
+      pollingInterval: 30
+      cooldownPeriod: 300
+      triggers:
+        cpu:
+          enabled: true
+          value: "70"
+        memory:
+          enabled: true
+          value: "75"
+```
+
+If no Kafka or Prometheus trigger is enabled, the existing
+`targetCPUUtilizationPercentage` and
+`targetMemoryUtilizationPercentage` settings are used as KEDA CPU/memory
+targets.
+
+### Arbitrary Prometheus query
+
+A generic Prometheus trigger is available for Relay and other supported
+workloads.
+
+```yaml
+relay:
+  autoscaling:
+    enabled: true
+    autoscaler: keda
+    minReplicas: 2
+    maxReplicas: 12
+    triggers:
+      prometheus:
+        enabled: true
+        serverAddress: http://prometheus-operated.monitoring.svc:9090
+        query: sum(rate(relay_buffer_envelope_body_size_count[2m])) or vector(0)
+        threshold: "30"
+        activationThreshold: "5"
+```
+
+Supported optional fields include `namespace`, `customHeaders`,
+`ignoreNullValues`, `unsafeSsl`, and `authenticationRef`.
+
+### Native KEDA Kafka scaler
+
+The native Kafka trigger connects directly to Kafka:
+
+```yaml
+global:
+  autoscaling:
+    pollingInterval: 30
+    cooldownPeriod: 300
+    triggers:
+      kafka:
+        lagThreshold: "1000"
+        activationLagThreshold: "0"
+        offsetResetPolicy: latest
+
+sentry:
+  ingestConsumerEvents:
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 1
+      maxReplicas: 35
+      triggers:
+        kafka:
+          enabled: true
+```
+
+For known consumers, topic and consumer group defaults are supplied by the
+chart. `bootstrapServers` defaults to the Kafka connection used by Sentry.
+They can be overridden under the workload trigger.
+
+Optional Kafka metadata includes `allowIdleConsumers`,
+`scaleToZeroOnInvalidOffset`, `excludePersistentLag`,
+`limitToPartitionsWithLag`, `version`, `partitionLimitation`, `sasl`,
+`tls`, and `unsafeSsl`.
+
+## Kafka Exporter subchart
+
+The chart has an optional dependency on
+`prometheus-kafka-exporter` version 3.1.0, aliased as `kafkaExporter`.
+It is disabled by default.
+
+```yaml
+kafkaExporter:
+  enabled: true
+  kafkaServer:
+    - sentry-kafka.sentry.svc.cluster.local:9092
+  prometheus:
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      additionalLabels:
+        release: kube-prometheus-stack
+```
+
+The value in `kafkaServer` must be a broker address reachable from the
+exporter Pod. It is not derived dynamically from the parent release name.
+Always set it explicitly for the target environment.
+
+When ServiceMonitor is enabled:
+
+- the Prometheus Operator CRDs must exist;
+- the ServiceMonitor namespace must be watched by Prometheus;
+- `additionalLabels` must match the Prometheus selector;
+- network policies must allow Prometheus to scrape the exporter service.
+
+If the Prometheus Operator is not used, leave ServiceMonitor disabled and
+configure Prometheus service discovery separately.
+
+### Consumer lag through Kafka Exporter
+
+The `kafkaLag` trigger uses KEDA's Prometheus scaler. KEDA queries Prometheus,
+and Prometheus reads `kafka_consumergroup_lag` from Kafka Exporter.
+
+```text
+Kafka -> Kafka Exporter -> Prometheus -> KEDA -> Deployment replicas
+```
+
+Define shared Prometheus and threshold settings globally:
+
+```yaml
+global:
+  autoscaling:
+    pollingInterval: 30
+    cooldownPeriod: 300
+    triggers:
+      kafkaLag:
+        serverAddress: http://prometheus-operated.monitoring.svc:9090
+        metricName: kafka_consumergroup_lag
+        threshold: "1000"
+        activationThreshold: "10"
+```
+
+Enable lag scaling on a consumer:
+
+```yaml
+sentry:
+  ingestConsumerEvents:
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 1
+      maxReplicas: 35
+      triggers:
+        kafkaLag:
+          enabled: true
+```
+
+The generated query is:
+
+```promql
+sum(kafka_consumergroup_lag{topic="ingest-events",consumergroup="ingest-consumer"})
+```
+
+Known defaults are:
+
+| Consumer | Topic | Consumer group |
+| --- | --- | --- |
+| Attachments | `ingest-attachments` | `ingest-consumer` |
+| Events | `ingest-events` | `ingest-consumer` |
+| Transactions | `ingest-transactions` | `ingest-consumer` |
+| Occurrences | `ingest-occurrences` | `ingest-occurrences` |
+
+Override labels when the deployed consumer configuration differs:
+
+```yaml
+triggers:
+  kafkaLag:
+    enabled: true
+    topic: custom-events
+    consumerGroup: custom-ingest-consumer
+```
+
+Before rollout, verify the exact metric and labels in Prometheus:
+
+```promql
+count by (topic, consumergroup) (kafka_consumergroup_lag)
+```
+
+Then verify the intended query returns one numeric result. An empty result may
+prevent scaling; a permanently stale series may cause incorrect scaling.
+
+### Taskworker caution
+
+Taskworker consumes work through Taskbroker rather than directly consuming the
+Kafka topic itself. Kafka lag can be an early backlog signal, but it may not
+match actual Taskworker backlog when Taskbroker drains Kafka faster than
+workers process tasks. Validate the correlation before enabling `kafkaLag`
+for Taskworker. CPU/memory or a dedicated Taskbroker queue metric may be safer.
+
+## Scaling behavior and tuning
+
+Important values:
+
+| Value | Meaning |
+| --- | --- |
+| `minReplicas` | Lower replica bound |
+| `maxReplicas` | Upper replica bound |
+| `pollingInterval` | Seconds between KEDA metric checks |
+| `cooldownPeriod` | Delay before scaling back toward the minimum |
+| `threshold` | Target lag or Prometheus value per scaling decision |
+| `activationThreshold` | Value below which the scaler is inactive |
+| `advanced` | KEDA advanced/HPA behavior passed to the ScaledObject |
+
+Start with conservative `maxReplicas`. For Kafka consumers, the useful
+parallelism may be bounded by topic partition count. Increasing replicas beyond
+available partitions can create idle consumers and unnecessary churn.
+
+## KEDA rollout procedure
+
+1. Install KEDA and verify its CRDs.
+2. Enable Kafka Exporter and verify its `/metrics` endpoint.
+3. Confirm Prometheus scrapes the exporter target.
+4. Run the exact lag query in Prometheus.
+5. Enable `kafkaLag` for one low-risk consumer.
+6. Render the release and verify that it contains one ScaledObject and no
+   chart-managed HPA for the target.
+7. Deploy and observe KEDA operator logs, generated HPA, replica count, lag,
+   consumer rebalances, and processing latency.
+8. Expand to additional consumers after the first workload is stable.
+
+Rollback a workload by setting `autoscaler: hpa`, or disable chart-managed
+autoscaling entirely with `enabled: false`.
+
+## ClickHouse prepare hook
+
+The optional ClickHouse preparation Job runs as a
+`pre-install,pre-upgrade` Helm hook. It is disabled by default.
+
+Its responsibilities are:
+
+1. connect to the configured external ClickHouse endpoint;
+2. verify the configured cluster exists in `system.clusters`;
+3. validate shard count and replicas per shard;
+4. create the Snuba database if it does not exist;
+5. optionally create or alter the configured runtime user;
+6. optionally grant database and cluster privileges;
+7. optionally apply required user settings;
+8. verify runtime settings;
+9. create temporary local and Distributed tables;
+10. insert test rows and verify that all expected shards receive data;
+11. remove the temporary tables.
+
+A failed check exits non-zero and blocks the Helm install or upgrade.
+
+### Credential model
+
+The hook has no separate username or password. It uses the same credentials as
+the rest of the chart:
+
+- `externalClickhouse.username`;
+- `externalClickhouse.password`; or
+- `externalClickhouse.existingSecret` and
+  `externalClickhouse.existingSecretKey`.
+
+The configured account therefore needs every permission required by the
+enabled prepare operations. Use an existing Kubernetes Secret instead of a
+plain password in production.
+
+### Basic configuration
+
+```yaml
+hooks:
+  enabled: true
+  removeOnSuccess: true
+
+externalClickhouse:
+  host: clickhouse.example.svc
+  tcpPort: 9000
+  httpPort: 8123
+  database: sentry
+  username: sentry
+  existingSecret: clickhouse-credentials
+  existingSecretKey: password
+  clusterName: sentry_local
+  distributedClusterName: sentry_distributed
+
+  prepare:
+    enabled: true
+    expectedShards: 2
+    expectedReplicasPerShard: 3
+    backoffLimit: 20
+    activeDeadlineSeconds: 1800
+    ttlSecondsAfterFinished: 3600
+```
+
+`clusterName` is required when the hook is enabled.
+`distributedClusterName` defaults to `clusterName`.
+
+### Runtime user and grants
+
+```yaml
+externalClickhouse:
+  prepare:
+    runtimeUser:
+      enabled: true
+      grantAll: false
+      grantOption: false
+      grants:
+        - SELECT
+        - INSERT
+        - CREATE
+        - ALTER
+        - DROP
+        - TRUNCATE
+        - OPTIMIZE
+      clusterGrants:
+        - CLUSTER
+        - REMOTE
+```
+
+With `grantAll: false`, database grants are applied to
+`externalClickhouse.database`, while cluster grants are applied to `*.*`.
+With `grantAll: true`, the account receives `ALL ON *.*`. Review this mode
+carefully before enabling it.
+
+Because the prepare connection and runtime user are now the same
+`externalClickhouse.username`, enabling `runtimeUser.enabled` makes the Job
+create or alter the account it is currently using. The account must already
+exist and be privileged enough to alter itself, or the connection must be
+accepted by an external authentication configuration. Leave this option
+disabled when the user is managed by a ClickHouse Operator, XML configuration,
+or another identity system.
+
+### Required settings
+
+```yaml
+externalClickhouse:
+  prepare:
+    settings:
+      apply: false
+      verify: true
+      values:
+        insert_distributed_one_random_shard: "1"
+        distributed_foreground_insert: "1"
+        skip_unavailable_shards: "0"
+        load_balancing: random
+```
+
+When `apply: true`, the Job runs `ALTER USER ... SETTINGS`. When
+`verify: true`, it reads `system.settings` through the runtime connection
+and fails if the values differ. If settings are managed externally, leave
+`apply: false` and ensure the expected values are already effective, or
+disable verification deliberately.
+
+### Distributed INSERT test
+
+```yaml
+externalClickhouse:
+  prepare:
+    distributedInsertTest:
+      enabled: true
+      maxBatches: 64
+      rowsPerBatch: 10
+```
+
+The Job creates temporary ReplicatedMergeTree and Distributed tables, inserts
+batches until every expected shard has data, validates total row count, and
+drops the tables on exit. The runtime account needs CREATE, INSERT, SELECT, and
+DROP privileges plus the required cluster access.
+
+Disable this test only when those temporary DDL permissions are intentionally
+unavailable and cluster behavior is verified elsewhere.
+
+### Hook scheduling and Pod customization
+
+The following values are supported:
+
+- `image.repository`, `image.tag`, and `image.pullPolicy`;
+- `resources`;
+- `affinity`, `nodeSelector`, and `tolerations`;
+- Pod and container security contexts;
+- Pod labels and annotations;
+- additional environment variables;
+- sidecars;
+- volumes and volume mounts.
+
+Global selectors, tolerations, sidecars, volumes, and volume mounts are used
+when applicable.
+
+## ClickHouse rollout procedure
+
+1. Verify the ClickHouse account can connect with `clickhouse-client`.
+2. Query `system.clusters` and record cluster names, shards, and replicas.
+3. Set `clusterName`, `distributedClusterName`,
+   `expectedShards`, and `expectedReplicasPerShard`.
+4. Decide whether user management and settings are controlled by Helm or an
+   external operator.
+5. Render the chart and inspect the prepare Job.
+6. Run the Job in a non-production environment.
+7. Review logs and confirm temporary tables are removed.
+8. Enable the hook for production upgrades.
+
+To bypass the hook during an incident, set
+`externalClickhouse.prepare.enabled: false`. Understand that this skips the
+preflight checks; it does not correct the underlying ClickHouse issue.
+
+## Rendering and validation
+
+Recommended static checks:
+
+```console
+helm dependency build
+helm lint charts/sentry
+helm template sentry charts/sentry -f values.yaml > rendered.yaml
+```
+
+Check autoscaler exclusivity:
+
+```console
+grep -E '^kind: (HorizontalPodAutoscaler|ScaledObject)$' rendered.yaml
+```
+
+Check the prepare hook:
+
+```console
+grep -n 'clickhouse-prepare' rendered.yaml
+```
+
+A KEDA consumer should have exactly one ScaledObject and no chart-managed HPA.
+The ClickHouse prepare Job should appear only when both `hooks.enabled` and
+`externalClickhouse.prepare.enabled` are true.
+
+## Troubleshooting
+
+### ScaledObject is missing
+
+Verify:
+
+- workload `enabled` is true;
+- `autoscaling.enabled` is true;
+- `autoscaling.autoscaler` is exactly `keda`;
+- the workload profile is enabled;
+- Helm is using the intended values file.
+
+### Both HPA and ScaledObject appear
+
+This should not happen for the migrated workloads. Confirm the HPA is not
+created by another chart, GitOps resource, or a previous release. Remove the
+external HPA owner before enabling KEDA.
+
+### Kafka lag query is empty
+
+Verify:
+
+- Kafka Exporter can reach every broker;
+- Prometheus lists the exporter target as up;
+- metric name is `kafka_consumergroup_lag`;
+- label names are `topic` and `consumergroup`;
+- the consumer group has committed offsets;
+- the Prometheus URL is reachable from the KEDA operator namespace.
+
+### Consumer does not scale down
+
+Inspect persistent lag, partition availability, cooldown period, activation
+threshold, and KEDA-generated HPA behavior. A partition with a permanently
+unavailable offset may keep lag above zero.
+
+### ClickHouse prepare reports wrong topology
+
+Run:
+
+```sql
+SELECT
+  cluster,
+  shard_num,
+  replica_num,
+  host_name
+FROM system.clusters
+ORDER BY cluster, shard_num, replica_num;
+```
+
+Confirm the Helm cluster name and expected counts match the returned topology.
+
+### ClickHouse settings verification fails
+
+Query the effective values using the same account used by the Job:
+
+```sql
+SELECT name, value
+FROM system.settings
+WHERE name IN (
+  'insert_distributed_one_random_shard',
+  'distributed_foreground_insert',
+  'skip_unavailable_shards',
+  'load_balancing'
+);
+```
+
+If settings are profile-managed, update the expected values or leave
+`settings.apply` disabled.
+
+### Distributed INSERT test fails
+
+Check:
+
+- CREATE/DROP/INSERT/SELECT privileges;
+- CLUSTER and REMOTE grants;
+- ZooKeeper or ClickHouse Keeper health;
+- ReplicatedMergeTree paths and macros;
+- distributed cluster name;
+- shard reachability;
+- `skip_unavailable_shards` and load-balancing settings.
+
+## Related files
+
+- `Chart.yaml`: Kafka Exporter dependency.
+- `Chart.lock`: locked dependency version.
+- `values.yaml`: defaults and feature configuration.
+- `templates/_helper-keda.tpl`: autoscaler and trigger rendering.
+- `templates/keda-scaledobjects.yaml`: supported workload mappings.
+- `templates/hooks/clickhouse-prepare.job.yaml`: ClickHouse preflight Job.
+- `docs/keda-scaling.md`: concise KEDA guide.
+- `docs/clickhouse-prepare.md`: concise ClickHouse prepare guide.

--- a/charts/sentry/docs/keda-scaling.md
+++ b/charts/sentry/docs/keda-scaling.md
@@ -117,3 +117,71 @@ relay:
 CPU and memory triggers are supported through `triggers.cpu` and
 `triggers.memory`. If neither Kafka nor Prometheus is enabled, the existing HPA
 CPU/memory targets are used by KEDA.
+
+At least one effective trigger is required. Helm rendering fails when KEDA is
+selected but Kafka, Kafka lag, Prometheus, CPU and memory triggers are all
+disabled. `minReplicas: 0` is preserved and can be used for scale-to-zero when
+the selected KEDA trigger supports activation from zero.
+
+The `autoscaler` value must be exactly `hpa` or `keda`. For KEDA,
+`minReplicas`, `maxReplicas`, `pollingInterval`, and `cooldownPeriod` must be
+integers. Helm also enforces `minReplicas >= 0`, `maxReplicas >= 1`,
+`minReplicas <= maxReplicas`, `pollingInterval >= 1`, and
+`cooldownPeriod >= 0`.
+
+For authenticated native Kafka scalers, reference a separately managed KEDA
+`TriggerAuthentication`:
+
+```yaml
+sentry:
+  ingestConsumerEvents:
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 0
+      triggers:
+        kafka:
+          enabled: true
+          authenticationRef: sentry-kafka-auth
+```
+
+## Connecting newly added consumers
+
+KEDA support is explicit rather than automatic. When the chart gains another
+consumer, such as the uptime-results and Snuba uptime consumers proposed in
+PR #1830, adding its Deployment and values alone does not make it a KEDA scale
+target. The chart change introducing the consumer must also:
+
+1. add an `autoscaling` block with `enabled`, `autoscaler`, replica limits and
+   trigger configuration;
+2. register the values path, Deployment name, Kafka topic and consumer group
+   in `templates/_helper-keda.tpl`;
+3. suppress the static `spec.replicas` value while autoscaling is enabled;
+4. guard any workload-specific HPA with `autoscaler: hpa`;
+5. render tests for HPA, native Kafka, Prometheus Kafka lag and disabled modes.
+
+For an uptime-results consumer using topic and group `uptime-results`, the
+resulting user-facing configuration should follow this shape after that
+consumer is registered by the chart:
+
+```yaml
+sentry:
+  uptimeResults:
+    enabled: true
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 1
+      maxReplicas: 10
+      triggers:
+        kafkaLag:
+          enabled: true
+          topic: uptime-results
+          consumerGroup: uptime-results
+```
+
+The corresponding Snuba consumer should use its actual Kafka topic and
+consumer group from the Deployment command. Do not copy the example values
+blindly: verify both labels in Kafka Exporter metrics first. The same
+registration rule applies to renamed consumers, because the ScaledObject's
+`scaleTargetRef.name` must exactly match the rendered Deployment name.

--- a/charts/sentry/docs/keda-scaling.md
+++ b/charts/sentry/docs/keda-scaling.md
@@ -1,0 +1,119 @@
+# KEDA autoscaling
+
+This chart can render KEDA `ScaledObject` resources for selected workloads. The
+KEDA operator and CRDs must already be installed in the cluster. An optional
+`prometheus-kafka-exporter` subchart exposes Kafka consumer-group lag metrics.
+
+Autoscaling remains backward compatible: `autoscaler: hpa` is the default. Set
+`autoscaler: keda` on an enabled workload to replace its chart-managed HPA with
+a `ScaledObject`.
+
+Supported workloads are Relay, Sentry Web, Vroom, Snuba API, the attachments,
+events, transactions and occurrences ingest consumers, and every configured
+Sentry Taskworker.
+
+Global trigger defaults can be configured under `global.autoscaling.triggers`.
+Workload trigger values take precedence over global values.
+
+## Kafka lag through kafka-exporter
+
+Enable the exporter and configure the Kafka brokers it should query. Prometheus
+must scrape the exporter Service; enable its ServiceMonitor when using the
+Prometheus Operator.
+
+```yaml
+kafkaExporter:
+  enabled: true
+  kafkaServer:
+    - sentry-kafka:9092
+  prometheus:
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      additionalLabels:
+        release: kube-prometheus-stack
+
+global:
+  autoscaling:
+    triggers:
+      kafkaLag:
+        serverAddress: http://prometheus-operated.monitoring.svc:9090
+        metricName: kafka_consumergroup_lag
+        threshold: "1000"
+        activationThreshold: "10"
+
+sentry:
+  ingestConsumerEvents:
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 1
+      maxReplicas: 35
+      triggers:
+        kafkaLag:
+          enabled: true
+```
+
+The chart derives the known Kafka topic and consumer group from the workload.
+Both can be overridden with `topic` and `consumerGroup` in `kafkaLag`. The
+generated PromQL query is equivalent to:
+
+```promql
+sum(kafka_consumergroup_lag{topic="ingest-events",consumergroup="ingest-consumer"})
+```
+
+The metric and its `topic` and `consumergroup` labels must be present in the
+Prometheus instance referenced by `serverAddress`.
+
+## Native Kafka scaler
+
+The native KEDA Kafka scaler remains available as an alternative:
+
+```yaml
+global:
+  autoscaling:
+    pollingInterval: 30
+    cooldownPeriod: 300
+    triggers:
+      kafka:
+        lagThreshold: "1000"
+        activationLagThreshold: "0"
+        offsetResetPolicy: latest
+
+sentry:
+  ingestConsumerEvents:
+    autoscaling:
+      enabled: true
+      autoscaler: keda
+      minReplicas: 1
+      maxReplicas: 10
+      triggers:
+        kafka:
+          enabled: true
+```
+
+Its Kafka bootstrap servers, topic and consumer group default to the chart's
+Kafka configuration and the workload's known topic/group. They can be
+overridden under the workload trigger.
+
+Relay can use a Prometheus trigger:
+
+```yaml
+relay:
+  autoscaling:
+    enabled: true
+    autoscaler: keda
+    minReplicas: 2
+    maxReplicas: 10
+    triggers:
+      prometheus:
+        enabled: true
+        serverAddress: http://prometheus.monitoring.svc:9090
+        query: sum(rate(relay_buffer_envelope_body_size_count[2m])) or vector(0)
+        threshold: "30"
+        activationThreshold: "5"
+```
+
+CPU and memory triggers are supported through `triggers.cpu` and
+`triggers.memory`. If neither Kafka nor Prometheus is enabled, the existing HPA
+CPU/memory targets are used by KEDA.

--- a/charts/sentry/templates/_helper-keda.tpl
+++ b/charts/sentry/templates/_helper-keda.tpl
@@ -1,0 +1,151 @@
+{{/* Select the chart-managed autoscaler for a workload. */}}
+{{- define "sentry.autoscaling.isHpa" -}}
+{{- $autoscaling := default dict .autoscaling -}}
+{{- if and $autoscaling.enabled (eq (default "hpa" $autoscaling.autoscaler) "hpa") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "sentry.autoscaling.isKeda" -}}
+{{- $autoscaling := default dict .autoscaling -}}
+{{- if and $autoscaling.enabled (eq (default "hpa" $autoscaling.autoscaler) "keda") -}}true{{- end -}}
+{{- end -}}
+
+{{/* Hook annotations shared by ScaledObjects whose target is a hook workload. */}}
+{{- define "sentry.keda.annotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name | quote }}
+meta.helm.sh/release-namespace: {{ .Release.Namespace | quote }}
+"helm.sh/hook": "post-install,post-upgrade"
+"helm.sh/hook-weight": "25"
+"helm.sh/hook-delete-policy": "before-hook-creation"
+{{- end -}}
+
+{{/* Build a PromQL query for consumer-group lag exported by kafka_exporter. */}}
+{{- define "sentry.keda.kafkaExporterLagQuery" -}}
+{{- $metricName := default "kafka_consumergroup_lag" .metricName -}}
+{{- printf "sum(%s{topic=%q,consumergroup=%q})" $metricName .topic .consumerGroup -}}
+{{- end -}}
+
+{{/* Render a KEDA ScaledObject for a Deployment-backed workload. */}}
+{{- define "sentry.autoscaling.scaledObject" -}}
+{{- $root := .root -}}
+{{- $autoscaling := default dict .autoscaling -}}
+{{- $globalAutoscaling := default dict $root.Values.global.autoscaling -}}
+{{- $globalTriggers := default dict $globalAutoscaling.triggers -}}
+{{- $triggers := default dict $autoscaling.triggers -}}
+{{- $kafka := mergeOverwrite (deepCopy (default dict $globalTriggers.kafka)) (deepCopy (default dict $triggers.kafka)) -}}
+{{- $kafkaLag := mergeOverwrite (deepCopy (default dict $globalTriggers.kafkaLag)) (deepCopy (default dict $triggers.kafkaLag)) -}}
+{{- $prometheus := mergeOverwrite (deepCopy (default dict $globalTriggers.prometheus)) (deepCopy (default dict $triggers.prometheus)) -}}
+{{- $cpu := default dict $triggers.cpu -}}
+{{- $memory := default dict $triggers.memory -}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ template "sentry.fullname" $root }}-{{ default .name .scaledObjectName }}
+  {{- if .hook }}
+  annotations:
+{{ include "sentry.keda.annotations" $root | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "sentry.component.labels" (dict "component" .component "ctx" $root) | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "sentry.fullname" $root }}-{{ .targetName }}
+  pollingInterval: {{ default (default 30 $globalAutoscaling.pollingInterval) $autoscaling.pollingInterval }}
+  cooldownPeriod: {{ default (default 300 $globalAutoscaling.cooldownPeriod) $autoscaling.cooldownPeriod }}
+  minReplicaCount: {{ default 1 $autoscaling.minReplicas }}
+  maxReplicaCount: {{ default 3 $autoscaling.maxReplicas }}
+  {{- with $autoscaling.advanced }}
+  advanced:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  triggers:
+    {{- if $kafkaLag.enabled }}
+    - type: prometheus
+      metadata:
+        serverAddress: {{ required (printf "%s.autoscaling.triggers.kafkaLag.serverAddress is required" .valuePath) $kafkaLag.serverAddress | quote }}
+        query: {{ include "sentry.keda.kafkaExporterLagQuery" (dict "metricName" $kafkaLag.metricName "topic" (required (printf "%s.autoscaling.triggers.kafkaLag.topic is required" .valuePath) (default .kafkaTopic $kafkaLag.topic)) "consumerGroup" (required (printf "%s.autoscaling.triggers.kafkaLag.consumerGroup is required" .valuePath) (default .kafkaConsumerGroup $kafkaLag.consumerGroup))) | quote }}
+        threshold: {{ default "1000" $kafkaLag.threshold | quote }}
+        activationThreshold: {{ default "0" $kafkaLag.activationThreshold | quote }}
+        {{- with $kafkaLag.namespace }}
+        namespace: {{ . | quote }}
+        {{- end }}
+        {{- with $kafkaLag.customHeaders }}
+        customHeaders: {{ . | quote }}
+        {{- end }}
+        {{- with $kafkaLag.ignoreNullValues }}
+        ignoreNullValues: {{ . | quote }}
+        {{- end }}
+        {{- with $kafkaLag.unsafeSsl }}
+        unsafeSsl: {{ . | quote }}
+        {{- end }}
+      {{- with $kafkaLag.authenticationRef }}
+      authenticationRef:
+        name: {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if $prometheus.enabled }}
+    - type: prometheus
+      metadata:
+        serverAddress: {{ required (printf "%s.autoscaling.triggers.prometheus.serverAddress is required" .valuePath) $prometheus.serverAddress | quote }}
+        query: {{ required (printf "%s.autoscaling.triggers.prometheus.query is required" .valuePath) $prometheus.query | quote }}
+        threshold: {{ default "100" $prometheus.threshold | quote }}
+        {{- with $prometheus.activationThreshold }}
+        activationThreshold: {{ . | quote }}
+        {{- end }}
+        {{- with $prometheus.namespace }}
+        namespace: {{ . | quote }}
+        {{- end }}
+        {{- with $prometheus.customHeaders }}
+        customHeaders: {{ . | quote }}
+        {{- end }}
+        {{- with $prometheus.ignoreNullValues }}
+        ignoreNullValues: {{ . | quote }}
+        {{- end }}
+        {{- with $prometheus.queryParameters }}
+        queryParameters: {{ . | quote }}
+        {{- end }}
+        {{- with $prometheus.unsafeSsl }}
+        unsafeSsl: {{ . | quote }}
+        {{- end }}
+      {{- with $prometheus.authenticationRef }}
+      authenticationRef:
+        name: {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if $kafka.enabled }}
+    - type: kafka
+      metadata:
+        bootstrapServers: {{ default (include "sentry.kafka.bootstrap_servers_string" $root) $kafka.bootstrapServers | quote }}
+        topic: {{ required (printf "%s.autoscaling.triggers.kafka.topic is required" .valuePath) (default .kafkaTopic $kafka.topic) | quote }}
+        consumerGroup: {{ required (printf "%s.autoscaling.triggers.kafka.consumerGroup is required" .valuePath) (default .kafkaConsumerGroup $kafka.consumerGroup) | quote }}
+        lagThreshold: {{ default "1000" $kafka.lagThreshold | quote }}
+        activationLagThreshold: {{ default "0" $kafka.activationLagThreshold | quote }}
+        offsetResetPolicy: {{ default "latest" $kafka.offsetResetPolicy | quote }}
+        {{- range $key := list "allowIdleConsumers" "scaleToZeroOnInvalidOffset" "excludePersistentLag" "limitToPartitionsWithLag" "version" "partitionLimitation" "sasl" "tls" "unsafeSsl" }}
+        {{- if hasKey $kafka $key }}
+        {{ $key }}: {{ get $kafka $key | quote }}
+        {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- if or $cpu.enabled (and (not $kafka.enabled) (not $kafkaLag.enabled) (not $prometheus.enabled) (not (hasKey $triggers "cpu")) $autoscaling.targetCPUUtilizationPercentage) }}
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ default $autoscaling.targetCPUUtilizationPercentage $cpu.value | quote }}
+    {{- end }}
+    {{- if or $memory.enabled (and (not $kafka.enabled) (not $kafkaLag.enabled) (not $prometheus.enabled) (not (hasKey $triggers "memory")) $autoscaling.targetMemoryUtilizationPercentage) }}
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: {{ default $autoscaling.targetMemoryUtilizationPercentage $memory.value | quote }}
+    {{- end }}
+{{- end -}}
+
+{{/* Place a ScaledObject next to its owning Deployment. */}}
+{{- define "sentry.autoscaling.forDeployment" -}}
+{{- if and .enabled (include "sentry.autoscaling.isKeda" (dict "autoscaling" .values.autoscaling)) }}
+---
+{{ include "sentry.autoscaling.scaledObject" (dict "root" .root "autoscaling" .values.autoscaling "name" .name "scaledObjectName" .scaledObjectName "targetName" .targetName "component" .component "valuePath" .valuePath "kafkaTopic" .kafkaTopic "kafkaConsumerGroup" .kafkaConsumerGroup "hook" .hook) }}
+{{- end }}
+{{- end -}}

--- a/charts/sentry/templates/_helper-keda.tpl
+++ b/charts/sentry/templates/_helper-keda.tpl
@@ -1,11 +1,24 @@
 {{/* Select the chart-managed autoscaler for a workload. */}}
+{{- define "sentry.autoscaling.validate" -}}
+{{- $autoscaling := default dict .autoscaling -}}
+{{- $valuePath := default "workload" .valuePath -}}
+{{- if $autoscaling.enabled -}}
+{{- $autoscaler := default "hpa" $autoscaling.autoscaler -}}
+{{- if not (has $autoscaler (list "hpa" "keda")) -}}
+{{- fail (printf "%s.autoscaling.autoscaler must be one of: hpa, keda (got %q)" $valuePath $autoscaler) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "sentry.autoscaling.isHpa" -}}
 {{- $autoscaling := default dict .autoscaling -}}
+{{- include "sentry.autoscaling.validate" . -}}
 {{- if and $autoscaling.enabled (eq (default "hpa" $autoscaling.autoscaler) "hpa") -}}true{{- end -}}
 {{- end -}}
 
 {{- define "sentry.autoscaling.isKeda" -}}
 {{- $autoscaling := default dict .autoscaling -}}
+{{- include "sentry.autoscaling.validate" . -}}
 {{- if and $autoscaling.enabled (eq (default "hpa" $autoscaling.autoscaler) "keda") -}}true{{- end -}}
 {{- end -}}
 
@@ -36,6 +49,56 @@ meta.helm.sh/release-namespace: {{ .Release.Namespace | quote }}
 {{- $prometheus := mergeOverwrite (deepCopy (default dict $globalTriggers.prometheus)) (deepCopy (default dict $triggers.prometheus)) -}}
 {{- $cpu := default dict $triggers.cpu -}}
 {{- $memory := default dict $triggers.memory -}}
+{{- $cpuFallback := and (not $kafka.enabled) (not $kafkaLag.enabled) (not $prometheus.enabled) (not (hasKey $triggers "cpu")) $autoscaling.targetCPUUtilizationPercentage -}}
+{{- $memoryFallback := and (not $kafka.enabled) (not $kafkaLag.enabled) (not $prometheus.enabled) (not (hasKey $triggers "memory")) $autoscaling.targetMemoryUtilizationPercentage -}}
+{{- $cpuEnabled := or $cpu.enabled $cpuFallback -}}
+{{- $memoryEnabled := or $memory.enabled $memoryFallback -}}
+{{- if not (or $kafka.enabled $kafkaLag.enabled $prometheus.enabled $cpuEnabled $memoryEnabled) -}}
+{{- fail (printf "%s.autoscaling must enable at least one KEDA trigger" .valuePath) -}}
+{{- end -}}
+{{- $minReplicas := 1 -}}
+{{- if hasKey $autoscaling "minReplicas" -}}
+{{- $minReplicas = $autoscaling.minReplicas -}}
+{{- end -}}
+{{- $maxReplicas := 3 -}}
+{{- if hasKey $autoscaling "maxReplicas" -}}
+{{- $maxReplicas = $autoscaling.maxReplicas -}}
+{{- end -}}
+{{- $pollingInterval := 30 -}}
+{{- if hasKey $globalAutoscaling "pollingInterval" -}}
+{{- $pollingInterval = $globalAutoscaling.pollingInterval -}}
+{{- end -}}
+{{- if hasKey $autoscaling "pollingInterval" -}}
+{{- $pollingInterval = $autoscaling.pollingInterval -}}
+{{- end -}}
+{{- $cooldownPeriod := 300 -}}
+{{- if hasKey $globalAutoscaling "cooldownPeriod" -}}
+{{- $cooldownPeriod = $globalAutoscaling.cooldownPeriod -}}
+{{- end -}}
+{{- if hasKey $autoscaling "cooldownPeriod" -}}
+{{- $cooldownPeriod = $autoscaling.cooldownPeriod -}}
+{{- end -}}
+{{- if not (regexMatch "^[0-9]+$" (toString $minReplicas)) -}}
+{{- fail (printf "%s.autoscaling.minReplicas must be a non-negative integer" .valuePath) -}}
+{{- end -}}
+{{- if not (regexMatch "^[0-9]+$" (toString $maxReplicas)) -}}
+{{- fail (printf "%s.autoscaling.maxReplicas must be a positive integer" .valuePath) -}}
+{{- end -}}
+{{- if lt (int $maxReplicas) 1 -}}
+{{- fail (printf "%s.autoscaling.maxReplicas must be at least 1" .valuePath) -}}
+{{- end -}}
+{{- if gt (int $minReplicas) (int $maxReplicas) -}}
+{{- fail (printf "%s.autoscaling.minReplicas must not exceed maxReplicas" .valuePath) -}}
+{{- end -}}
+{{- if not (regexMatch "^[0-9]+$" (toString $pollingInterval)) -}}
+{{- fail (printf "%s.autoscaling.pollingInterval must be a positive integer" .valuePath) -}}
+{{- end -}}
+{{- if lt (int $pollingInterval) 1 -}}
+{{- fail (printf "%s.autoscaling.pollingInterval must be at least 1" .valuePath) -}}
+{{- end -}}
+{{- if not (regexMatch "^[0-9]+$" (toString $cooldownPeriod)) -}}
+{{- fail (printf "%s.autoscaling.cooldownPeriod must be a non-negative integer" .valuePath) -}}
+{{- end -}}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -51,10 +114,10 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "sentry.fullname" $root }}-{{ .targetName }}
-  pollingInterval: {{ default (default 30 $globalAutoscaling.pollingInterval) $autoscaling.pollingInterval }}
-  cooldownPeriod: {{ default (default 300 $globalAutoscaling.cooldownPeriod) $autoscaling.cooldownPeriod }}
-  minReplicaCount: {{ default 1 $autoscaling.minReplicas }}
-  maxReplicaCount: {{ default 3 $autoscaling.maxReplicas }}
+  pollingInterval: {{ $pollingInterval }}
+  cooldownPeriod: {{ $cooldownPeriod }}
+  minReplicaCount: {{ $minReplicas }}
+  maxReplicaCount: {{ $maxReplicas }}
   {{- with $autoscaling.advanced }}
   advanced:
     {{- toYaml . | nindent 4 }}
@@ -73,11 +136,11 @@ spec:
         {{- with $kafkaLag.customHeaders }}
         customHeaders: {{ . | quote }}
         {{- end }}
-        {{- with $kafkaLag.ignoreNullValues }}
-        ignoreNullValues: {{ . | quote }}
+        {{- if hasKey $kafkaLag "ignoreNullValues" }}
+        ignoreNullValues: {{ get $kafkaLag "ignoreNullValues" | quote }}
         {{- end }}
-        {{- with $kafkaLag.unsafeSsl }}
-        unsafeSsl: {{ . | quote }}
+        {{- if hasKey $kafkaLag "unsafeSsl" }}
+        unsafeSsl: {{ get $kafkaLag "unsafeSsl" | quote }}
         {{- end }}
       {{- with $kafkaLag.authenticationRef }}
       authenticationRef:
@@ -99,14 +162,14 @@ spec:
         {{- with $prometheus.customHeaders }}
         customHeaders: {{ . | quote }}
         {{- end }}
-        {{- with $prometheus.ignoreNullValues }}
-        ignoreNullValues: {{ . | quote }}
+        {{- if hasKey $prometheus "ignoreNullValues" }}
+        ignoreNullValues: {{ get $prometheus "ignoreNullValues" | quote }}
         {{- end }}
         {{- with $prometheus.queryParameters }}
         queryParameters: {{ . | quote }}
         {{- end }}
-        {{- with $prometheus.unsafeSsl }}
-        unsafeSsl: {{ . | quote }}
+        {{- if hasKey $prometheus "unsafeSsl" }}
+        unsafeSsl: {{ get $prometheus "unsafeSsl" | quote }}
         {{- end }}
       {{- with $prometheus.authenticationRef }}
       authenticationRef:
@@ -127,14 +190,18 @@ spec:
         {{ $key }}: {{ get $kafka $key | quote }}
         {{- end }}
         {{- end }}
+      {{- with $kafka.authenticationRef }}
+      authenticationRef:
+        name: {{ . | quote }}
+      {{- end }}
     {{- end }}
-    {{- if or $cpu.enabled (and (not $kafka.enabled) (not $kafkaLag.enabled) (not $prometheus.enabled) (not (hasKey $triggers "cpu")) $autoscaling.targetCPUUtilizationPercentage) }}
+    {{- if $cpuEnabled }}
     - type: cpu
       metricType: Utilization
       metadata:
         value: {{ default $autoscaling.targetCPUUtilizationPercentage $cpu.value | quote }}
     {{- end }}
-    {{- if or $memory.enabled (and (not $kafka.enabled) (not $kafkaLag.enabled) (not $prometheus.enabled) (not (hasKey $triggers "memory")) $autoscaling.targetMemoryUtilizationPercentage) }}
+    {{- if $memoryEnabled }}
     - type: memory
       metricType: Utilization
       metadata:
@@ -144,7 +211,7 @@ spec:
 
 {{/* Place a ScaledObject next to its owning Deployment. */}}
 {{- define "sentry.autoscaling.forDeployment" -}}
-{{- if and .enabled (include "sentry.autoscaling.isKeda" (dict "autoscaling" .values.autoscaling)) }}
+{{- if and .enabled (include "sentry.autoscaling.isKeda" (dict "autoscaling" .values.autoscaling "valuePath" .valuePath)) }}
 ---
 {{ include "sentry.autoscaling.scaledObject" (dict "root" .root "autoscaling" .values.autoscaling "name" .name "scaledObjectName" .scaledObjectName "targetName" .targetName "component" .component "valuePath" .valuePath "kafkaTopic" .kafkaTopic "kafkaConsumerGroup" .kafkaConsumerGroup "hook" .hook) }}
 {{- end }}

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -178,7 +178,22 @@ If release name contains chart name it will be used as a full name.
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
 {{- end -}}
+{{- end -}}
+
+{{/*
+Build and validate a first-party Service name. Kubernetes Service names are
+DNS labels and must not exceed 63 characters.
+
+Arguments: root (chart context), suffix (component-specific suffix).
+*/}}
+{{- define "sentry.serviceName" -}}
+{{- $name := printf "%s-%s" (include "sentry.fullname" .root) .suffix -}}
+{{- if gt (len $name) 63 -}}
+{{- fail (printf "generated Service name %q is %d characters; Kubernetes allows at most 63. Shorten the Helm release name or set fullnameOverride" $name (len $name)) -}}
+{{- end -}}
+{{- $name -}}
 {{- end -}}
 
 

--- a/charts/sentry/templates/geoip/deployment-geoip-job.yaml
+++ b/charts/sentry/templates/geoip/deployment-geoip-job.yaml
@@ -15,7 +15,7 @@ spec:
       {{- end }}
     spec:
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-geoip
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-geoip{{ end }}
       {{- end }}
       {{- if .Values.geodata.nodeSelector }}
       nodeSelector:

--- a/charts/sentry/templates/geoip/serviceaccount-geoip.yaml
+++ b/charts/sentry/templates/geoip/serviceaccount-geoip.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.geodata.accountID .Values.serviceAccount.enabled }}
+{{- if and .Values.geodata.accountID .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/hooks/clickhouse-prepare-serviceaccount.yaml
+++ b/charts/sentry/templates/hooks/clickhouse-prepare-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.hooks.enabled .Values.externalClickhouse.prepare.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sentry.fullname" . }}-clickhouse-prepare
+  labels:
+    {{- include "sentry.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    {{- with .Values.externalClickhouse.prepare.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.externalClickhouse.prepare.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sentry/templates/hooks/clickhouse-prepare.job.yaml
+++ b/charts/sentry/templates/hooks/clickhouse-prepare.job.yaml
@@ -34,6 +34,7 @@ spec:
 {{ toYaml .Values.externalClickhouse.prepare.podLabels | indent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ template "sentry.fullname" . }}-clickhouse-prepare
       restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
       {{- if .Values.externalClickhouse.prepare.affinity }}
       affinity:

--- a/charts/sentry/templates/hooks/clickhouse-prepare.job.yaml
+++ b/charts/sentry/templates/hooks/clickhouse-prepare.job.yaml
@@ -1,0 +1,347 @@
+{{- if and .Values.hooks.enabled .Values.externalClickhouse.prepare.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sentry.fullname" . }}-clickhouse-prepare
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "{{ if .Values.hooks.removeOnSuccess }}hook-succeeded,{{ end }}before-hook-creation"
+    "helm.sh/hook-weight": "0"
+spec:
+  backoffLimit: {{ .Values.externalClickhouse.prepare.backoffLimit }}
+  {{- if .Values.externalClickhouse.prepare.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.externalClickhouse.prepare.activeDeadlineSeconds }}
+  {{- end }}
+  {{- if .Values.externalClickhouse.prepare.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.externalClickhouse.prepare.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      name: {{ template "sentry.fullname" . }}-clickhouse-prepare
+      {{- if .Values.externalClickhouse.prepare.podAnnotations }}
+      annotations:
+{{ toYaml .Values.externalClickhouse.prepare.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        app: sentry
+        release: "{{ .Release.Name }}"
+        {{- if .Values.externalClickhouse.prepare.podLabels }}
+{{ toYaml .Values.externalClickhouse.prepare.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: {{ .Values.hooks.restartPolicy | default "Never" }}
+      {{- if .Values.externalClickhouse.prepare.affinity }}
+      affinity:
+{{ toYaml .Values.externalClickhouse.prepare.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.externalClickhouse.prepare.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.externalClickhouse.prepare.nodeSelector | indent 8 }}
+      {{- else if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.externalClickhouse.prepare.tolerations }}
+      tolerations:
+{{ toYaml .Values.externalClickhouse.prepare.tolerations | indent 8 }}
+      {{- else if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.snuba.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.snuba.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.externalClickhouse.prepare.securityContext }}
+      securityContext:
+{{ toYaml .Values.externalClickhouse.prepare.securityContext | indent 8 }}
+      {{- else if .Values.hooks.securityContext }}
+      securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: clickhouse-prepare
+        image: {{ .Values.externalClickhouse.prepare.image.repository }}:{{ .Values.externalClickhouse.prepare.image.tag }}
+        imagePullPolicy: {{ .Values.externalClickhouse.prepare.image.pullPolicy }}
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - |
+            set -euo pipefail
+
+            log() {
+              echo "[$(date -Iseconds)] $*"
+            }
+
+            query() {
+              clickhouse-client "${ADMIN_CH_ARGS[@]}" --query="$1"
+            }
+
+            test_query() {
+              clickhouse-client "${RUNTIME_CH_ARGS[@]}" --query="$1"
+            }
+
+            query_value() {
+              query "$1" | tr -d '\r'
+            }
+
+            test_query_value() {
+              test_query "$1" | tr -d '\r'
+            }
+
+            quote_ident() {
+              local value="$1"
+              value="${value//\`/\`\`}"
+              printf '`%s`' "$value"
+            }
+
+            quote_string() {
+              local value="$1"
+              local escaped
+              escaped="$(printf "%s" "$value" | sed "s/'/''/g")"
+              printf "'%s'" "$escaped"
+            }
+
+            ADMIN_CH_ARGS=(
+              --host="$CLICKHOUSE_HOST"
+              --port="$CLICKHOUSE_PORT"
+              --user="$CLICKHOUSE_ADMIN_USER"
+              --database="$CLICKHOUSE_DATABASE"
+            )
+            if [ -n "${CLICKHOUSE_ADMIN_PASSWORD:-}" ]; then
+              ADMIN_CH_ARGS+=(--password="$CLICKHOUSE_ADMIN_PASSWORD")
+            fi
+
+            RUNTIME_CH_ARGS=(
+              --host="$CLICKHOUSE_HOST"
+              --port="$CLICKHOUSE_PORT"
+              --user="$CLICKHOUSE_RUNTIME_USER"
+              --database="$CLICKHOUSE_DATABASE"
+            )
+            if [ -n "${CLICKHOUSE_RUNTIME_PASSWORD:-}" ]; then
+              RUNTIME_CH_ARGS+=(--password="$CLICKHOUSE_RUNTIME_PASSWORD")
+            fi
+
+            DB_IDENT="$(quote_ident "$CLICKHOUSE_DATABASE")"
+            RUNTIME_USER_IDENT="$(quote_ident "$CLICKHOUSE_RUNTIME_USER")"
+            RUNTIME_PASSWORD_LITERAL="$(quote_string "${CLICKHOUSE_RUNTIME_PASSWORD:-}")"
+            LOCAL_TABLE="sentry_clickhouse_prepare_local"
+            DIST_TABLE="sentry_clickhouse_prepare_dist"
+            LOCAL_IDENT="$(quote_ident "$LOCAL_TABLE")"
+            DIST_IDENT="$(quote_ident "$DIST_TABLE")"
+
+            log "Preparing ClickHouse for Snuba: host=${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT} database=${CLICKHOUSE_DATABASE} cluster=${CLICKHOUSE_CLUSTER_NAME} distributed_cluster=${CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME}"
+            query "SELECT 1" >/dev/null
+
+            log "Checking ClickHouse cluster topology"
+            ACTUAL_SHARDS="$(query_value "SELECT countDistinct(shard_num) FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER_NAME}'")"
+            ACTUAL_REPLICAS="$(query_value "SELECT count() FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER_NAME}'")"
+            EXPECTED_REPLICAS=$((EXPECTED_SHARDS * EXPECTED_REPLICAS_PER_SHARD))
+
+            if [ "$ACTUAL_SHARDS" != "$EXPECTED_SHARDS" ]; then
+              echo "Unexpected shard count for cluster ${CLICKHOUSE_CLUSTER_NAME}: expected ${EXPECTED_SHARDS}, got ${ACTUAL_SHARDS}" >&2
+              exit 1
+            fi
+
+            if [ "$ACTUAL_REPLICAS" != "$EXPECTED_REPLICAS" ]; then
+              echo "Unexpected replica count for cluster ${CLICKHOUSE_CLUSTER_NAME}: expected ${EXPECTED_REPLICAS}, got ${ACTUAL_REPLICAS}" >&2
+              exit 1
+            fi
+
+            BAD_SHARDS="$(query_value "SELECT count() FROM (SELECT shard_num, count() AS replicas FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER_NAME}' GROUP BY shard_num HAVING replicas != ${EXPECTED_REPLICAS_PER_SHARD})")"
+            if [ "$BAD_SHARDS" != "0" ]; then
+              echo "Cluster ${CLICKHOUSE_CLUSTER_NAME} has shards with unexpected replica counts" >&2
+              query "SELECT shard_num, count() AS replicas FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER_NAME}' GROUP BY shard_num ORDER BY shard_num" >&2
+              exit 1
+            fi
+
+            log "Cluster topology is valid: ${ACTUAL_SHARDS} shards, ${ACTUAL_REPLICAS} replicas"
+
+            query "CREATE DATABASE IF NOT EXISTS ${DB_IDENT}"
+
+            {{- if .Values.externalClickhouse.prepare.runtimeUser.enabled }}
+            log "Creating or updating ClickHouse runtime user ${CLICKHOUSE_RUNTIME_USER}"
+            if [ -n "${CLICKHOUSE_RUNTIME_PASSWORD:-}" ]; then
+              query "CREATE USER IF NOT EXISTS ${RUNTIME_USER_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' IDENTIFIED WITH plaintext_password BY ${RUNTIME_PASSWORD_LITERAL}"
+              query "ALTER USER ${RUNTIME_USER_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' IDENTIFIED WITH plaintext_password BY ${RUNTIME_PASSWORD_LITERAL}"
+            else
+              query "CREATE USER IF NOT EXISTS ${RUNTIME_USER_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' IDENTIFIED WITH no_password"
+              query "ALTER USER ${RUNTIME_USER_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' IDENTIFIED WITH no_password"
+            fi
+            {{- if .Values.externalClickhouse.prepare.runtimeUser.grantAll }}
+            query "GRANT ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' ALL ON *.* TO ${RUNTIME_USER_IDENT}{{ if .Values.externalClickhouse.prepare.runtimeUser.grantOption }} WITH GRANT OPTION{{ end }}"
+            {{- else }}
+            query "GRANT ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' ${CLICKHOUSE_RUNTIME_GRANTS} ON ${DB_IDENT}.* TO ${RUNTIME_USER_IDENT}"
+            {{- if .Values.externalClickhouse.prepare.runtimeUser.clusterGrants }}
+            query "GRANT ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' ${CLICKHOUSE_RUNTIME_CLUSTER_GRANTS} ON *.* TO ${RUNTIME_USER_IDENT}"
+            {{- end }}
+            {{- end }}
+            {{- end }}
+
+            {{- if .Values.externalClickhouse.prepare.settings.apply }}
+            log "Applying required ClickHouse settings to runtime user ${CLICKHOUSE_RUNTIME_USER}"
+            query "ALTER USER ${RUNTIME_USER_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' SETTINGS insert_distributed_one_random_shard = {{ index .Values.externalClickhouse.prepare.settings.values "insert_distributed_one_random_shard" }}, distributed_foreground_insert = {{ index .Values.externalClickhouse.prepare.settings.values "distributed_foreground_insert" }}, skip_unavailable_shards = {{ index .Values.externalClickhouse.prepare.settings.values "skip_unavailable_shards" }}, load_balancing = '{{ index .Values.externalClickhouse.prepare.settings.values "load_balancing" }}'"
+            {{- end }}
+
+            {{- if .Values.externalClickhouse.prepare.settings.verify }}
+            log "Verifying ClickHouse settings for prepare session"
+            check_setting() {
+              local name="$1"
+              local expected="$2"
+              local actual
+              actual="$(test_query_value "SELECT value FROM system.settings WHERE name = '${name}'")"
+              if [ "$actual" != "$expected" ]; then
+                echo "Unexpected setting ${name}: expected ${expected}, got ${actual}" >&2
+                exit 1
+              fi
+            }
+            check_setting "insert_distributed_one_random_shard" "{{ index .Values.externalClickhouse.prepare.settings.values "insert_distributed_one_random_shard" }}"
+            check_setting "distributed_foreground_insert" "{{ index .Values.externalClickhouse.prepare.settings.values "distributed_foreground_insert" }}"
+            check_setting "skip_unavailable_shards" "{{ index .Values.externalClickhouse.prepare.settings.values "skip_unavailable_shards" }}"
+            check_setting "load_balancing" "{{ index .Values.externalClickhouse.prepare.settings.values "load_balancing" }}"
+            {{- end }}
+
+            {{- if .Values.externalClickhouse.prepare.distributedInsertTest.enabled }}
+            log "Running Distributed INSERT smoke test with explicit sharding key"
+            cleanup() {
+              set +e
+              clickhouse-client "${RUNTIME_CH_ARGS[@]}" --query="DROP TABLE IF EXISTS ${DB_IDENT}.${DIST_IDENT} ON CLUSTER '${CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME}' SYNC" >/dev/null 2>&1
+              clickhouse-client "${RUNTIME_CH_ARGS[@]}" --query="DROP TABLE IF EXISTS ${DB_IDENT}.${LOCAL_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' SYNC" >/dev/null 2>&1
+            }
+            trap cleanup EXIT
+            cleanup
+
+            test_query "CREATE TABLE ${DB_IDENT}.${LOCAL_IDENT} ON CLUSTER '${CLICKHOUSE_CLUSTER_NAME}' (id UInt64, marker String, created_at DateTime DEFAULT now()) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/sentry_clickhouse_prepare_local', '{replica}') ORDER BY id"
+            test_query "CREATE TABLE ${DB_IDENT}.${DIST_IDENT} ON CLUSTER '${CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME}' AS ${DB_IDENT}.${LOCAL_IDENT} ENGINE = Distributed('${CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME}', '${CLICKHOUSE_DATABASE}', '${LOCAL_TABLE}', id)"
+
+            TOTAL_ROWS=0
+            ACTIVE_SHARDS=0
+            BATCH=0
+            while [ "$BATCH" -lt "$MAX_INSERT_BATCHES" ]; do
+              VALUES=()
+              ROW=0
+              while [ "$ROW" -lt "$ROWS_PER_BATCH" ]; do
+                ID=$((BATCH * ROWS_PER_BATCH + ROW + 1))
+                VALUES+=("(${ID}, 'sentry-clickhouse-prepare')")
+                ROW=$((ROW + 1))
+              done
+              IFS=,
+              test_query "INSERT INTO ${DB_IDENT}.${DIST_IDENT} (id, marker) VALUES ${VALUES[*]}"
+              unset IFS
+              TOTAL_ROWS=$((TOTAL_ROWS + ROWS_PER_BATCH))
+
+              ACTIVE_SHARDS="$(test_query_value "SELECT count() FROM (SELECT shardNum() AS shard, count() AS rows FROM cluster('${CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME}', '${CLICKHOUSE_DATABASE}', '${LOCAL_TABLE}') WHERE marker = 'sentry-clickhouse-prepare' GROUP BY shard HAVING rows > 0)")"
+              if [ "$ACTIVE_SHARDS" = "$EXPECTED_SHARDS" ]; then
+                break
+              fi
+              BATCH=$((BATCH + 1))
+            done
+
+            ACTUAL_ROWS="$(test_query_value "SELECT count() FROM ${DB_IDENT}.${DIST_IDENT} WHERE marker = 'sentry-clickhouse-prepare'")"
+            if [ "$ACTUAL_ROWS" != "$TOTAL_ROWS" ]; then
+              echo "Distributed INSERT row count mismatch: expected ${TOTAL_ROWS}, got ${ACTUAL_ROWS}" >&2
+              exit 1
+            fi
+
+            if [ "$ACTIVE_SHARDS" != "$EXPECTED_SHARDS" ]; then
+              echo "Distributed INSERT did not reach every shard: expected ${EXPECTED_SHARDS}, got ${ACTIVE_SHARDS}" >&2
+              test_query "SELECT shardNum() AS shard, count() AS rows FROM cluster('${CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME}', '${CLICKHOUSE_DATABASE}', '${LOCAL_TABLE}') WHERE marker = 'sentry-clickhouse-prepare' GROUP BY shard ORDER BY shard" >&2
+              exit 1
+            fi
+
+            log "Distributed INSERT smoke test passed: rows=${ACTUAL_ROWS}, active_shards=${ACTIVE_SHARDS}"
+            {{- end }}
+
+            log "ClickHouse prepare completed successfully"
+        env:
+        - name: CLICKHOUSE_HOST
+          value: {{ include "sentry.clickhouse.host" . | quote }}
+        - name: CLICKHOUSE_PORT
+          value: {{ include "sentry.clickhouse.port" . | quote }}
+        - name: CLICKHOUSE_DATABASE
+          value: {{ include "sentry.clickhouse.database" . | quote }}
+        - name: CLICKHOUSE_ADMIN_USER
+          value: {{ include "sentry.clickhouse.username" . | quote }}
+        - name: CLICKHOUSE_RUNTIME_USER
+          value: {{ include "sentry.clickhouse.username" . | quote }}
+        - name: CLICKHOUSE_RUNTIME_GRANTS
+          value: {{ join ", " .Values.externalClickhouse.prepare.runtimeUser.grants | quote }}
+        - name: CLICKHOUSE_RUNTIME_CLUSTER_GRANTS
+          value: {{ join ", " .Values.externalClickhouse.prepare.runtimeUser.clusterGrants | quote }}
+        - name: CLICKHOUSE_CLUSTER_NAME
+          value: {{ include "sentry.clickhouse.cluster.name" . | quote }}
+        - name: CLICKHOUSE_DISTRIBUTED_CLUSTER_NAME
+          value: {{ include "sentry.clickhouse.distributed.cluster.name" . | quote }}
+        - name: EXPECTED_SHARDS
+          value: {{ .Values.externalClickhouse.prepare.expectedShards | quote }}
+        - name: EXPECTED_REPLICAS_PER_SHARD
+          value: {{ .Values.externalClickhouse.prepare.expectedReplicasPerShard | quote }}
+        - name: MAX_INSERT_BATCHES
+          value: {{ .Values.externalClickhouse.prepare.distributedInsertTest.maxBatches | quote }}
+        - name: ROWS_PER_BATCH
+          value: {{ .Values.externalClickhouse.prepare.distributedInsertTest.rowsPerBatch | quote }}
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          {{- if .Values.externalClickhouse.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalClickhouse.existingSecret | quote }}
+              key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey | quote }}
+          {{- else }}
+          value: {{ include "sentry.clickhouse.password" . | quote }}
+          {{- end }}
+        {{- if .Values.externalClickhouse.existingSecret }}
+        - name: CLICKHOUSE_RUNTIME_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalClickhouse.existingSecret | quote }}
+              key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey | quote }}
+        {{- else if .Values.externalClickhouse.password }}
+        - name: CLICKHOUSE_RUNTIME_PASSWORD
+          value: {{ include "sentry.clickhouse.password" . | quote }}
+        {{- end }}
+{{- if .Values.externalClickhouse.prepare.env }}
+{{ toYaml .Values.externalClickhouse.prepare.env | indent 8 }}
+{{- end }}
+{{- if or .Values.externalClickhouse.prepare.volumeMounts .Values.global.volumeMounts }}
+        volumeMounts:
+{{- end }}
+{{- if .Values.externalClickhouse.prepare.volumeMounts }}
+{{ toYaml .Values.externalClickhouse.prepare.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.global.volumeMounts }}
+{{ toYaml .Values.global.volumeMounts | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.externalClickhouse.prepare.resources | indent 10 }}
+{{- if .Values.externalClickhouse.prepare.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.externalClickhouse.prepare.containerSecurityContext | indent 10 }}
+{{- end }}
+{{- if .Values.externalClickhouse.prepare.sidecars }}
+{{ toYaml .Values.externalClickhouse.prepare.sidecars | indent 6 }}
+{{- end }}
+{{- if .Values.global.sidecars }}
+{{ toYaml .Values.global.sidecars | indent 6 }}
+{{- end }}
+{{- if or .Values.externalClickhouse.prepare.volumes .Values.global.volumes }}
+      volumes:
+{{- end }}
+{{- if .Values.externalClickhouse.prepare.volumes }}
+{{ toYaml .Values.externalClickhouse.prepare.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.global.volumes }}
+{{ toYaml .Values.global.volumes | indent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/sentry/templates/hooks/hooks-serviceaccount.yaml
+++ b/charts/sentry/templates/hooks/hooks-serviceaccount.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.relay.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
+{{- if and .Values.hooks.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}-relay
+  name: {{ .Values.serviceAccount.name }}-hooks
   labels:
-    {{- include "sentry.component.labels" (dict "component" "relay" "ctx" .) | nindent 4 }}
+    {{- include "sentry.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}

--- a/charts/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -37,6 +37,9 @@ spec:
 {{ toYaml .Values.hooks.dbCheck.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-hooks{{ end }}
+      {{- end }}
       {{- if .Values.hooks.dbCheck.affinity }}
       affinity:
 {{ toYaml .Values.hooks.dbCheck.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -33,6 +33,9 @@ spec:
 {{ toYaml .Values.hooks.dbInit.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-hooks{{ end }}
+      {{- end }}
       {{- if .Values.hooks.dbInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.dbInit.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -41,6 +41,9 @@ spec:
 {{ toYaml .Values.hooks.snubaInit.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-hooks{{ end }}
+      {{- end }}
       {{- if .Values.hooks.snubaInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.snubaInit.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/snuba-migrate.job.yaml
+++ b/charts/sentry/templates/hooks/snuba-migrate.job.yaml
@@ -41,6 +41,9 @@ spec:
 {{ toYaml .Values.hooks.snubaMigrate.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-hooks{{ end }}
+      {{- end }}
       {{- if .Values.hooks.snubaMigrate.affinity }}
       affinity:
 {{ toYaml .Values.hooks.snubaMigrate.affinity | indent 8 }}

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -34,6 +34,9 @@ spec:
 {{ toYaml .Values.hooks.dbInit.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-hooks{{ end }}
+      {{- end }}
       {{- if .Values.hooks.dbInit.affinity }}
       affinity:
 {{ toYaml .Values.hooks.dbInit.affinity | indent 8 }}

--- a/charts/sentry/templates/keda-scaledobjects.yaml
+++ b/charts/sentry/templates/keda-scaledobjects.yaml
@@ -1,7 +1,7 @@
 {{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.relay.enabled "values" .Values.relay "name" "relay" "targetName" "relay" "component" "relay" "valuePath" "relay" "hook" .Values.relay.asHook) }}
 {{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.web.enabled "values" .Values.sentry.web "name" "sentry-web" "targetName" "web" "component" "web" "valuePath" "sentry.web" "hook" false) }}
 {{- if has "feature-complete" .Values.profiles }}
-{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" true "values" .Values.vroom "name" "vroom" "targetName" "vroom" "component" "vroom" "valuePath" "vroom" "hook" false) }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.features.enableProfiling "values" .Values.vroom "name" "vroom" "targetName" "vroom" "component" "vroom" "valuePath" "vroom" "hook" false) }}
 {{- end }}
 
 {{- if .Values.sentry.taskWorker.enabled }}

--- a/charts/sentry/templates/keda-scaledobjects.yaml
+++ b/charts/sentry/templates/keda-scaledobjects.yaml
@@ -1,0 +1,27 @@
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.relay.enabled "values" .Values.relay "name" "relay" "targetName" "relay" "component" "relay" "valuePath" "relay" "hook" .Values.relay.asHook) }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.web.enabled "values" .Values.sentry.web "name" "sentry-web" "targetName" "web" "component" "web" "valuePath" "sentry.web" "hook" false) }}
+{{- if has "feature-complete" .Values.profiles }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" true "values" .Values.vroom "name" "vroom" "targetName" "vroom" "component" "vroom" "valuePath" "vroom" "hook" false) }}
+{{- end }}
+
+{{- if .Values.sentry.taskWorker.enabled }}
+{{- $root := . }}
+{{- $taskWorkerAutoscaling := default dict .Values.sentry.taskWorker.autoscaling }}
+{{- range $worker := .Values.sentry.taskWorker.workers }}
+{{- $workerAutoscaling := default dict $worker.autoscaling }}
+{{- $autoscaling := mergeOverwrite (deepCopy $taskWorkerAutoscaling) (deepCopy $workerAutoscaling) }}
+{{- $brokerName := default $worker.name $worker.brokerName }}
+{{- $defaultTopic := ternary "taskworker" (printf "taskworker-%s" $brokerName) (eq $brokerName "default") }}
+{{- $workerKafka := default dict $worker.kafka }}
+{{- $topic := default $defaultTopic $workerKafka.topic }}
+{{- $consumerGroup := default $defaultTopic $workerKafka.consumerGroup }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" $root "enabled" true "values" (dict "autoscaling" $autoscaling) "name" (printf "taskworker-%s" $worker.name) "targetName" (printf "taskworker-%s" $worker.name) "component" (printf "taskworker-%s" $worker.name) "valuePath" (printf "sentry.taskWorker.workers[%s]" $worker.name) "kafkaTopic" $topic "kafkaConsumerGroup" $consumerGroup "hook" $root.Values.asHook) }}
+{{- end }}
+{{- end }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.snuba.api.enabled "values" .Values.snuba.api "name" "snuba-api" "targetName" "snuba-api" "component" "snuba-api" "valuePath" "snuba.api" "hook" false) }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.ingestConsumerAttachments.enabled "values" .Values.sentry.ingestConsumerAttachments "name" "sentry-ingest-consumer-attachments" "targetName" "ingest-consumer-attachments" "component" "ingest-consumer-attachments" "valuePath" "sentry.ingestConsumerAttachments" "kafkaTopic" "ingest-attachments" "kafkaConsumerGroup" "ingest-consumer" "hook" .Values.asHook) }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.ingestConsumerEvents.enabled "values" .Values.sentry.ingestConsumerEvents "name" "sentry-ingest-consumer-events" "targetName" "ingest-consumer-events" "component" "ingest-consumer-events" "valuePath" "sentry.ingestConsumerEvents" "kafkaTopic" "ingest-events" "kafkaConsumerGroup" "ingest-consumer" "hook" .Values.asHook) }}
+{{- if has "feature-complete" .Values.profiles }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.ingestConsumerTransactions.enabled "values" .Values.sentry.ingestConsumerTransactions "name" "sentry-ingest-consumer-transactions" "targetName" "ingest-consumer-transactions" "component" "ingest-consumer-transactions" "valuePath" "sentry.ingestConsumerTransactions" "kafkaTopic" "ingest-transactions" "kafkaConsumerGroup" "ingest-consumer" "hook" .Values.asHook) }}
+{{ include "sentry.autoscaling.forDeployment" (dict "root" . "enabled" .Values.sentry.ingestOccurrences.enabled "values" .Values.sentry.ingestOccurrences "name" "sentry-ingest-occurrences" "targetName" "ingest-occurrences" "component" "ingest-occurrences" "valuePath" "sentry.ingestOccurrences" "kafkaTopic" "ingest-occurrences" "kafkaConsumerGroup" "ingest-occurrences" "hook" .Values.asHook) }}
+{{- end }}

--- a/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/deployment-launchpad-taskworker.yaml
@@ -73,7 +73,7 @@ spec:
       priorityClassName: "{{ .Values.launchpadTaskWorker.priorityClassName }}"
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-launchpad-taskworker
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-launchpad-taskworker{{ end }}
       {{- end }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | quote }}

--- a/charts/sentry/templates/launchpad-taskworker/serviceaccount-launchpad-taskworker.yaml
+++ b/charts/sentry/templates/launchpad-taskworker/serviceaccount-launchpad-taskworker.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "launchpad.enabled" .) "true") .Values.serviceAccount.enabled }}
+{{- if and (eq (include "launchpad.enabled" .) "true") .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/pgbouncer/pgbouncer-service.yaml
+++ b/charts/sentry/templates/pgbouncer/pgbouncer-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" . }}-pgbouncer
+  name: {{ include "sentry.serviceName" (dict "root" . "suffix" "pgbouncer") }}
   labels:
     {{- include "sentry.component.labels" (dict "component" "pgbouncer" "ctx" .) | nindent 4 }}
 spec:

--- a/charts/sentry/templates/relay/deployment-relay.yaml
+++ b/charts/sentry/templates/relay/deployment-relay.yaml
@@ -263,7 +263,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-relay
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-relay{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/relay/hpa-relay.yaml
+++ b/charts/sentry/templates/relay/hpa-relay.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.relay.enabled .Values.relay.autoscaling.enabled }}
+{{- if and .Values.relay.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.relay.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/relay/hpa-relay.yaml
+++ b/charts/sentry/templates/relay/hpa-relay.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.relay.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.relay.autoscaling)) }}
+{{- if and .Values.relay.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.relay.autoscaling "valuePath" "relay")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/relay/service-relay.yaml
+++ b/charts/sentry/templates/relay/service-relay.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" . }}-relay
+  name: {{ include "sentry.serviceName" (dict "root" . "suffix" "relay") }}
   annotations:
     {{- range $key, $value := .Values.relay.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/cronjob-sentry-cleanup.yaml
@@ -156,6 +156,6 @@ spec:
           priorityClassName: "{{ .Values.sentry.cleanup.priorityClassName }}"
           {{- end }}
           {{- if .Values.serviceAccount.enabled }}
-          serviceAccountName: {{ .Values.serviceAccount.name }}-cleanup
+          serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-cleanup{{ end }}
           {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/cleanup/serviceaccount-sentry-cleanup.yaml
+++ b/charts/sentry/templates/sentry/cleanup/serviceaccount-sentry-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -168,7 +168,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-consumer-attachments
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-consumer-attachments{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.ingestConsumerAttachments.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerAttachments.autoscaling)) }}
+{{- if and .Values.sentry.ingestConsumerAttachments.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerAttachments.autoscaling "valuePath" "sentry.ingestConsumerAttachments")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/hpa-ingest-consumer-attachments.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.ingestConsumerAttachments.enabled .Values.sentry.ingestConsumerAttachments.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestConsumerAttachments.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerAttachments.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/attachments/serviceaccount-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/serviceaccount-sentry-ingest-consumer-attachments.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerAttachments.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestConsumerAttachments.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -172,7 +172,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-consumer-events
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-consumer-events{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.ingestConsumerEvents.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerEvents.autoscaling)) }}
+{{- if and .Values.sentry.ingestConsumerEvents.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerEvents.autoscaling "valuePath" "sentry.ingestConsumerEvents")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/hpa-ingest-consumer-events.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.ingestConsumerEvents.enabled .Values.sentry.ingestConsumerEvents.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestConsumerEvents.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerEvents.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/events/serviceaccount-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/serviceaccount-sentry-ingest-consumer-events.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerEvents.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestConsumerEvents.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -150,7 +150,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-feedback
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-feedback{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/serviceaccount-sentry-ingest-feedback.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestFeedback.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestFeedback.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -150,7 +150,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-monitors
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-monitors{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tasks.yaml
@@ -151,7 +151,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-monitors-clock-tasks
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-monitors-clock-tasks{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-monitors-clock-tick.yaml
@@ -151,7 +151,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-monitors-clock-tick
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-monitors-clock-tick{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-ingest-monitors.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestMonitors.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestMonitors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tasks.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTasks.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.monitorsClockTasks.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/serviceaccount-sentry-monitors-clock-tick.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.monitorsClockTick.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.monitorsClockTick.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-occurrences
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-occurrences{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.sentry.ingestOccurrences.enabled .Values.sentry.ingestOccurrences.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestOccurrences.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestOccurrences.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/hpa-ingest-occurrences.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.sentry.ingestOccurrences.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestOccurrences.autoscaling)) }}
+{{- if and .Values.sentry.ingestOccurrences.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestOccurrences.autoscaling "valuePath" "sentry.ingestOccurrences")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/occurrences/serviceaccount-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/serviceaccount-sentry-ingest-occurrences.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestOccurrences.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestOccurrences.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -150,7 +150,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-replay-recordings
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-replay-recordings{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/serviceaccount-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/serviceaccount-sentry-ingest-replay-recordings.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestReplayRecordings.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestReplayRecordings.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -173,7 +173,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-consumer-transactions
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-ingest-consumer-transactions{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.sentry.ingestConsumerTransactions.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerTransactions.autoscaling)) }}
+{{- if and .Values.sentry.ingestConsumerTransactions.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerTransactions.autoscaling "valuePath" "sentry.ingestConsumerTransactions")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/hpa-ingest-consumer-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.sentry.ingestConsumerTransactions.enabled .Values.sentry.ingestConsumerTransactions.autoscaling.enabled }}
+{{- if and .Values.sentry.ingestConsumerTransactions.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.ingestConsumerTransactions.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/ingest/transactions/serviceaccount-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/serviceaccount-sentry-ingest-consumer-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.ingestConsumerTransactions.enabled  }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.ingestConsumerTransactions.enabled  }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -150,7 +150,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-billing-metrics-consumer
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-billing-metrics-consumer{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/metrics/billing/serviceaccount-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/serviceaccount-sentry-billing-metrics-consumer.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.billingMetricsConsumer.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.billingMetricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-metrics.yaml
@@ -139,6 +139,6 @@ spec:
 {{- end }}
 
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-metrics
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-metrics{{ end }}
       {{- end }}
 {{- end }}

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -157,7 +157,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-metrics-consumer
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-metrics-consumer{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -157,7 +157,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-generic-metrics-consumer
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-generic-metrics-consumer{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/metrics/generic/serviceaccount-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/serviceaccount-sentry-generic-metrics-consumer.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.genericMetricsConsumer.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.genericMetricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/service-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/service-metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
- name: {{ template "sentry.fullname" . }}-metrics
+ name: {{ include "sentry.serviceName" (dict "root" . "suffix" "metrics") }}
   {{- if .Values.metrics.service.annotations }}
  annotations: {{ toYaml .Values.metrics.service.annotations | nindent 4 }}
   {{- end }}

--- a/charts/sentry/templates/sentry/metrics/serviceaccount-metrics.yaml
+++ b/charts/sentry/templates/sentry/metrics/serviceaccount-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/metrics/serviceaccount-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/serviceaccount-sentry-metrics-consumer.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.metricsConsumer.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.metricsConsumer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -147,7 +147,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-errors
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-post-process-forwarder-errors{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/serviceaccount-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/serviceaccount-sentry-post-process-forwarder-errors.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardErrors.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.postProcessForwardErrors.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -149,7 +149,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-issue-platform
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-post-process-forwarder-issue-platform{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/serviceaccount-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/serviceaccount-sentry-post-process-forwarder-issue-platform.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardIssuePlatform.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.postProcessForwardIssuePlatform.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -156,7 +156,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-post-process-forwarder-transactions
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-post-process-forwarder-transactions{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/serviceaccount-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/serviceaccount-sentry-post-process-forwarder-transactions.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.postProcessForwardTransactions.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.postProcessForwardTransactions.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -161,7 +161,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-process-segments
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-process-segments{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/process/segments/serviceaccount-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/serviceaccount-sentry-process-segments.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.processSegments.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.processSegments.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -161,7 +161,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-process-spans
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-process-spans{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/process/spans/serviceaccount-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/serviceaccount-sentry-process-spans.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.processSpans.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.processSpans.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/taskbroker/serviceaccount-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/serviceaccount-taskbroker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.taskBroker.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.sentry.taskBroker.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
+++ b/charts/sentry/templates/sentry/taskbroker/statefulset-taskbroker.yaml
@@ -87,7 +87,7 @@ spec:
       priorityClassName: "{{ $root.Values.sentry.taskBroker.priorityClassName }}"
       {{- end }}
       {{- if $root.Values.serviceAccount.enabled }}
-      serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskbroker
+      serviceAccountName: {{ if $root.Values.serviceAccount.shared }}{{ $root.Values.serviceAccount.name }}{{ else }}{{ $root.Values.serviceAccount.name }}-taskbroker{{ end }}
       {{- end }}
       containers:
       - name: taskbroker
@@ -174,7 +174,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" $root }}-taskbroker-{{ $broker.name }}
+  name: {{ include "sentry.serviceName" (dict "root" $root "suffix" (printf "taskbroker-%s" $broker.name)) }}
   labels:
     app: {{ template "sentry.fullname" $root }}
     release: "{{ $root.Release.Name }}"

--- a/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/deployment-taskscheduler.yaml
@@ -74,7 +74,7 @@ spec:
       priorityClassName: "{{ .Values.sentry.taskScheduler.priorityClassName }}"
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-taskscheduler
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-taskscheduler{{ end }}
       {{- end }}
       initContainers:
 {{ include "sentry.initContainer.nodestore-s3" . | indent 6 }}

--- a/charts/sentry/templates/sentry/taskscheduler/serviceaccount-taskscheduler.yaml
+++ b/charts/sentry/templates/sentry/taskscheduler/serviceaccount-taskscheduler.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.taskScheduler.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.sentry.taskScheduler.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/deployment-taskworker.yaml
@@ -85,7 +85,7 @@ spec:
       priorityClassName: "{{ $root.Values.sentry.taskWorker.priorityClassName }}"
       {{- end }}
       {{- if $root.Values.serviceAccount.enabled }}
-      serviceAccountName: {{ $root.Values.serviceAccount.name }}-taskworker
+      serviceAccountName: {{ if $root.Values.serviceAccount.shared }}{{ $root.Values.serviceAccount.name }}{{ else }}{{ $root.Values.serviceAccount.name }}-taskworker{{ end }}
       {{- end }}
       {{- if $root.Values.dnsPolicy }}
       dnsPolicy: {{ $root.Values.dnsPolicy | quote }}

--- a/charts/sentry/templates/sentry/taskworker/hpa-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/hpa-taskworker.yaml
@@ -9,8 +9,12 @@
 {{- else if hasKey $globalAutoscaling "enabled" }}
   {{- $enabled = $globalAutoscaling.enabled }}
 {{- end }}
+{{- $autoscaler := default "hpa" $globalAutoscaling.autoscaler }}
+{{- if hasKey $workerAutoscaling "autoscaler" }}
+  {{- $autoscaler = $workerAutoscaling.autoscaler }}
+{{- end }}
 
-{{- if $enabled }}
+{{- if and $enabled (eq $autoscaler "hpa") }}
 {{- $minReplicas := default $globalAutoscaling.minReplicas $workerAutoscaling.minReplicas }}
 {{- $maxReplicas := default $globalAutoscaling.maxReplicas $workerAutoscaling.maxReplicas }}
 {{- $targetCPU := default $globalAutoscaling.targetCPUUtilizationPercentage $workerAutoscaling.targetCPUUtilizationPercentage }}
@@ -83,4 +87,3 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-

--- a/charts/sentry/templates/sentry/taskworker/serviceaccount-taskworker.yaml
+++ b/charts/sentry/templates/sentry/taskworker/serviceaccount-taskworker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.taskWorker.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.sentry.taskWorker.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -146,7 +146,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-uptime-results
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-uptime-results{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/uptime/serviceaccount-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/serviceaccount-sentry-uptime-results.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.uptimeResults.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.uptimeResults.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/deployment-vroom.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-vroom
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-vroom{{ end }}
       {{- end }}
       volumes:
       {{- if .Values.vroom.persistence.enabled }}

--- a/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.vroom.autoscaling) }}
+{{- if and .Values.sentry.features.enableProfiling (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.vroom.autoscaling "valuePath" "vroom")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/hpa-vroom.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if .Values.vroom.autoscaling.enabled }}
+{{- if include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.vroom.autoscaling) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/vroom/service-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/service-vroom.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" . }}-vroom
+  name: {{ include "sentry.serviceName" (dict "root" . "suffix" "vroom") }}
   annotations:
     {{- range $key, $value := .Values.vroom.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/sentry/templates/sentry/vroom/serviceaccount-sentry-vroom.yaml
+++ b/charts/sentry/templates/sentry/vroom/serviceaccount-sentry-vroom.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableProfiling }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.features.enableProfiling }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/deployment-sentry-web.yaml
@@ -177,7 +177,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-web
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-web{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/sentry/web/hpa-web.yaml
+++ b/charts/sentry/templates/sentry/web/hpa-web.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.web.enabled .Values.sentry.web.autoscaling.enabled }}
+{{- if and .Values.sentry.web.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.web.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/web/hpa-web.yaml
+++ b/charts/sentry/templates/sentry/web/hpa-web.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.web.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.web.autoscaling)) }}
+{{- if and .Values.sentry.web.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.sentry.web.autoscaling "valuePath" "sentry.web")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/sentry/web/service-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/service-sentry-web.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" . }}-web
+  name: {{ include "sentry.serviceName" (dict "root" . "suffix" "web") }}
   annotations:
     {{- range $key, $value := .Values.sentry.web.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/sentry/templates/sentry/web/serviceaccount-sentry-web.yaml
+++ b/charts/sentry/templates/sentry/web/serviceaccount-sentry-web.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.sentry.web.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.web.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/serviceaccount-shared.yaml
+++ b/charts/sentry/templates/serviceaccount-shared.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.relay.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
+{{- if and .Values.serviceAccount.enabled .Values.serviceAccount.shared }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}-relay
+  name: {{ .Values.serviceAccount.name }}
   labels:
-    {{- include "sentry.component.labels" (dict "component" "relay" "ctx" .) | nindent 4 }}
+    {{- include "sentry.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -260,6 +260,6 @@ spec:
           priorityClassName: "{{ .Values.snuba.cleanup.priorityClassName }}"
           {{- end }}
           {{- if .Values.serviceAccount.enabled }}
-          serviceAccountName: {{ .Values.serviceAccount.name }}-clickhouse-cleanup
+          serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-clickhouse-cleanup{{ end }}
           {{- end }}
 {{- end }}

--- a/charts/sentry/templates/snuba/cleanup/serviceaccount-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/serviceaccount-clickhouse-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.enabled .Values.snuba.cleanup.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.snuba.cleanup.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/snuba/deployment-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-api.yaml
@@ -134,7 +134,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -166,7 +166,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -166,7 +166,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-accepted-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-accepted-consumer.yaml
@@ -161,7 +161,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -164,7 +164,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -140,7 +140,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-eap-items.yaml
@@ -138,7 +138,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-events.yaml
@@ -138,7 +138,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-counters.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-distributions.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-gauges.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-generic-metrics-sets.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-metrics.yaml
@@ -140,7 +140,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-subscription-consumer-transactions.yaml
@@ -139,7 +139,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -167,7 +167,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-snuba
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-snuba{{ end }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/sentry/templates/snuba/hpa-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/hpa-snuba-api.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.snuba.api.enabled .Values.snuba.api.autoscaling.enabled }}
+{{- if and .Values.snuba.api.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.snuba.api.autoscaling)) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/snuba/hpa-snuba-api.yaml
+++ b/charts/sentry/templates/snuba/hpa-snuba-api.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.snuba.api.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.snuba.api.autoscaling)) }}
+{{- if and .Values.snuba.api.enabled (include "sentry.autoscaling.isHpa" (dict "autoscaling" .Values.snuba.api.autoscaling "valuePath" "snuba.api")) }}
 apiVersion: {{ template "sentry.autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/sentry/templates/snuba/service-snuba.yaml
+++ b/charts/sentry/templates/snuba/service-snuba.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" . }}-snuba
+  name: {{ include "sentry.serviceName" (dict "root" . "suffix" "snuba") }}
   annotations:
    {{- range $key, $value := .Values.service.annotations }}
      {{ $key }}: {{ $value | quote }}

--- a/charts/sentry/templates/snuba/serviceaccount-snuba.yaml
+++ b/charts/sentry/templates/snuba/serviceaccount-snuba.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.snuba.api.enabled .Values.serviceAccount.enabled }}
+{{- if and .Values.snuba.api.enabled .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/deployment-symbolicator.yaml
@@ -169,7 +169,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-symbolicator-api{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/symbolicator/service-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/service-symbolicator.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sentry.fullname" . }}-symbolicator
+  name: {{ include "sentry.serviceName" (dict "root" . "suffix" "symbolicator") }}
   annotations:
    {{- range $key, $value := .Values.service.annotations }}
      {{ $key }}: {{ $value | quote }}

--- a/charts/sentry/templates/symbolicator/serviceaccount-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/serviceaccount-symbolicator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
+++ b/charts/sentry/templates/symbolicator/statefulset-symbolicator.yaml
@@ -165,7 +165,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-symbolicator-api
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-symbolicator-api{{ end }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/deployment-uptime-checker.yaml
@@ -115,7 +115,7 @@ spec:
 {{ toYaml .Values.global.sidecars | indent 6 }}
 {{- end }}
       {{- if .Values.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}-uptime-checker
+      serviceAccountName: {{ if .Values.serviceAccount.shared }}{{ .Values.serviceAccount.name }}{{ else }}{{ .Values.serviceAccount.name }}-uptime-checker{{ end }}
       {{- end }}
 {{- if or .Values.uptimeChecker.volumes .Values.global.volumes }}
       volumes:

--- a/charts/sentry/templates/uptime-checker/serviceaccount-uptime-checker.yaml
+++ b/charts/sentry/templates/uptime-checker/serviceaccount-uptime-checker.yaml
@@ -1,5 +1,5 @@
 {{- if has "feature-complete" .Values.profiles }}
-{{- if and .Values.serviceAccount.enabled .Values.sentry.features.enableUptime }}
+{{- if and .Values.serviceAccount.enabled (not .Values.serviceAccount.shared) .Values.sentry.features.enableUptime }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sentry/templates/validate.yaml
+++ b/charts/sentry/templates/validate.yaml
@@ -1,0 +1,16 @@
+{{/* Validate Service names rendered by dependency subcharts that do not fail clearly themselves. */}}
+{{- if .Values.redis.enabled -}}
+{{- $redisBase := default (printf "%s-%s" .Release.Name (default "redis" .Values.redis.nameOverride)) .Values.redis.fullnameOverride -}}
+{{- $redisService := printf "%s-replicas" $redisBase -}}
+{{- if gt (len $redisService) 63 -}}
+{{- fail (printf "generated Redis Service name %q is %d characters; Kubernetes allows at most 63. Shorten the Helm release name or set redis.fullnameOverride" $redisService (len $redisService)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- if .Values.postgresql.enabled -}}
+{{- $postgresBase := default (printf "%s-%s" .Release.Name (default "postgresql" .Values.postgresql.nameOverride)) .Values.postgresql.fullnameOverride -}}
+{{- $postgresService := printf "%s-hl" $postgresBase -}}
+{{- if gt (len $postgresService) 63 -}}
+{{- fail (printf "generated PostgreSQL Service name %q is %d characters; Kubernetes allows at most 63 and truncation can cause collisions. Shorten the Helm release name or set postgresql.fullnameOverride" $postgresService (len $postgresService)) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -124,6 +124,10 @@ serviceAccount:
   name: "sentry"
   # serviceAccount.automountServiceAccountToken -- Automount API credentials for a Service Account.
   automountServiceAccountToken: true
+  # serviceAccount.shared -- Use one ServiceAccount named by `serviceAccount.name` for regular first-party components and hooks.
+  # The pre-install ClickHouse prepare hook and dependency subcharts keep dedicated ServiceAccounts.
+  # When `false`, component-specific suffixes such as `-web`, `-snuba`, and `-hooks` are used.
+  shared: false
 
 vroom:
   annotations: {}
@@ -3119,6 +3123,11 @@ externalClickhouse:
       repository: clickhouse/clickhouse-server
       tag: latest
       pullPolicy: IfNotPresent
+    # Dedicated pre-install/pre-upgrade hook ServiceAccount. It is created
+    # before the prepare Job and is independent of the chart-wide ServiceAccount mode.
+    serviceAccount:
+      annotations: {}
+      automountServiceAccountToken: false
     runtimeUser:
       enabled: false
       grantAll: false

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -16,6 +16,37 @@ global:
   volumeMounts: []
   volumes: []
 
+  # Shared KEDA defaults. Workload-level autoscaling values override these.
+  autoscaling:
+    pollingInterval: 30
+    cooldownPeriod: 300
+    triggers:
+      kafka:
+        # bootstrapServers defaults to the chart Kafka configuration.
+        lagThreshold: "1000"
+        activationLagThreshold: "0"
+        offsetResetPolicy: latest
+      # Kafka consumer lag from kafka-exporter, queried through Prometheus.
+      kafkaLag:
+        # serverAddress: http://prometheus.monitoring.svc:9090
+        metricName: kafka_consumergroup_lag
+        threshold: "1000"
+        activationThreshold: "0"
+      prometheus: {}
+
+# Optional prometheus-kafka-exporter subchart. Prometheus must scrape its
+# Service (directly or through the ServiceMonitor) before kafkaLag triggers can
+# be used by KEDA.
+kafkaExporter:
+  enabled: false
+  kafkaServer:
+    - kafka:9092
+  prometheus:
+    serviceMonitor:
+      enabled: false
+      namespace: monitoring
+      additionalLabels: {}
+
 # Profiles correspond to COMPOSE_PROFILES in the original self-hosted docker-compose.yml.
 # https://github.com/getsentry/self-hosted/blob/master/docker-compose.yml
 # When set to errors-only, the chart only deploys components related to processing errors.
@@ -150,6 +181,8 @@ vroom:
 
   autoscaling:
     enabled: false
+    # autoscaler may be "hpa" (default) or "keda".
+    autoscaler: hpa
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
@@ -249,6 +282,8 @@ relay:
   # priorityClassName: ""
   autoscaling:
     enabled: false
+    # autoscaler may be "hpa" (default) or "keda".
+    autoscaler: hpa
     minReplicas: 2
     maxReplicas: 5
     targetCPUUtilizationPercentage: 50
@@ -366,6 +401,8 @@ sentry:
     # logFormat: "human" # human|machine
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
@@ -557,6 +594,11 @@ sentry:
     maxChildTaskCount: 10000
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
+      triggers:
+        kafkaLag:
+          enabled: false
       minReplicas: 1
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
@@ -627,6 +669,11 @@ sentry:
     # the size of the queue
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
+      triggers:
+        kafkaLag:
+          enabled: false
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
@@ -674,6 +721,11 @@ sentry:
     # the size of the queue
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
+      triggers:
+        kafkaLag:
+          enabled: false
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
@@ -721,6 +773,11 @@ sentry:
     # the size of the queue
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
+      triggers:
+        kafkaLag:
+          enabled: false
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
@@ -800,6 +857,11 @@ sentry:
     # the size of the queue
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
+      triggers:
+        kafkaLag:
+          enabled: false
       minReplicas: 1
       maxReplicas: 3
       targetCPUUtilizationPercentage: 50
@@ -1341,6 +1403,8 @@ snuba:
 
     autoscaling:
       enabled: false
+      # autoscaler may be "hpa" (default) or "keda".
+      autoscaler: hpa
       minReplicas: 2
       maxReplicas: 5
       targetCPUUtilizationPercentage: 50
@@ -3042,6 +3106,58 @@ externalClickhouse:
   ## Use this when your ClickHouse distributed queries need a different cluster name
   ##
   # distributedClusterName: distributed_test_shard_localhost
+  prepare:
+    # Run a pre-install/pre-upgrade Job that validates the cluster, optionally
+    # provisions the Snuba runtime user, and tests Distributed INSERTs.
+    enabled: false
+    expectedShards: 1
+    expectedReplicasPerShard: 1
+    backoffLimit: 20
+    activeDeadlineSeconds: 1800
+    ttlSecondsAfterFinished: 3600
+    image:
+      repository: clickhouse/clickhouse-server
+      tag: latest
+      pullPolicy: IfNotPresent
+    runtimeUser:
+      enabled: false
+      grantAll: false
+      grantOption: false
+      grants:
+        - SELECT
+        - INSERT
+        - CREATE
+        - ALTER
+        - DROP
+        - TRUNCATE
+        - OPTIMIZE
+      clusterGrants:
+        - CLUSTER
+        - REMOTE
+    settings:
+      apply: false
+      verify: true
+      values:
+        insert_distributed_one_random_shard: "1"
+        distributed_foreground_insert: "1"
+        skip_unavailable_shards: "0"
+        load_balancing: random
+    distributedInsertTest:
+      enabled: true
+      maxBatches: 64
+      rowsPerBatch: 10
+    podLabels: {}
+    podAnnotations: {}
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    containerSecurityContext: {}
+    tolerations: []
+    env: []
+    sidecars: []
+    volumes: []
+    volumeMounts: []
 
 # Settings for Kafka.
 # See https://github.com/bitnami/charts/tree/master/bitnami/kafka


### PR DESCRIPTION
## Summary

This PR adds opt-in KEDA autoscaling and external ClickHouse preparation to the Sentry chart while preserving the existing HPA-based behavior by default.

A substantial part of the implementation and its documentation was created with AI assistance and subsequently reviewed and validated.

## Changes

### KEDA autoscaling

- Add a `prometheus-kafka-exporter` subchart for exposing Kafka consumer-group lag metrics.
- Add reusable KEDA `ScaledObject` templates for Relay, Web, Vroom, Snuba API, ingest consumers, and TaskWorker deployments.
- Support both Prometheus-based and native Kafka triggers, including `authenticationRef`.
- Preserve explicit `minReplicas: 0` values.
- Preserve boolean `false` values in Prometheus trigger metadata.
- Create the Vroom autoscaler only when the corresponding Vroom Deployment exists.
- Keep HPA and KEDA mutually exclusive; HPA remains the default scaling mechanism.

### Validation and safety

- Reject unsupported autoscaler values.
- Fail rendering when a KEDA ScaledObject has no triggers.
- Validate KEDA replica and polling/cooldown numeric constraints.
- Validate generated Service names against Kubernetes' 63-character limit and provide actionable errors.
- Validate target workloads and avoid duplicate or dangling ScaledObjects.

### ClickHouse preparation

- Add an opt-in pre-install/pre-upgrade hook Job for preparing external ClickHouse.
- Reuse credentials configured under `externalClickhouse`; credentials are not duplicated in the prepare configuration.
- Add a dedicated ServiceAccount so the hook works during the first installation.
- Support an explicitly shared ServiceAccount when configured.
- Clean up the hook ServiceAccount and related resources after successful execution.
- Add ClickHouse connectivity and preparation smoke-test coverage.

### Documentation

- Add configuration guides and examples for:
  - Kafka exporter deployment
  - KEDA Prometheus and native Kafka triggers
  - authentication references
  - connecting autoscaling to newly introduced chart components
  - external ClickHouse preparation and credential reuse
- Document compatibility, migration behavior, validation rules, and operational considerations.

## Backward compatibility

All new functionality is disabled by default. Existing installations continue to use the current HPA behavior unless KEDA or ClickHouse preparation is explicitly enabled.

## Validation performed

- `helm lint --strict`
- Default and CI values rendering
- HPA and KEDA rendering scenarios
- Native Kafka and Prometheus trigger scenarios
- Shared and dedicated ServiceAccount scenarios
- ClickHouse prepare hook rendering
- Negative validation cases for invalid scaler values, empty triggers, invalid numeric limits, and excessive Service name lengths
- Rendered-object checks: 12 ScaledObjects, no missing targets, no empty trigger lists, and no duplicate resources

## Related work

The implementation incorporates and adapts the relevant chart changes associated with #1704 and #2025. #1771 and #1752 are intentionally out of scope. Documentation includes connection examples for the new chart elements discussed in #1830.
