### PR TITLE
fix(sentry): replace unmaintained pgbouncer image with edoburu/pgbouncer

### DIFF
--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -375,8 +375,8 @@ Note: this table is incomplete, so have a look at the values.yaml in case you mi
 | pgbouncer.authType | string | `"md5"` |  |
 | pgbouncer.enabled | bool | `false` |  |
 | pgbouncer.image.pullPolicy | string | `"IfNotPresent"` |  |
-| pgbouncer.image.repository | string | `"bitnami/pgbouncer"` |  |
-| pgbouncer.image.tag | string | `"1.23.1-debian-12-r5"` |  |
+| pgbouncer.image.repository | string | `"edoburu/pgbouncer"` |  |
+| pgbouncer.image.tag | string | `"v1.25.2-p0"` |  |
 | pgbouncer.maxClientConn | string | `"8192"` |  |
 | pgbouncer.nodeSelector | object | `{}` |  |
 | pgbouncer.podDisruptionBudget.enabled | bool | `true` |  |

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -1326,7 +1326,11 @@ Launchpad RPC shared secret (required by Sentry web and launchpad-taskworker)
 
 
 {{/*
-Pgbouncer environment variables
+Pgbouncer environment variables.
+
+Injected under both Bitnami names (POSTGRESQL_*, PGBOUNCER_*) and edoburu names
+(DB_*) so the default edoburu/pgbouncer image works and a bitnamilegacy override
+still does.
 */}}
 {{- define "sentry.pgbouncer.env" -}}
 {{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.host }}
@@ -1335,8 +1339,15 @@ Pgbouncer environment variables
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
       key: {{ default .Values.externalPostgresql.existingSecretKeys.host }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.host }}
 {{- else }}
 - name: POSTGRESQL_HOST
+  value: {{ include "sentry.postgresql.host" . | quote }}
+- name: DB_HOST
   value: {{ include "sentry.postgresql.host" . | quote }}
 {{- end }}
 {{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.port }}
@@ -1345,8 +1356,15 @@ Pgbouncer environment variables
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
       key: {{ default .Values.externalPostgresql.existingSecretKeys.port }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.port }}
 {{- else }}
 - name: POSTGRESQL_PORT
+  value: {{ include "sentry.postgresql.port" . | quote }}
+- name: DB_PORT
   value: {{ include "sentry.postgresql.port" . | quote }}
 {{- end }}
 {{- if and .Values.externalPostgresql.existingSecret .Values.externalPostgresql.existingSecretKeys.database }}
@@ -1355,8 +1373,15 @@ Pgbouncer environment variables
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
       key: {{ default .Values.externalPostgresql.existingSecretKeys.database }}
+- name: DB_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.database }}
 {{- else }}
 - name: PGBOUNCER_DATABASE
+  value: {{ include "sentry.postgresql.database" . | quote }}
+- name: DB_NAME
   value: {{ include "sentry.postgresql.database" . | quote }}
 {{- end }}
 {{- if .Values.postgresql.enabled }}
@@ -1365,11 +1390,23 @@ Pgbouncer environment variables
     secretKeyRef:
       name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
       key: {{ default "postgres-password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
+      key: {{ default "postgres-password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
 {{- else if .Values.externalPostgresql.password }}
 - name: POSTGRESQL_PASSWORD
   value: {{ .Values.externalPostgresql.password | quote }}
+- name: DB_PASSWORD
+  value: {{ .Values.externalPostgresql.password | quote }}
 {{- else if .Values.externalPostgresql.existingSecret }}
 - name: POSTGRESQL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ or .Values.externalPostgresql.existingSecretKeys.password .Values.externalPostgresql.existingSecretKey "postgresql-password" }}
+- name: DB_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
@@ -1381,8 +1418,15 @@ Pgbouncer environment variables
     secretKeyRef:
       name: {{ .Values.externalPostgresql.existingSecret }}
       key: {{ default .Values.externalPostgresql.existingSecretKeys.username }}
+- name: DB_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalPostgresql.existingSecret }}
+      key: {{ default .Values.externalPostgresql.existingSecretKeys.username }}
 {{- else }}
 - name: POSTGRESQL_USERNAME
