### PR TITLE
fix: remove obsolete suggested solution configuration

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -365,7 +365,6 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | nginx.enabled | bool | `false` |  |
 | nginx.existingServerConfigConfigmap | string | `"{{ template \"sentry.fullname\" . }}"` |  |
 | nginx.extraLocationSnippet | bool | `false` |  |
-| openai | object | `{}` |  |
 | pagerduty | object | `{}` |  |
 | pgbouncer.affinity | object | `{}` |  |
 | pgbouncer.authType | string | `"md5"` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1156,17 +1156,6 @@ Set google auth
 {{- end }}
 
 {{/*
-Set openai api
-*/}}
-{{- if .Values.openai.existingSecret }}
-- name: OPENAI_API_KEY
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Values.openai.existingSecret }}
-      key: {{ default "api-token" .Values.openai.existingSecretKey }}
-{{- end }}
-
-{{/*
 Set JS SDK Loader assets setup
 */}}
 {{- if .Values.sentry.jsSdk.setupAssets }}

--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -713,12 +713,6 @@ sentry.conf.py: |-
   SENTRY_RELAY_WHITELIST_PK = []
   SENTRY_RELAY_OPEN_REGISTRATION = True
 
-  #######################
-  # OpenAi Suggestions #
-  #######################
-
-  OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
-
   ########################
   # JS SDK Loader Script #
   ########################

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -2632,10 +2632,6 @@ pagerduty: {}
 #   existingSecretAppId: ""             # by default "app-id"
 #   Reference -> https://develop.sentry.dev/integrations/pagerduty/
 
-openai: {}
-#   existingSecret: "xxxxx"
-#   existingSecretKey: ""               # by default "api-token"
-
 ingress:
   enabled: false
   ingressClassName: nginx


### PR DESCRIPTION
## Context
- Sentry removed the legacy Suggested Solution endpoint in [getsentry/sentry#81096](https://github.com/getsentry/sentry/pull/81096).
- The chart still exposed unused provider credentials and rendered a dead application setting.

## Changes
- Remove the obsolete values and secret-backed environment variable.
- Remove the unused application configuration and values documentation.

## Testing
- `helm dependency build charts/sentry`
- `helm lint charts/sentry`
- Rendered the chart and verified the obsolete configuration is absent.