### PR TITLE
feat: charts/sentry: source Postgres, mail and admin credentials from a Secret

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -872,6 +872,25 @@ DISCORD_PUBLIC_KEY: {{ .Values.discord.publicKey | b64enc | quote }}
 DISCORD_CLIENT_SECRET: {{ .Values.discord.clientSecret | b64enc | quote }}
 DISCORD_BOT_TOKEN: {{ .Values.discord.botToken | b64enc | quote }}
 {{- end }}
+{{- include "sentry.credentials.postgresMail.data" . }}
+{{- end -}}
+
+{{/*
+The Postgres and mail credentials the chart manages itself, in the key names the
+Sentry fleet already reads. Shared by the Sentry Secret and the hook Secret so the
+two can never disagree about a value.
+
+The conditions mirror the env blocks these replace: postgresql.enabled takes the
+password from the subchart's own Secret, and mail.password takes precedence over
+mail.existingSecret.
+*/}}
+{{- define "sentry.credentials.postgresMail.data" -}}
+{{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.password }}
+POSTGRES_PASSWORD: {{ .Values.externalPostgresql.password | b64enc | quote }}
+{{- end }}
+{{- with .Values.mail.password }}
+SENTRY_EMAIL_PASSWORD: {{ . | b64enc | quote }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -908,6 +927,70 @@ credential is chart-managed.
 */}}
 {{- define "sentry.config.checksum" -}}
 {{- printf "%s%s" (include "sentry.config" .) (include "sentry.credentials.sentryEnv.data" . | trim) | sha256sum -}}
+{{- end -}}
+
+{{/*
+Credentials the hook Jobs need before the release's own resources exist.
+
+With hooks.preUpgrade enabled, sentry-db-init and user-create run as pre-upgrade
+hooks, which Helm executes before it applies the release manifest. A credential
+held only in a normal Secret is therefore unavailable to them on the upgrade that
+first introduces it, and the Job fails before the Secret it needs is ever applied.
+This Secret is a hook itself, at a weight below every Job that reads it, so it is
+always in place first.
+*/}}
+{{- define "sentry.credentials.hooksEnv.data" -}}
+{{- include "sentry.credentials.postgresMail.data" . }}
+{{- if and (not .Values.user.existingSecret) .Values.user.password }}
+ADMIN_PASSWORD: {{ .Values.user.password | b64enc | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "sentry.credentials.hooksEnv.enabled" -}}
+{{- if and .Values.hooks.enabled (include "sentry.credentials.hooksEnv.data" . | trim) }}true{{ end }}
+{{- end -}}
+
+{{/*
+The full envFrom block for the hook Jobs, which read from both the Sentry Secret
+and the hook Secret. Emitted as one block because a container may only have a
+single envFrom. Reduces to exactly sentry.envFrom when no hook credential is
+chart-managed, so hook Jobs that gain nothing here are left untouched.
+
+Both references are optional for the same reason as in sentry.envFrom: either
+Secret exists only when the chart manages a credential that belongs in it, and a
+missing reference must not block the pod from starting.
+*/}}
+{{- define "sentry.hooks.envFrom" -}}
+{{- $sentryEnv := include "sentry.credentials.sentryEnv.enabled" . -}}
+{{- $hooksEnv := include "sentry.credentials.hooksEnv.enabled" . -}}
+{{- if or $sentryEnv $hooksEnv -}}
+envFrom:
+{{- if $sentryEnv }}
+  - secretRef:
+      name: {{ template "sentry.fullname" . }}-sentry-env
+      optional: true
+{{- end }}
+{{- if $hooksEnv }}
+  - secretRef:
+      name: {{ template "sentry.fullname" . }}-hooks-env
+      optional: true
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The Postgres password pgbouncer connects with. Kept in its own Secret rather than
+sharing the Sentry one so pgbouncer is not handed S3 keys and integration tokens
+it has no use for.
+*/}}
+{{- define "sentry.credentials.pgbouncerEnv.data" -}}
+{{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.password }}
+POSTGRESQL_PASSWORD: {{ .Values.externalPostgresql.password | b64enc | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "sentry.credentials.pgbouncerEnv.enabled" -}}
+{{- if (include "sentry.credentials.pgbouncerEnv.data" . | trim) }}true{{ end }}
 {{- end -}}
 
 {{/*
@@ -963,8 +1046,8 @@ Set external Postgresql password from existingSecret
       name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
       key: {{ default "postgres-password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
 {{- else if .Values.externalPostgresql.password }}
-- name: POSTGRES_PASSWORD
-  value: {{ .Values.externalPostgresql.password | quote }}
+{{- /* Supplied by the chart-managed Secret through envFrom. The branch is kept so
+       that a plaintext password still takes precedence over existingSecret. */}}
 {{- else if .Values.externalPostgresql.existingSecret }}
 - name: POSTGRES_PASSWORD
   valueFrom:
