### PR TITLE
chore(ci): migrate workflows from Helm 3 to Helm 4

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,7 +18,10 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.21.4
+          version: v4.2.4
+
+      - name: Helm lint
+        run: helm lint charts/clickhouse charts/sentry-kubernetes
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,6 +18,11 @@ jobs:
         with:
           path: 'gh-pages'
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v4.2.4
+
       - run: |
           cd gh-pages
           git config --local user.email "action@github.com"
@@ -25,25 +30,12 @@ jobs:
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git checkout gh-pages
 
-      - name: Build clickhouse chart
-        uses: WyriHaximus/github-action-helm3@v4
-        with:
-          exec: helm package -u main/charts/clickhouse --destination gh-pages/charts
-
-      - name: Build sentry chart
-        uses: WyriHaximus/github-action-helm3@v4
-        with:
-          exec: helm package -u main/charts/sentry --destination gh-pages/charts
-
-      - name: Build sentry-kubernetes chart
-        uses: WyriHaximus/github-action-helm3@v4
-        with:
-          exec: helm package -u main/charts/sentry-kubernetes --destination gh-pages/charts
-
-      - name: Build sentry-kubernetes chart
-        uses: WyriHaximus/github-action-helm3@v4
-        with:
-          exec: helm repo index --url https://sentry-kubernetes.github.io/charts ./gh-pages/charts
+      - name: Package charts
+        run: |
+          helm package -u main/charts/clickhouse --destination gh-pages/charts
+          helm package -u main/charts/sentry --destination gh-pages/charts
+          helm package -u main/charts/sentry-kubernetes --destination gh-pages/charts
+          helm repo index --url https://sentry-kubernetes.github.io/charts ./gh-pages/charts
 
       - name: Commit files
         run: |


### PR DESCRIPTION
## Summary
- Pin `azure/setup-helm` to Helm `v4.2.4` in lint and publish workflows
- Replace `WyriHaximus/github-action-helm3` with native `helm package` / `helm repo index`
- Always run `helm lint` on `clickhouse` and `sentry-kubernetes` so Helm 4 is exercised even when no chart files change

Supersedes https://github.com/sentry-kubernetes/charts/pull/2247 (version bump only; CI would skip lint/install).

Chart API v2 charts are unchanged. The deprecated clickhouse chart (`apiVersion: v1`) still lints and packages on Helm 4.

## Test plan
- [x] `helm lint charts/clickhouse charts/sentry-kubernetes` on Helm 4.2.x
- [x] `helm package` clickhouse (`apiVersion: v1`) on Helm 4
- [ ] PR `lint-test` job runs the new Helm lint step
- [ ] Next tagged release packages charts with Helm 4

Made with [Cursor](https://cursor.com)