### PR TITLE
feat(ci): publish helm charts as OCI artifacts to GHCR

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -32,9 +36,11 @@ jobs:
 
       - name: Package charts
         run: |
-          helm package -u main/charts/clickhouse --destination gh-pages/charts
-          helm package -u main/charts/sentry --destination gh-pages/charts
-          helm package -u main/charts/sentry-kubernetes --destination gh-pages/charts
+          mkdir -p packages
+          helm package -u main/charts/clickhouse --destination packages
+          helm package -u main/charts/sentry --destination packages
+          helm package -u main/charts/sentry-kubernetes --destination packages
+          cp packages/*.tgz gh-pages/charts/
           helm repo index --url https://sentry-kubernetes.github.io/charts ./gh-pages/charts
 
       - name: Commit files
@@ -58,3 +64,17 @@ jobs:
           PUBLISH_DIR: ./gh-pages/charts
         with:
           keepFiles: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in packages/*.tgz; do
+            helm push "$pkg" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done

--- a/README.md
+++ b/README.md
@@ -198,11 +198,16 @@ EOF
 
 **Note**: The `clusterName` in your Sentry `values.yaml` must match the cluster name in the ClickHouse manifest above (`sentry-cluster`).
 
-Install Sentry:
+Install Sentry from the Helm repo:
 ```bash
 helm repo add sentry https://sentry-kubernetes.github.io/charts
 helm repo update
 helm install -n sentry my-sentry sentry/sentry -f values.yaml --wait --timeout=2400s
+```
+
+Or from GHCR (OCI). Harbor proxy caches need this path:
+```bash
+helm install -n sentry my-sentry oci://ghcr.io/sentry-kubernetes/charts/sentry --version <chart-version> -f values.yaml --wait --timeout=2400s
 ```
 
 ## Values

--- a/charts/sentry/README.md
+++ b/charts/sentry/README.md
@@ -14,6 +14,12 @@ Please refer to the [External Services Documentation](docs/external-services.md)
 helm repo add sentry https://sentry-kubernetes.github.io/charts
 ```
 
+Charts are also published as OCI artifacts on GHCR:
+
+```
+helm install sentry oci://ghcr.io/sentry-kubernetes/charts/sentry --version <chart-version>
+```
+
 ## Quick install
 
 You must provide an admin password (or reference an existing secret). For a quick test:


### PR DESCRIPTION
## Summary
- Publish the same packaged charts to GHCR on each tag, next to the existing GitHub Pages Helm repo.
- Closes https://github.com/sentry-kubernetes/charts/issues/2262: Harbor can proxy `ghcr.io` and cannot proxy `index.yaml` on GitHub Pages.

Install path after the first successful tag:

```bash
helm install sentry oci://ghcr.io/sentry-kubernetes/charts/sentry --version <chart-version>
```

`sentry-kubernetes` and `clickhouse` go to the same `oci://ghcr.io/sentry-kubernetes/charts` repository.

## Test plan
- [ ] After merge, cut a tag (or re-run the tag workflow) and confirm the job pushes `.tgz` files to GHCR
- [ ] `helm pull oci://ghcr.io/sentry-kubernetes/charts/sentry --version <that version>` succeeds without login
- [ ] If the new GHCR packages default to private, set them public and link them to this repo
- [ ] Confirm gh-pages still updates `index.yaml` as before


Made with [Cursor](https://cursor.com)