@@ -1161,8 +1244,8 @@ Set google application
 Set sentry email password
 */}}
 {{- if .Values.mail.password }}
-- name: SENTRY_EMAIL_PASSWORD
-  value: {{ .Values.mail.password | quote }}
+{{- /* Supplied by the chart-managed Secret through envFrom. The branch is kept so
+       that a plaintext password still takes precedence over existingSecret. */}}
 {{- else if .Values.mail.existingSecret }}
 - name: SENTRY_EMAIL_PASSWORD
   valueFrom:
@@ -1366,8 +1449,8 @@ Pgbouncer environment variables
       name: {{ default (include "sentry.postgresql.fullname" .) .Values.postgresql.auth.existingSecret }}
       key: {{ default "postgres-password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
 {{- else if .Values.externalPostgresql.password }}
-- name: POSTGRESQL_PASSWORD
-  value: {{ .Values.externalPostgresql.password | quote }}
+{{- /* Supplied by the chart-managed Secret through envFrom. The branch is kept so
+       that a plaintext password still takes precedence over existingSecret. */}}
 {{- else if .Values.externalPostgresql.existingSecret }}
 - name: POSTGRESQL_PASSWORD
   valueFrom:

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -886,10 +886,10 @@ mail.existingSecret.
 */}}
 {{- define "sentry.credentials.postgresMail.data" -}}
 {{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.password }}
-POSTGRES_PASSWORD: {{ .Values.externalPostgresql.password | b64enc | quote }}
+POSTGRES_PASSWORD: {{ .Values.externalPostgresql.password | toString | b64enc | quote }}
 {{- end }}
 {{- with .Values.mail.password }}
-SENTRY_EMAIL_PASSWORD: {{ . | b64enc | quote }}
+SENTRY_EMAIL_PASSWORD: {{ . | toString | b64enc | quote }}
 {{- end }}
 {{- end -}}
 
@@ -942,7 +942,7 @@ always in place first.
 {{- define "sentry.credentials.hooksEnv.data" -}}
 {{- include "sentry.credentials.postgresMail.data" . }}
 {{- if and (not .Values.user.existingSecret) .Values.user.password }}
-ADMIN_PASSWORD: {{ .Values.user.password | b64enc | quote }}
+ADMIN_PASSWORD: {{ .Values.user.password | toString | b64enc | quote }}
 {{- end }}
 {{- end -}}
 
@@ -985,7 +985,7 @@ it has no use for.
 */}}
 {{- define "sentry.credentials.pgbouncerEnv.data" -}}
 {{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.password }}
