### PR TITLE
fix: extend Recreate/RollingUpdate strategy to remaining Kafka consumer deployments

### DIFF
--- a/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
+++ b/charts/sentry/templates/sentry/ingest/attachments/deployment-sentry-ingest-consumer-attachments.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestConsumerAttachments.strategyType "replicas" .Values.sentry.ingestConsumerAttachments.replicas "autoscaling" .Values.sentry.ingestConsumerAttachments.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
+++ b/charts/sentry/templates/sentry/ingest/events/deployment-sentry-ingest-consumer-events.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestConsumerEvents.strategyType "replicas" .Values.sentry.ingestConsumerEvents.replicas "autoscaling" .Values.sentry.ingestConsumerEvents.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
+++ b/charts/sentry/templates/sentry/ingest/feedback/deployment-sentry-ingest-feedback.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestFeedback.strategyType "replicas" .Values.sentry.ingestFeedback.replicas "autoscaling" .Values.sentry.ingestFeedback.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
+++ b/charts/sentry/templates/sentry/ingest/monitors/deployment-sentry-ingest-monitors.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestMonitors.strategyType "replicas" .Values.sentry.ingestMonitors.replicas "autoscaling" .Values.sentry.ingestMonitors.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
+++ b/charts/sentry/templates/sentry/ingest/occurrences/deployment-sentry-ingest-occurrences.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestOccurrences.strategyType "replicas" .Values.sentry.ingestOccurrences.replicas "autoscaling" .Values.sentry.ingestOccurrences.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
+++ b/charts/sentry/templates/sentry/ingest/replay-recordings/deployment-sentry-ingest-replay-recordings.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestReplayRecordings.strategyType "replicas" .Values.sentry.ingestReplayRecordings.replicas "autoscaling" .Values.sentry.ingestReplayRecordings.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
+++ b/charts/sentry/templates/sentry/ingest/transactions/deployment-sentry-ingest-consumer-transactions.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.ingestConsumerTransactions.strategyType "replicas" .Values.sentry.ingestConsumerTransactions.replicas "autoscaling" .Values.sentry.ingestConsumerTransactions.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/billing/deployment-sentry-billing-metrics-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.billingMetricsConsumer.strategyType "replicas" .Values.sentry.billingMetricsConsumer.replicas "autoscaling" .Values.sentry.billingMetricsConsumer.autoscaling) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/deployment-sentry-metrics-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.metricsConsumer.strategyType "replicas" .Values.sentry.metricsConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
+++ b/charts/sentry/templates/sentry/metrics/generic/deployment-sentry-generic-metrics-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.genericMetricsConsumer.strategyType "replicas" .Values.sentry.genericMetricsConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/errors/deployment-sentry-post-process-forwarder-errors.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.postProcessForwardErrors.strategyType "replicas" .Values.sentry.postProcessForwardErrors.replicas) }}
   selector:
     matchLabels:
         app: sentry

--- a/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/issue-platform/deployment-sentry-post-process-forwarder-issue-platform.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.postProcessForwardIssuePlatform.strategyType "replicas" .Values.sentry.postProcessForwardIssuePlatform.replicas) }}
   selector:
     matchLabels:
         app: sentry

--- a/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
+++ b/charts/sentry/templates/sentry/post-process-forwarder/transactions/deployment-sentry-post-process-forwarder-transactions.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.postProcessForwardTransactions.strategyType "replicas" .Values.sentry.postProcessForwardTransactions.replicas) }}
   selector:
     matchLabels:
         app: sentry

--- a/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
+++ b/charts/sentry/templates/sentry/process/segments/deployment-sentry-process-segments.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.processSegments.strategyType "replicas" .Values.sentry.processSegments.replicas) }}
   selector:
     matchLabels:
         app: sentry

--- a/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
+++ b/charts/sentry/templates/sentry/process/spans/deployment-sentry-process-spans.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.processSpans.strategyType "replicas" .Values.sentry.processSpans.replicas) }}
   selector:
     matchLabels:
       app: sentry

--- a/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
+++ b/charts/sentry/templates/sentry/uptime/deployment-sentry-uptime-results.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.sentry.uptimeResults.strategyType "replicas" .Values.sentry.uptimeResults.replicas) }}
   selector:
     matchLabels:
         app: sentry

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.consumer.strategyType "replicas" .Values.snuba.consumer.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.eapItemsConsumer.strategyType "replicas" .Values.snuba.eapItemsConsumer.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.genericMetricsCountersConsumer.strategyType "replicas" .Values.snuba.genericMetricsCountersConsumer.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-distributions-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.genericMetricsDistributionConsumer.strategyType "replicas" .Values.snuba.genericMetricsDistributionConsumer.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-gauges-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.genericMetricsGaugesConsumer.strategyType "replicas" .Values.snuba.genericMetricsGaugesConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-sets-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.genericMetricsSetsConsumer.strategyType "replicas" .Values.snuba.genericMetricsSetsConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.groupAttributesConsumer.strategyType "replicas" .Values.snuba.groupAttributesConsumer.replicas) }}
   selector:
     matchLabels:
         app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.issueOccurrenceConsumer.strategyType "replicas" .Values.snuba.issueOccurrenceConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.metricsConsumer.strategyType "replicas" .Values.snuba.metricsConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.outcomesBillingConsumer.strategyType "replicas" .Values.snuba.outcomesBillingConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -19,6 +19,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.outcomesConsumer.strategyType "replicas" .Values.snuba.outcomesConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.profilingChunksConsumer.strategyType "replicas" .Values.snuba.profilingChunksConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.profilingFunctionsConsumer.strategyType "replicas" .Values.snuba.profilingFunctionsConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.profilingProfilesConsumer.strategyType "replicas" .Values.snuba.profilingProfilesConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.replaysConsumer.strategyType "replicas" .Values.snuba.replaysConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -20,6 +20,8 @@ metadata:
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ include "sentry.kafkaConsumer.strategyType" (dict "strategyType" .Values.snuba.transactionsConsumer.strategyType "replicas" .Values.snuba.transactionsConsumer.replicas) }}
   selector:
     matchLabels:
       app: {{ template "sentry.fullname" . }}

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -605,6 +605,8 @@ sentry:
 
   ingestConsumerAttachments:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -651,6 +653,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -698,6 +702,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -743,6 +749,8 @@ sentry:
 
   ingestReplayRecordings:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -782,6 +790,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -824,6 +834,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -860,6 +872,8 @@ sentry:
 
   ingestMonitors:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -973,6 +987,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1009,6 +1025,8 @@ sentry:
 
   genericMetricsConsumer:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -1048,6 +1066,8 @@ sentry:
 
   metricsConsumer:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -1089,6 +1109,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1118,6 +1140,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1147,6 +1171,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # processes: 1
