### PR TITLE
feat: charts/sentry: add missing taskworker topics to default provisioning list

### DIFF
--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3229,6 +3229,17 @@ kafka:
       - name: taskworker-symbolication-dlq
       - name: taskworker-usage
       - name: taskworker-usage-dlq
+      # Pre-consolidation topics: namespaces that used to route here directly
+      # now route through taskworker-ingest (see taskworker.route.overrides
+      # above), but these topics can still hold in-flight/retained data and
+      # aren't safe to just stop declaring.
+      - name: taskworker-buffer
+      - name: taskworker-cutover
+      - name: taskworker-email
+      - name: taskworker-ingest-attachments
+      - name: taskworker-ingest-errors-postprocess
+      - name: taskworker-ingest-profiling
+      - name: taskworker-workflows-engine
   listeners:
     client:
       protocol: "PLAINTEXT"


### PR DESCRIPTION

The chart's default kafka.provisioning.topics list covers the current taskworker.route.overrides destinations (taskworker-ingest, -long, -products, -billing, -control, -internal, -limited, -sentryapp, -symbolication, -usage, each with a -dlq pair) but is missing 7 topics that predate the current consolidated routing:
```
  taskworker-buffer
  taskworker-cutover
  taskworker-email
  taskworker-ingest-attachments
  taskworker-ingest-errors-postprocess
  taskworker-ingest-profiling
  taskworker-workflows-engine
```

These namespaces (buffer, cutover, email, ingest.attachments, ingest.errors.postprocess, ingest.profiling, workflows_engine) now route through taskworker-ingest via taskworker.route.overrides, but the older per-namespace topics can still hold retained/in-flight data and aren't safe to just stop declaring - deployments upgrading through the consolidation need them provisioned too, and the chart currently has no way to declare them without a hand-rolled PostSync job outside the chart.

Add them to kafka.provisioning.topics so externalKafka.provisioning (which falls back to this list when its own topics: is empty) picks them up natively.

Verified with helm template --set kafka.enabled=false --set externalKafka.provisioning.enabled=true that all 7 render in the provisioning ConfigMap. helm lint passes.