### PR TITLE
fix: clickhouse cleanup cronjob fails when CLICKHOUSE_PASSWORD is unset

### DIFF
--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -79,6 +79,8 @@ spec:
                 echo "Connecting to ClickHouse at $CLICKHOUSE_HOST:$CLICKHOUSE_PORT"
 
                 # Build clickhouse-client arguments; omit --password if empty to avoid bad-arg error
+                # CLICKHOUSE_PASSWORD may be unset (secret key is optional), so default it under `set -u`
+                CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
                 CH_ARGS=(--host="$CLICKHOUSE_HOST" --port="$CLICKHOUSE_PORT" --user="$CLICKHOUSE_USER" --database="$CLICKHOUSE_DATABASE")
                 if [ -n "$CLICKHOUSE_PASSWORD" ]; then
                   CH_ARGS+=(--password="$CLICKHOUSE_PASSWORD")
@@ -218,8 +220,8 @@ spec:
                   name: {{ .Values.externalClickhouse.existingSecret | quote }}
                   key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey | quote }}
                 {{- else }}
-                  name: {{ template "sentry.fullname" . }}-clickhouse
-                  key: clickhouse-password
+                  name: {{ template "sentry.fullname" . }}-snuba-env
+                  key: CLICKHOUSE_PASSWORD
                 {{- end }}
                   optional: true
 {{- if .Values.snuba.cleanup.env }}


### PR DESCRIPTION
When `externalClickhouse.password` is left at its default and `externalClickhouse.existingSecret` is not used, the `-clickhouse-cleanup` CronJob fails on startup.

Two issues:

1. The `secretKeyRef` pointed at `{{ fullname }}-clickhouse` / `clickhouse-password` — the ClickHouse subchart secret, which doesn't exist in an external-ClickHouse setup. The actual password lives in `{{ fullname }}-snuba-env` / `CLICKHOUSE_PASSWORD`.
2. Because the key is marked `optional: true`, the env var is not created at all (rather than being empty), so under `set -euo pipefail` the first reference `[ -n "$CLICKHOUSE_PASSWORD" ]` aborts the job with `unbound variable`.

Fix: point the default branch at the `-snuba-env` secret, and default the variable with `CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"` before use. The `existingSecret` branch is unchanged. Verified with `helm template` in both branches.