@@ -1177,6 +1203,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1206,6 +1234,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -1238,6 +1268,8 @@ sentry:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     # concurrency: 4
@@ -1356,6 +1388,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1394,6 +1428,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1433,6 +1469,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1507,6 +1545,8 @@ snuba:
 
   outcomesBillingConsumer:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1569,6 +1609,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1758,6 +1800,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1791,6 +1835,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1824,6 +1870,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1857,6 +1905,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1945,6 +1995,8 @@ snuba:
 
   replaysConsumer:
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -1984,6 +2036,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -2019,6 +2073,8 @@ snuba:
     #       medium: Memory
 
   profilingProfilesConsumer:
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     annotations: {}
@@ -2057,6 +2113,8 @@ snuba:
     #       medium: Memory
 
   profilingFunctionsConsumer:
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     annotations: {}
@@ -2094,6 +2152,8 @@ snuba:
     #       medium: Memory
 
   profilingChunksConsumer:
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     annotations: {}
@@ -2134,6 +2194,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []
@@ -2172,6 +2234,8 @@ snuba:
     # Default --max-poll-interval-ms (self-hosted SENTRY_KAFKA_MAX_POLL_INTERVAL_MS). Set null to disable.
     maxPollIntervalMs: 300000
     enabled: true
+    # Recreate if replicas=1, else RollingUpdate (see sentry-kubernetes/charts#2238). Override to force either.
+    strategyType: null
     annotations: {}
     replicas: 1
     env: []


### PR DESCRIPTION
## Context

Follow-up to #2258, which defaulted `strategy: Recreate` on 10 single-partition consumer Deployments (monitors-clock-tick/tasks, snuba subscription-consumer-*) to fix the rollout deadlock described in #2238: a RollingUpdate surge pod can never get a Kafka partition assignment (the old pod already holds it), so it never touches the healthcheck file, fails its startup probe, and is killed in a loop while the old ReplicaSet is kept alive.

As raised in https://github.com/sentry-kubernetes/charts/pull/2258#issuecomment-5089626258, that scope was too narrow. The other ~32 consumer Deployments using the same `execHealthcheckFile` startup/liveness probe also default to `replicas: 1`, and the chart's own Kafka topic provisioning defaults to `numPartitions: 1` unless overridden, so on a default/minimal install (e.g. `ci/kind-values.yaml`, or any install that hasn't explicitly sized up partitions) they hit the exact same deadlock. The distinguishing factor isn't "is this topic contractually single-partition," it's simply "is this Deployment currently running `replicas: 1`" - which is what the `sentry.kafkaConsumer.strategyType` helper from #2258 already encodes.

## Changes

Wires the existing `sentry.kafkaConsumer.strategyType` helper (`Recreate` when `replicas == 1` and autoscaling is off, else `RollingUpdate`; explicit `strategyType` always wins) into the remaining 32 file-probe consumer Deployments:

- sentry: ingestConsumerAttachments, ingestConsumerEvents, ingestConsumerTransactions, ingestFeedback, ingestMonitors, ingestOccurrences, ingestReplayRecordings, billingMetricsConsumer, metricsConsumer, genericMetricsConsumer, postProcessForwardErrors, postProcessForwardIssuePlatform, postProcessForwardTransactions, processSegments, processSpans, uptimeResults
- snuba: consumer, eapItemsConsumer, genericMetricsCountersConsumer, genericMetricsDistributionConsumer, genericMetricsGaugesConsumer, genericMetricsSetsConsumer, groupAttributesConsumer, issueOccurrenceConsumer, metricsConsumer, outcomesBillingConsumer, outcomesConsumer, profilingChunksConsumer, profilingFunctionsConsumer, profilingProfilesConsumer, replaysConsumer, transactionsConsumer

Deliberately **not** touched: `snuba-replacer` (no healthcheck-file probe at all) and `snuba-outcomes-accepted-consumer` (template explicitly notes it doesn't write the healthcheck file yet) - neither can hit this deadlock. `sentry-web` and `relay` already manage their own `strategyType` independently and are unaffected.

## Verification

- `helm lint` passes
- `helm template` (`feature-complete` profile): all 41 file-probe consumer Deployments now render a `strategy` block - 39 at `Recreate` (default `replicas: 1`), `sentry-web`/`relay` unaffected at `RollingUpdate`
- `--set <component>.strategyType=RollingUpdate` overrides correctly
- Bumping any covered component's `replicas` above 1 (without an explicit override) correctly flips its default back to `RollingUpdate`