### PR TITLE
feat: charts/sentry: add maxPollIntervalMs for snuba replacer

### DIFF
--- a/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replacer.yaml
@@ -107,6 +107,10 @@ spec:
           - "--queued-min-messages"
           - "{{ .Values.snuba.replacer.queuedMinMessages }}"
         {{- end }}
+          {{- if .Values.snuba.replacer.maxPollIntervalMs }}
+          - "--max-poll-interval-ms"
+          - "{{ .Values.snuba.replacer.maxPollIntervalMs }}"
+          {{- end }}
         ports:
         - containerPort: {{ template "snuba.port" }}
         env:

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -1558,6 +1558,7 @@ snuba:
     sidecars: []
     # autoOffsetReset: "earliest"
     # maxBatchTimeMs: ""
+    # maxPollIntervalMs: 30000
     # queuedMaxMessagesKbytes: ""
     # queuedMinMessages: ""
     volumes: []


### PR DESCRIPTION
`snuba replacer`'s `--max-poll-interval-ms` defaults to `30000`. When a
replacement batch takes longer than that, librdkafka evicts the consumer
from its group *after* the write succeeds but *before* the offset commits
— so the same message gets redelivered and fails identically forever,
not just occasionally.

Observed in production (sentry chart 33.0.0 / snuba 26.7.0), a single
~970k-row replacement took ~53s every time, permanently exceeding the 30s
ceiling:

    Replacing 970586 rows took 53574ms
    MAXPOLL [thrd:main]: Application maximum poll interval (30000ms)
    exceeded by 14ms ...: leaving group
    arroyo.errors.ConsumerError: KafkaError{code=_MAX_POLL_EXCEEDED,...}
    Commit failed: KafkaError{code=UNKNOWN_MEMBER_ID,...}

47+ restarts over 4+ hours, no self-recovery possible without raising the
poll interval past the actual processing time.

## Change

Expose `maxPollIntervalMs` for `snuba.replacer`, matching the pattern
already used by `metricsConsumer`, `replaysConsumer`,
`outcomesBillingConsumer`, and `eapItemsConsumer` (#2259):

- `charts/sentry/templates/snuba/deployment-snuba-replacer.yaml` — render
  the flag when set
- `charts/sentry/values.yaml` — document it as a commented default

## Backwards compatibility

Flag only renders when the value is set — default output unchanged.

Verified with `helm template`:

    # unset (default) -> flag absent
    - "--storage"
    - "errors"
    ports:

    # --set snuba.replacer.maxPollIntervalMs=120000 -> flag present
    - "--storage"
    - "errors"
    - "--max-poll-interval-ms"
    - "120000"
    ports:

`helm lint` passes. No `Chart.yaml` bump — release-please handles that.