### PR TITLE
fix: charts/sentry: support TLS in ClickHouse cleanup

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -64,13 +64,16 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | config.web.maxRequestsDelta | int | `500` |  |
 | config.web.maxWorkerLifetime | int | `86400` |  |
 | discord | object | `{}` |  |
+| externalClickhouse.ca_certs | string | `""` | Path to a custom ClickHouse CA certificate bundle mounted in Snuba containers |
 | externalClickhouse.database | string | `"default"` |  |
 | externalClickhouse.host | string | `"clickhouse"` |  |
 | externalClickhouse.httpPort | int | `8123` |  |
 | externalClickhouse.password | string | `""` |  |
+| externalClickhouse.secure | bool | `false` | Use TLS for ClickHouse connections |
 | externalClickhouse.singleNode | bool | `true` |  |
 | externalClickhouse.tcpPort | int | `9000` |  |
 | externalClickhouse.username | string | `"default"` |  |
+| externalClickhouse.verify | bool | `false` | Verify the ClickHouse TLS certificate. When false, the cleanup client accepts invalid certificates |
 | externalKafka.cluster | list | `[]` | Multi hosts and ports of external Kafka |
 | externalKafka.host | string | `"kafka-confluent"` | Hostname or IP address of external Kafka |
 | externalKafka.port | int | `9092` | Port for external Kafka |

--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -83,6 +83,12 @@ spec:
                 if [ -n "$CLICKHOUSE_PASSWORD" ]; then
                   CH_ARGS+=(--password="$CLICKHOUSE_PASSWORD")
                 fi
+                {{ if .Values.externalClickhouse.secure }}
+                CH_ARGS+=(--secure)
+                {{ if not .Values.externalClickhouse.verify }}
+                CH_ARGS+=(--accept-invalid-certificate)
+                {{ end }}
+                {{ end }}
 
                 # Function to discover tables
                 discover_tables() {

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3094,6 +3094,12 @@ externalClickhouse:
   username: default
   password: ""
   database: default
+  # -- Use TLS for ClickHouse connections
+  secure: false
+  # -- Verify the ClickHouse TLS certificate. When false, the cleanup client accepts invalid certificates
+  verify: false
+  # -- Path to a custom ClickHouse CA certificate bundle mounted in Snuba containers
+  ca_certs: ""
   singleNode: true
   # existingSecret: secret-name
   ## set existingSecretKey if key name inside existingSecret is different from 'clickhouse-password'


### PR DESCRIPTION
## Context
- The ClickHouse cleanup Job ignores `externalClickhouse.secure` and connects without TLS arguments.
- Secure-only ClickHouse clusters reject the plaintext native connection before cleanup queries run.

## Changes
- Add documented defaults for the existing ClickHouse TLS and certificate-verification values.
- Pass `--secure` to `clickhouse-client` when external ClickHouse TLS is enabled.
- Pass `--accept-invalid-certificate` when TLS verification is disabled.

## Testing
- `helm lint charts/sentry --set user.create=false`
- Rendered plaintext, TLS-without-verification, and TLS-with-verification configurations.
- Verified each configuration emits only its expected `clickhouse-client` arguments.