### PR TITLE
fix(sentry): configure uptime-checker Kafka authentication

### DIFF
--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -778,12 +778,7 @@ See: https://github.com/getsentry/taskbroker/blob/main/docs/kafka-config-migrati
 {{- define "uptimeChecker.env" -}}
 - name: UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
-{{- if not .Values.kafka.enabled -}}
-{{- $securityProtocol := include "sentry.kafka.security_protocol" . }}
-- name: UPTIME_CHECKER_KAFKA_SECURITY_PROTOCOL
-  value: {{ $securityProtocol | lower | quote }}
-{{- if regexMatch "^SASL_" $securityProtocol }}
-{{- if .Values.externalKafka.sasl.existingSecret }}
+{{- if and (not .Values.kafka.enabled) .Values.externalKafka.sasl.existingSecret }}
 - name: UPTIME_CHECKER_KAFKA_SASL_MECHANISM
   valueFrom:
     secretKeyRef:
@@ -800,24 +795,24 @@ See: https://github.com/getsentry/taskbroker/blob/main/docs/kafka-config-migrati
       name: {{ .Values.externalKafka.sasl.existingSecret }}
       key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
 {{- else }}
-{{- $saslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
-{{- $saslUsername := include "sentry.kafka.sasl_username" . -}}
-{{- $saslPassword := include "sentry.kafka.sasl_password" . -}}
-{{- if not (eq "None" $saslMechanism) }}
+{{- $sentryKafkaSaslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
+{{- if not (eq "None" $sentryKafkaSaslMechanism) }}
 - name: UPTIME_CHECKER_KAFKA_SASL_MECHANISM
-  value: {{ $saslMechanism | quote }}
+  value: {{ $sentryKafkaSaslMechanism | quote }}
 {{- end }}
-{{- if not (eq "None" $saslUsername) }}
+{{- $sentryKafkaSaslUsername := include "sentry.kafka.sasl_username" . -}}
+{{- if not (eq "None" $sentryKafkaSaslUsername) }}
 - name: UPTIME_CHECKER_KAFKA_SASL_USERNAME
-  value: {{ $saslUsername | quote }}
+  value: {{ $sentryKafkaSaslUsername | quote }}
 {{- end }}
-{{- if not (eq "None" $saslPassword) }}
+{{- $sentryKafkaSaslPassword := include "sentry.kafka.sasl_password" . -}}
+{{- if not (eq "None" $sentryKafkaSaslPassword) }}
 - name: UPTIME_CHECKER_KAFKA_SASL_PASSWORD
-  value: {{ $saslPassword | quote }}
+  value: {{ $sentryKafkaSaslPassword | quote }}
 {{- end }}
 {{- end }}
-{{- end }}
-{{- end }}
+- name: UPTIME_CHECKER_KAFKA_SECURITY_PROTOCOL
+  value: {{ include "sentry.kafka.security_protocol" . | lower | quote }}
 {{- /* Expose Redis password from secret if configured to avoid rendering secrets inline */}}
 {{- if and (.Values.redis.enabled) (.Values.redis.auth.existingSecret) }}
 - name: HELM_CHARTS_SENTRY_REDIS_PASSWORD_CONTROLLED

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -778,6 +778,46 @@ See: https://github.com/getsentry/taskbroker/blob/main/docs/kafka-config-migrati
 {{- define "uptimeChecker.env" -}}
 - name: UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER
   value: {{ include "sentry.kafka.bootstrap_servers_string" . | quote }}
+{{- if not .Values.kafka.enabled -}}
+{{- $securityProtocol := include "sentry.kafka.security_protocol" . }}
+- name: UPTIME_CHECKER_KAFKA_SECURITY_PROTOCOL
+  value: {{ $securityProtocol | lower | quote }}
+{{- if regexMatch "^SASL_" $securityProtocol }}
+{{- if .Values.externalKafka.sasl.existingSecret }}
+- name: UPTIME_CHECKER_KAFKA_SASL_MECHANISM
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "mechanism" .Values.externalKafka.sasl.existingSecretKeys.mechanism }}
+- name: UPTIME_CHECKER_KAFKA_SASL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "username" .Values.externalKafka.sasl.existingSecretKeys.username }}
+- name: UPTIME_CHECKER_KAFKA_SASL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalKafka.sasl.existingSecret }}
+      key: {{ default "password" .Values.externalKafka.sasl.existingSecretKeys.password }}
+{{- else }}
+{{- $saslMechanism := include "sentry.kafka.sasl_mechanism" . -}}
+{{- $saslUsername := include "sentry.kafka.sasl_username" . -}}
+{{- $saslPassword := include "sentry.kafka.sasl_password" . -}}
+{{- if not (eq "None" $saslMechanism) }}
+- name: UPTIME_CHECKER_KAFKA_SASL_MECHANISM
+  value: {{ $saslMechanism | quote }}
+{{- end }}
+{{- if not (eq "None" $saslUsername) }}
+- name: UPTIME_CHECKER_KAFKA_SASL_USERNAME
+  value: {{ $saslUsername | quote }}
+{{- end }}
+{{- if not (eq "None" $saslPassword) }}
+- name: UPTIME_CHECKER_KAFKA_SASL_PASSWORD
+  value: {{ $saslPassword | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- /* Expose Redis password from secret if configured to avoid rendering secrets inline */}}
 {{- if and (.Values.redis.enabled) (.Values.redis.auth.existingSecret) }}
 - name: HELM_CHARTS_SENTRY_REDIS_PASSWORD_CONTROLLED


### PR DESCRIPTION
## Context
- Uptime-checker reads Kafka security settings from `UPTIME_CHECKER_KAFKA_*` environment variables.
- The chart currently passes broker addresses only, so bundled and external Kafka authentication settings are ignored.

## Changes
- Follow the shared Snuba Kafka selection pattern for bundled, inline external, and Secret-backed credentials.
- Preserve `externalKafka.sasl.existingSecret` precedence and custom Secret key mappings.
- Pass the computed security protocol using uptime-checker’s lowercase value format.

## Testing
- `helm lint charts/sentry --set user.create=false`.
- Passed a 23-case render matrix covering every added condition, all credential subsets, Secret precedence/key mappings, supported protocol classes, bundled/external Kafka, broker lists, and manual env ordering.
- Verified the final diff changes only `charts/sentry/templates/_helper.tpl`.