+  value: {{ include "sentry.postgresql.username" . | quote }}
+- name: DB_USER
   value: {{ include "sentry.postgresql.username" . | quote }}
 {{- end }}
 {{- end -}}

--- a/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -35,13 +35,23 @@ spec:
           {{ include "sentry.pgbouncer.env" . | nindent 10 }}
           - name: PGBOUNCER_PORT
             value: "5432"
+          - name: LISTEN_PORT
+            value: "5432"
           - name: PGBOUNCER_AUTH_TYPE
+            value: {{ .Values.pgbouncer.authType | quote }}
+          - name: AUTH_TYPE
             value: {{ .Values.pgbouncer.authType | quote }}
           - name: PGBOUNCER_MAX_CLIENT_CONN
             value: {{ .Values.pgbouncer.maxClientConn | quote }}
+          - name: MAX_CLIENT_CONN
+            value: {{ .Values.pgbouncer.maxClientConn | quote }}
           - name: PGBOUNCER_DEFAULT_POOL_SIZE
             value: {{ .Values.pgbouncer.poolSize | quote }}
+          - name: DEFAULT_POOL_SIZE
+            value: {{ .Values.pgbouncer.poolSize | quote }}
           - name: PGBOUNCER_POOL_MODE
+            value: {{ .Values.pgbouncer.poolMode | quote }}
+          - name: POOL_MODE
             value: {{ .Values.pgbouncer.poolMode | quote }}
         ports:
           - containerPort: 5432

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -3402,6 +3402,9 @@ extraManifests: []
 
 pgbouncer:
   enabled: false
+  # Extra container env. Must match the image dialect (edoburu/pgbouncer by default:
+  # AUTH_TYPE, MIN_POOL_SIZE, SERVER_TLS_SSLMODE, ...). Built-in settings are
+  # injected under both edoburu and Bitnami names so a bitnamilegacy image override still works.
   env: []
   postgres:
     cp_max: 10
@@ -3411,8 +3414,8 @@ pgbouncer:
     user: ''
     password: ''
   image:
-    repository: "bitnamilegacy/pgbouncer"
-    tag: "1.23.1-debian-12-r5"
+    repository: "edoburu/pgbouncer"
+    tag: "v1.25.2-p0"
     pullPolicy: IfNotPresent
   replicas: 2
   podDisruptionBudget:


### PR DESCRIPTION
## Summary
- Switch the default PgBouncer image from frozen `bitnamilegacy/pgbouncer:1.23.1-debian-12-r5` to maintained `edoburu/pgbouncer:v1.25.2-p0`.
- Helm values (`authType`, `poolMode`, `poolSize`, `maxClientConn`, postgres secrets) and the `{release}-pgbouncer:5432` Service are unchanged.
- Built-in settings are injected under both edoburu names (`DB_HOST`, `AUTH_TYPE`, …) and Bitnami names (`POSTGRESQL_HOST`, `PGBOUNCER_*`) so a `bitnamilegacy/pgbouncer` image override still works.

Closes #2283

## Test plan
- [ ] `helm template` with `pgbouncer.enabled=true` shows `edoburu/pgbouncer:v1.25.2-p0` and both env-name sets
- [ ] Install with bundled PostgreSQL and `pgbouncer.enabled=true`; Sentry still reaches Postgres through `{release}-pgbouncer:5432`
- [ ] Install with `externalPostgresql` + `existingSecret`; pgbouncer still gets host/user/password
- [ ] Optional: override `pgbouncer.image` back to `bitnamilegacy/pgbouncer` and confirm Bitnami env names still configure it
- [ ] If you pass extra knobs via `pgbouncer.env`, use edoburu names (`MIN_POOL_SIZE`, `SERVER_TLS_SSLMODE`, …) rather than `PGBOUNCER_*`


Made with [Cursor](https://cursor.com)