### PR TITLE
fix(charts/sentry): point ClickHouse cleanup at a Secret that exists

### DIFF
--- a/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
+++ b/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml
@@ -224,8 +224,8 @@ spec:
                   name: {{ .Values.externalClickhouse.existingSecret | quote }}
                   key: {{ default "clickhouse-password" .Values.externalClickhouse.existingSecretKey | quote }}
                 {{- else }}
-                  name: {{ template "sentry.fullname" . }}-clickhouse
-                  key: clickhouse-password
+                  name: {{ template "sentry.fullname" . }}-snuba-env
+                  key: CLICKHOUSE_PASSWORD
                 {{- end }}
                   optional: true
 {{- if .Values.snuba.cleanup.env }}


### PR DESCRIPTION
## Problem

The ClickHouse cleanup CronJob sources `CLICKHOUSE_PASSWORD` from a Secret the chart
never creates:

https://github.com/sentry-kubernetes/charts/blob/develop/charts/sentry/templates/snuba/cleanup/cronjob-clickhouse-cleanup.yaml#L226-L229

```yaml
{{- else }}
  name: {{ template "sentry.fullname" . }}-clickhouse
  key: clickhouse-password
{{- end }}
```

No template in the chart produces a `<release>-clickhouse` Secret — the only Secrets
it renders are `-snuba-env`, `-geoip-env`, the launchpad secret and the
`sentry-secret-create` hook.

Because the `secretKeyRef` is marked `optional: true`, this does not fail loudly. The
variable is simply never set, and the job's own script then drops the flag:

```bash
if [ -n "$CLICKHOUSE_PASSWORD" ]; then
  CH_ARGS+=(--password="$CLICKHOUSE_PASSWORD")
fi
```

So on any password-protected ClickHouse the cleanup job authenticates as an
unauthenticated user and the retention cleanup silently does not happen. Only the
chart-managed branch is affected; users who set `externalClickhouse.existingSecret`
take the other branch and are fine.

## Change

Point the chart-managed branch at `<release>-snuba-env` / `CLICKHOUSE_PASSWORD`, which
already exists and already holds exactly this value:

https://github.com/sentry-kubernetes/charts/blob/develop/charts/sentry/templates/snuba/secret-snuba-env.yaml#L16-L18

The two are guarded on the same condition — `secret-snuba-env.yaml` emits
`CLICKHOUSE_PASSWORD` under `{{- if not .Values.externalClickhouse.existingSecret }}`
and this is the `{{- else }}` of `{{- if .Values.externalClickhouse.existingSecret }}` —
so the key is present exactly when this branch is taken. One file, two lines.

I chose this over creating the missing `-clickhouse` Secret because it introduces no new
object, reuses the Secret every other snuba workload already consumes, and keeps the
password in one place rather than two.

`optional: true` is left as-is. It is now harmless, and removing it would turn a
misconfigured `existingSecret` into a pod that will not start, which is a behavior
change beyond the scope of this fix.

## Verification

`snuba.cleanup.enabled` defaults to `false`, so this renders only when opted in.

Before — points at a Secret that is not in the release:

```
- name: CLICKHOUSE_PASSWORD
  valueFrom:
    secretKeyRef:
      name: sentry-clickhouse
      key: clickhouse-password
      optional: true
```

After, with `--set snuba.cleanup.enabled=true --set externalClickhouse.password=hunter2`:

```
# cronjob
      name: sentry-snuba-env
      key: CLICKHOUSE_PASSWORD

# the Secret it now resolves against
  CLICKHOUSE_PASSWORD: "aHVudGVyMg=="   # -> hunter2
```

With `--set externalClickhouse.existingSecret=my-ch-secret` the other branch still
renders `name: "my-ch-secret"` / `key: "clickhouse-password"`, unchanged.

Rendered output is byte-identical across the default install and four credential
configurations (all-`existingSecret`, no credentials configured, and the full
credential surface both ways), since the CronJob is disabled in all of them.
`helm lint`: 0 failed.

No `values.yaml` change. `Chart.yaml` is intentionally not bumped; release-please
manages versioning.

## Related

Part of a small series moving the chart's credentials into Secrets, which starts with
#2279 — please merge that one first so the series stays in order. This PR has no code
dependency on it and can be reviewed on its own.

---
🤖 Authored with [Cursor](https://cursor.com), reviewed by me before opening.