-POSTGRESQL_PASSWORD: {{ .Values.externalPostgresql.password | b64enc | quote }}
+POSTGRESQL_PASSWORD: {{ .Values.externalPostgresql.password | toString | b64enc | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/sentry/templates/hooks/secret-hooks-env.yaml
+++ b/charts/sentry/templates/hooks/secret-hooks-env.yaml
@@ -1,0 +1,23 @@
+{{- if (include "sentry.credentials.hooksEnv.enabled" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sentry.fullname" . }}-hooks-env
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "sentry.component.labels" (dict "component" "hooks" "ctx" .) | nindent 4 }}
+  annotations:
+    {{- if .Values.useArgoCdCompatibleAnnotations }}
+    "argocd.argoproj.io/hook": "Sync"
+    "argocd.argoproj.io/sync-wave": "-5"
+    {{- else }}
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+    {{- end }}
+type: Opaque
+data:
+{{- include "sentry.credentials.hooksEnv.data" . | trim | nindent 2 }}
+{{- end }}

--- a/charts/sentry/templates/hooks/sentry-db-init.job.yaml
+++ b/charts/sentry/templates/hooks/sentry-db-init.job.yaml
@@ -85,7 +85,7 @@ spec:
         {{- if .Values.hooks.dbInit.env }}
 {{ toYaml .Values.hooks.dbInit.env | indent 8 }}
         {{- end }}
-        {{- with include "sentry.envFrom" . }}{{ . | nindent 8 }}{{- end }}
+        {{- with include "sentry.hooks.envFrom" . }}{{ . | nindent 8 }}{{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/charts/sentry/templates/hooks/user-create.yaml
+++ b/charts/sentry/templates/hooks/user-create.yaml
@@ -106,13 +106,14 @@ spec:
               name: {{ .Values.user.existingSecret }}
               key: {{ default "admin-password" .Values.user.existingSecretKey }}
         {{- else if .Values.user.password }}
-        - name: ADMIN_PASSWORD
-          value: {{ .Values.user.password | quote }}
+        {{- /* Supplied by the chart-managed hook Secret through envFrom. The branch is
+               kept so that existingSecret still takes precedence over a plaintext
+               password, as it does today. */}}
         {{- end }}
         {{- if .Values.hooks.dbInit.env }}
 {{ toYaml .Values.hooks.dbInit.env | indent 8 }}
         {{- end }}
-        {{- with include "sentry.envFrom" . }}{{ . | nindent 8 }}{{- end }}
+        {{- with include "sentry.hooks.envFrom" . }}{{ . | nindent 8 }}{{- end }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/sentry/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -18,6 +18,10 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- if (include "sentry.credentials.pgbouncerEnv.enabled" .) }}
+      annotations:
+        checksum/pgbouncer-env: {{ include "sentry.credentials.pgbouncerEnv.data" . | trim | sha256sum }}
+      {{- end }}
       labels:
         app: {{ template "sentry.fullname" . }}-pgbouncer
         {{- include "sentry.component.labels" (dict "component" "pgbouncer" "ctx" .) | nindent 8 }}
@@ -43,6 +47,12 @@ spec:
             value: {{ .Values.pgbouncer.poolSize | quote }}
           - name: PGBOUNCER_POOL_MODE
             value: {{ .Values.pgbouncer.poolMode | quote }}
+        {{- if (include "sentry.credentials.pgbouncerEnv.enabled" .) }}
+        envFrom:
+          - secretRef:
+              name: {{ template "sentry.fullname" . }}-pgbouncer-env
+              optional: true
+        {{- end }}
         ports:
           - containerPort: 5432
             name: pgbouncer

--- a/charts/sentry/templates/pgbouncer/secret-pgbouncer-env.yaml
+++ b/charts/sentry/templates/pgbouncer/secret-pgbouncer-env.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.pgbouncer.enabled (include "sentry.credentials.pgbouncerEnv.enabled" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sentry.fullname" . }}-pgbouncer-env
+  labels:
+    app: sentry
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "sentry.component.labels" (dict "component" "pgbouncer" "ctx" .) | nindent 4 }}
+type: Opaque
+data:
+{{- include "sentry.credentials.pgbouncerEnv.data" . | trim | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
Second of the credential series, following #2279 which merged as 87bb399.

## Problem

`externalPostgresql.password`, `mail.password` and `user.password` are rendered as
plaintext `value:` entries in the pod spec of every workload that includes
`sentry.env` — around thirty Deployments, plus the `sentry-cleanup` CronJob, the
`db-init` and `user-create` hook Jobs and the pgbouncer Deployment.

A pod spec is readable by anything with namespace read access, and shows up in
`kubectl get deployment -o yaml`, `helm get manifest`, GitOps diffs and cluster
backups. Each of these credentials already has an `existingSecret` path that avoids
this; as in #2279, this makes the plaintext path converge on it.

## Change

- **`templates/_helper.tpl`** — adds `sentry.credentials.postgresMail.data` as the
  single definition of both credentials, `sentry.credentials.hooksEnv.*`,
  `sentry.hooks.envFrom` and `sentry.credentials.pgbouncerEnv.*`. The three plaintext
  `value:` branches are replaced with empty branches rather than deleted (see below).
- **`templates/hooks/secret-hooks-env.yaml` (new)** — a `<fullname>-hooks-env` Secret
  for the credentials the hook Jobs need, including the admin password.
- **`templates/pgbouncer/secret-pgbouncer-env.yaml` (new)** — a
  `<fullname>-pgbouncer-env` Secret holding only the Postgres password, kept separate
  so pgbouncer is not handed the S3 keys and integration tokens in `-sentry-env` that
  it has no use for.
- **`hooks/sentry-db-init.job.yaml`, `hooks/user-create.yaml`** — switch from
  `sentry.envFrom` to `sentry.hooks.envFrom`, which emits both `secretRef`s as one
  block because a container may only have a single `envFrom`. It reduces to exactly
  `sentry.envFrom` when no hook credential is chart-managed.
- **`pgbouncer/pgbouncer-deployment.yaml`** — gains the `envFrom` and a
  `checksum/pgbouncer-env` annotation.

The Sentry fleet needs no template changes at all: `POSTGRES_PASSWORD` and
`SENTRY_EMAIL_PASSWORD` are added to the existing `-sentry-env` Secret under the key
names those pods already read, and the `envFrom` that delivers it was added in #2279.

### Why the hook Jobs get their own Secret

With `hooks.preUpgrade: true`, `sentry-db-init` (weight 6) and `user-create`
(weight 9) run as `pre-upgrade` hooks, which Helm executes *before* it applies the
release manifest. A credential held only in an ordinary Secret would therefore be
missing on the very upgrade that introduces it — the Job would fail, the Secret would
never be applied, and a retry would hit the same wall.

`-hooks-env` is itself a `pre-install,pre-upgrade` hook at weight -5, below every Job
that reads it, so it is always in place first. That is also the weight the chart
already uses for `configmap-kafka-provisioning.yaml`.

Both Secrets are populated from the same `sentry.credentials.postgresMail.data`
helper, so the duplicated keys can never disagree.

### Why the plaintext branches are kept but emptied

`sentry.env` resolves these credentials with an if/else-if chain in which plaintext
wins over `existingSecret`. Deleting the plaintext branch outright would let the
`else if .Values.*.existingSecret` arm fire for a user who set both, silently changing
which credential is used. Each branch is therefore kept with a comment in place of the
`value:`, preserving precedence exactly.

### pgbouncer rotation

pgbouncer had no checksum annotation of any kind, so moving its password into a Secret
would have meant rotating it no longer restarted the pod — the rotation would silently
not take effect. `checksum/pgbouncer-env` is added, guarded so that installs which do
not have a chart-managed pgbouncer password see no new annotation.

## Backwards compatibility

No `values.yaml` change: no new keys, none removed, no defaults altered. `README.md`
and `Chart.yaml` are untouched.

Every new Secret and every new `envFrom` is guarded on the same predicate as the data
it carries, so an install that supplies these through `existingSecret` — or does not
set them at all — renders byte-identically and sees no pod rollout on upgrade.

Verified by rendering before and after across three configurations — every credential
via `existingSecret`, no credentials configured at all, and the full credential
surface via `existingSecret` — and diffing per Kubernetes object:

```
PASS   existing-secret: byte-identical to baseline
PASS   no-credentials: byte-identical to baseline
PASS   all-existing: byte-identical to baseline
```

Installs using plaintext values roll once as the credential leaves the pod spec.

## Scope

Counting credential values that appear outside a Secret object, measured against
`develop` at bf89329 with #2279 already merged:

| | before | after |
|---|---|---|
| representative install | 59 | **0** |
| full credential surface | 176 | 116 |

The representative install reaches zero here — Postgres (30 occurrences) and mail (29)
were all that #2279 left it. The 116 remaining on the full surface are Redis (56) and
Kafka SASL (60), both out of scope for this PR.

## Remaining series

Two left, unchanged in substance from the roadmap in #2279 but renumbered, since Redis
and Kafka SASL split into separate PRs rather than the single one originally announced
— each independently touches the Sentry, snuba, relay and kafka-provisioning surfaces,
so combined it was ~16 files.

- **Kafka SASL** — 9 files. Written and verified against this branch already; takes the
  full surface from 116 to 56.
- **Redis** — 7 files. The fiddliest of the series: three parallel value paths
  (`redis.password`, `redis.auth.password`, `externalRedis.password`) with three key
  conventions. Takes it to 0.

Both are ready. As promised in #2279, I will cut each from `develop` after the previous
merges rather than stacking branches, so nothing will be opened against this branch.
Say the word if you would rather see them all at once.

## Notes for review

- **Render-verified, not yet cluster-verified.** Unlike #2279, this one has not yet
  been through a live install. The before/after object diffs and the leak counts above
  are the evidence here. The install I validated #2279 on does run
  `postgresql.enabled: false` with a plaintext `externalPostgresql.password` and a
  plaintext `mail.password`, so it exercises exactly these paths and is where I intend
  to validate this — happy to hold the merge until I have done so if you would prefer.
- **The ArgoCD annotation on the new hook Secret** follows the existing convention in
  `hooks/sentry-secret-create.yaml` (`argocd.argoproj.io/hook: Sync` under
  `useArgoCdCompatibleAnnotations`). I see #2243 proposes dropping that annotation from
  `sentry-secret`; if it lands I will follow whatever it settles on here too.
- **`postgresql.enabled` is untouched.** When the bundled subchart is in use the
  password already comes from the subchart's own Secret, and both new helpers keep the
  `not .Values.postgresql.enabled` condition that guards it.
- **`user.existingSecret` still wins over `user.password`**, as it does today; the
  admin password only enters `-hooks-env` when no `existingSecret` is set.
- `Chart.yaml` is intentionally not bumped; release-please manages versioning.

---
🤖 Authored with [Cursor](https://cursor.com), reviewed by me.
