### PR TITLE
fix: charts/sentry IPv6 fixes + disable `--processes` for  rust-consumer

### DIFF
--- a/charts/sentry/templates/sentry/_helper-sentry.tpl
+++ b/charts/sentry/templates/sentry/_helper-sentry.tpl
@@ -276,7 +276,7 @@ sentry.conf.py: |-
   ##############
 
   {{- if .Values.ipv6 }}
-  SENTRY_WEB_HOST = "[::]"
+  SENTRY_WEB_HOST = "::"
   {{- else }}
   SENTRY_WEB_HOST = "0.0.0.0"
   {{- end }}
@@ -286,7 +286,7 @@ sentry.conf.py: |-
   SENTRY_PUBLIC = {{ .Values.system.public | ternary "True" "False" }}
   SENTRY_WEB_OPTIONS = {
   {{- if .Values.ipv6 }}
-      "http-socket": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
+      "http-socket": "[%s]:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
   {{- else }}
       "http": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
   {{- end }}

--- a/charts/sentry/templates/sentry/taskbroker/_helper-taskbroker.tpl
+++ b/charts/sentry/templates/sentry/taskbroker/_helper-taskbroker.tpl
@@ -200,6 +200,10 @@ kafka_session_timeout_ms: {{ default 60000 $broker.kafkaSessionTimeoutMs }}
 kafka_deadletter_topic: {{ required (printf "sentry.taskBroker.brokers[%s].kafkaDeadletterTopic is required" $broker.name) $broker.kafkaDeadletterTopic }}
 kafka_retry_topic: {{ required (printf "sentry.taskBroker.brokers[%s].kafkaRetryTopic is required" $broker.name) $broker.kafkaRetryTopic }}
 
+{{- if $root.Values.ipv6 }}
+grpc_addr: '[::]'
+{{- end }}
+
 kafka_topics:
 {{- range $topicName, $topic := $broker.kafkaTopics }}
   {{ $topicName }}:

--- a/charts/sentry/templates/snuba/_helper-snuba.tpl
+++ b/charts/sentry/templates/snuba/_helper-snuba.tpl
@@ -10,6 +10,10 @@ settings.py: |
 
   DEBUG = env("DEBUG", "0").lower() in ("1", "true")
 
+{{- if .Values.ipv6 }}
+  HOST = "::"
+{{- end }}
+
 {{- if .Values.kafka.enabled -}}
   {{ if .Values.kafka.provisioning.enabled }}
 

--- a/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-consumer.yaml
@@ -100,7 +100,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.consumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.consumer.processes }}
+          {{- if and .Values.snuba.consumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.consumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-eap-items-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.eapItemsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.eapItemsConsumer.processes }}
+          {{- if and .Values.snuba.eapItemsConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.eapItemsConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-generic-metrics-counters-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.genericMetricsCountersConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.genericMetricsCountersConsumer.processes }}
+          {{- if and .Values.snuba.genericMetricsCountersConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.genericMetricsCountersConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-group-attributes-consumer.yaml
@@ -100,7 +100,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.groupAttributesConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.groupAttributesConsumer.processes }}
+          {{- if and .Values.snuba.groupAttributesConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.groupAttributesConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-issue-occurrence-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.issueOccurrenceConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.issueOccurrenceConsumer.processes }}
+          {{- if and .Values.snuba.issueOccurrenceConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.issueOccurrenceConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-metrics-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.metricsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.metricsConsumer.processes }}
+          {{- if and .Values.snuba.metricsConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.metricsConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-billing-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.outcomesBillingConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.outcomesBillingConsumer.processes }}
+          {{- if and .Values.snuba.outcomesBillingConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.outcomesBillingConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-outcomes-consumer.yaml
@@ -98,7 +98,7 @@ spec:
           {{- end }}
           - "--max-batch-size"
           - "{{ default "3" .Values.snuba.outcomesConsumer.maxBatchSize }}"
-          {{- if .Values.snuba.outcomesConsumer.processes }}
+          {{- if and .Values.snuba.outcomesConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.outcomesConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-chunks-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.profilingChunksConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.profilingChunksConsumer.processes }}
+          {{- if and .Values.snuba.profilingChunksConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.profilingChunksConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-functions-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.profilingFunctionsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.profilingFunctionsConsumer.processes }}
+          {{- if and .Values.snuba.profilingFunctionsConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.profilingFunctionsConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-profiling-profiles-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.profilingProfilesConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.profilingProfilesConsumer.processes }}
+          {{- if and .Values.snuba.profilingProfilesConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.profilingProfilesConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-replays-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.replaysConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.replaysConsumer.processes }}
+          {{- if and .Values.snuba.replaysConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.replaysConsumer.processes }}"
           {{- end }}

--- a/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
+++ b/charts/sentry/templates/snuba/deployment-snuba-transactions-consumer.yaml
@@ -101,7 +101,7 @@ spec:
           - "--max-batch-size"
           - "{{ .Values.snuba.transactionsConsumer.maxBatchSize }}"
           {{- end }}
-          {{- if .Values.snuba.transactionsConsumer.processes }}
+          {{- if and .Values.snuba.transactionsConsumer.processes (not .Values.snuba.rustConsumer) }}
           - "--processes"
           - "{{ .Values.snuba.transactionsConsumer.processes }}"
           {{- end }}


### PR DESCRIPTION
Hey, I hope this is fine as it is, if you want me to split this up into two PRs I can also do that though.

While setting up Sentry based on this Chart (with external DBs though) in our IPv6-only cluster I faced some issues with services not listening on IPv6 (snuba/taskbroker gRPC) and others reading the `SENTRY_WEB_HOST` outside of the `SENTRY_WEB_OPTIONS` and utilizing the variable in a non-socket-address context (without port => so must not have `[]` around it).

I additionally noticed **some** snuba consumers failing with the `rustConsumer` "edition" when processes are set (which somehow was the default in my setup?). To keep any issues away from this I just gated the `--processes` argument generally behind `!rustConsumer`.

So here I just fixed all the issues I had with the **Sentry** setup (I didn't test the shipped Redis, Kafka or other parts)  for my case. If there are any questions or other concerns feel free to ask.