### PR TITLE
feat: upgrade to v26.7.2

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 type: application
 version: 33.2.0
 # renovate image=ghcr.io/getsentry/sentry
-appVersion: 26.7.1
+appVersion: 26.7.2
 dependencies:
   - name: memcached
     repository: oci://registry-1.docker.io/cloudpirates


### PR DESCRIPTION
https://github.com/getsentry/self-hosted/compare/26.7.1...26.7.2
`getsentry/self-hosted` release notes: [`26.7.2`](https://github.com/getsentry/self-hosted/releases/tag/26.7.2)
